### PR TITLE
[DYN-7844] As a user, I want to freeze groups

### DIFF
--- a/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
+++ b/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
@@ -422,6 +422,28 @@ namespace Dynamo.Graph.Annotations
                 }
             }
         }
+
+        private bool isFrozen = false;
+        /// <summary>
+        /// Returns whether or not all nodes in the group are frozen.
+        /// </summary>
+        [JsonIgnore]
+        public bool IsFrozen
+        {
+            get
+            {
+                return isFrozen;
+            }
+            internal set
+            {
+                if (value != isFrozen)
+                {
+                    isFrozen = value;
+                    RaisePropertyChanged(nameof(IsFrozen));
+                }
+            }
+        }
+
         #endregion
 
         /// <summary>

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -704,6 +704,7 @@ Dynamo.Graph.Annotations.AnnotationModel.InitialTop.get -> double
 Dynamo.Graph.Annotations.AnnotationModel.InitialTop.set -> void
 Dynamo.Graph.Annotations.AnnotationModel.IsExpanded.get -> bool
 Dynamo.Graph.Annotations.AnnotationModel.IsExpanded.set -> void
+Dynamo.Graph.Annotations.AnnotationModel.IsFrozen.get -> bool
 Dynamo.Graph.Annotations.AnnotationModel.IsVisible.get -> bool
 Dynamo.Graph.Annotations.AnnotationModel.loadFromXML.get -> bool
 Dynamo.Graph.Annotations.AnnotationModel.loadFromXML.set -> void

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3642,6 +3642,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Freeze Group.
+        /// </summary>
+        public static string GroupContextMenuFreezeGroup {
+            get {
+                return ResourceManager.GetString("GroupContextMenuFreezeGroup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cleanup Node Layout.
         /// </summary>
         public static string GroupContextMenuGraphLayout {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -4118,4 +4118,7 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="MessageErrorOpeningInvalidPath" xml:space="preserve">
     <value>Invalid file path provided. In case the file is archived, please make sure to extract it before opening.\n{0}</value>
   </data>
+  <data name="GroupContextMenuFreezeGroup" xml:space="preserve">
+    <value>Freeze Group</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -4105,4 +4105,7 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="MessageErrorOpeningInvalidPath" xml:space="preserve">
     <value>Invalid file path provided. In case the file is archived, please make sure to extract it before opening.\n{0}</value>
   </data>
+  <data name="GroupContextMenuFreezeGroup" xml:space="preserve">
+    <value>Freeze Group</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1762,6 +1762,7 @@ Dynamo.ViewModels.AnnotationViewModel.Nodes.get -> System.Collections.Generic.IE
 Dynamo.ViewModels.AnnotationViewModel.OutPorts.get -> System.Collections.ObjectModel.ObservableCollection<Dynamo.ViewModels.PortViewModel>
 Dynamo.ViewModels.AnnotationViewModel.PreviewState.get -> Dynamo.ViewModels.PreviewState
 Dynamo.ViewModels.AnnotationViewModel.RemoveGroupFromGroupCommand.get -> Dynamo.UI.Commands.DelegateCommand
+Dynamo.ViewModels.AnnotationViewModel.ToggleIsFrozenGroupCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.AnnotationViewModel.ToggleIsVisibleGroupCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.AnnotationViewModel.Top.get -> double
 Dynamo.ViewModels.AnnotationViewModel.Top.set -> void

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -353,6 +353,11 @@
                 <MenuItem Name="DeleteAnnotation"
                           Click="OnDeleteAnnotation"
                           Header="{x:Static p:Resources.GroupContextMenuDeleteGroup}" />
+                <MenuItem Name="FreezeAnnotation"
+                          Command="{Binding Path=ToggleIsFrozenGroupCommand}"
+                          Header="{x:Static p:Resources.GroupContextMenuFreezeGroup}"
+                          IsCheckable="true"
+                          IsChecked="{Binding Path=AnnotationModel.IsFrozen, Mode=OneWay}"/>
                 <MenuItem Name="UngroupAnnotation"
                           Click="OnUngroupAnnotation"
                           Header="{x:Static p:Resources.GroupContextMenuUngroup}" />

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -1486,6 +1486,132 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void CanFreezeAndUnfreezeAllNodesInAGroup()
+        {
+            // Arrange
+            var parentGroupName = "parentGroup";
+            var nestedGroupName = "nestedGroup";
+
+            OpenModel(@"core\annotationViewModelTests\connectorsRemainCollapsedAfterUndo.dyn");
+
+            var parentGroupVM = ViewModel.CurrentSpaceViewModel.Annotations.FirstOrDefault(x => x.AnnotationText == parentGroupName);
+            var nestedGroupVM = ViewModel.CurrentSpaceViewModel.Annotations.FirstOrDefault(x => x.AnnotationText == nestedGroupName);
+
+            // Ensure groups exist
+            Assert.NotNull(parentGroupVM);
+            Assert.NotNull(nestedGroupVM);
+
+            // Verify initial state - everything should be unfrozen
+            Assert.AreEqual(0, parentGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.AreEqual(0, nestedGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.IsTrue(!parentGroupVM.AnnotationModel.IsFrozen);
+            Assert.IsTrue(!nestedGroupVM.AnnotationModel.IsFrozen);
+
+            // Freeze parent group - should freeze both parent and nested group nodes
+            parentGroupVM.ToggleIsFrozenGroupCommand.Execute(null);
+
+            Assert.AreEqual(2, parentGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.AreEqual(2, nestedGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.IsTrue(parentGroupVM.AnnotationModel.IsFrozen);
+            Assert.IsTrue(nestedGroupVM.AnnotationModel.IsFrozen);
+
+            // Unfreeze only nested group - parent should remain frozen
+            nestedGroupVM.ToggleIsFrozenGroupCommand.Execute(null);
+
+            Assert.AreEqual(2, parentGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.AreEqual(0, nestedGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.IsTrue(parentGroupVM.AnnotationModel.IsFrozen);
+            Assert.IsTrue(!nestedGroupVM.AnnotationModel.IsFrozen);
+
+            // Freeze nested group again
+            nestedGroupVM.ToggleIsFrozenGroupCommand.Execute(null);
+
+            Assert.AreEqual(2, parentGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.AreEqual(2, nestedGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.IsTrue(parentGroupVM.AnnotationModel.IsFrozen);
+            Assert.IsTrue(nestedGroupVM.AnnotationModel.IsFrozen);
+
+            // Unfreeze parent group - should unfreeze everything
+            parentGroupVM.ToggleIsFrozenGroupCommand.Execute(null);
+
+            Assert.AreEqual(0, parentGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.AreEqual(0, nestedGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.IsTrue(!parentGroupVM.AnnotationModel.IsFrozen);
+            Assert.IsTrue(!nestedGroupVM.AnnotationModel.IsFrozen);
+        }
+
+        [Test]
+        public void CanFreezeAndUnfreezeCollapsedGroups()
+        {
+            // Arrange
+            var parentGroupName = "GroupWithGroupedGroup2";
+            var nestedGroupName = "CollapsedGroupInside";
+
+            OpenModel(@"core\annotationViewModelTests\groupsTestFile.dyn");
+
+            var parentGroupVM = ViewModel.CurrentSpaceViewModel.Annotations.FirstOrDefault(x => x.AnnotationText == parentGroupName);
+            var nestedGroupVM = ViewModel.CurrentSpaceViewModel.Annotations.FirstOrDefault(x => x.AnnotationText == nestedGroupName);
+
+            // Ensure groups exist
+            Assert.NotNull(parentGroupVM);
+            Assert.NotNull(nestedGroupVM);
+
+            // Verify initial state - everything should be unfrozen
+            Assert.AreEqual(0, parentGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.AreEqual(0, nestedGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.IsFalse(parentGroupVM.AnnotationModel.IsFrozen);
+            Assert.IsFalse(nestedGroupVM.AnnotationModel.IsFrozen);
+
+            // Freeze parent group - should freeze both parent and nested group nodes
+            parentGroupVM.ToggleIsFrozenGroupCommand.Execute(null);
+
+            Assert.AreEqual(2, parentGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.AreEqual(2, nestedGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.IsTrue(parentGroupVM.AnnotationModel.IsFrozen);
+            Assert.IsTrue(nestedGroupVM.AnnotationModel.IsFrozen);
+
+            // Unfreeze parent group - should unfreeze everything
+            parentGroupVM.ToggleIsFrozenGroupCommand.Execute(null);
+
+            Assert.AreEqual(0, parentGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.AreEqual(0, nestedGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.IsFalse(parentGroupVM.AnnotationModel.IsFrozen);
+            Assert.IsFalse(nestedGroupVM.AnnotationModel.IsFrozen);
+        }
+
+        [Test]
+        public void CanUnfreezeSingleNodeInFrozenAGroup()
+        {
+            // Arrange
+            var groupName = "GroupToCollapse";
+            var nodeGuid = new Guid("ebb5a1ec-cc86-4bc4-bfcd-4e5c84ed8ba9");
+
+            OpenModel(@"core\annotationViewModelTests\groupsTestFile.dyn");
+
+            var groupVM = ViewModel.CurrentSpaceViewModel.Annotations.FirstOrDefault(x => x.AnnotationText == groupName);
+            var nodeVM = groupVM.Nodes.OfType<NodeModel>().FirstOrDefault(n => n.GUID == nodeGuid);
+
+            // Ensure node is found
+            Assert.NotNull(nodeVM);
+
+            // Verify initial state - everything should be unfrozen
+            Assert.AreEqual(0, groupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.IsTrue(!groupVM.AnnotationModel.IsFrozen);
+
+            // Freeze parent group - all grouped nodes should be frozen
+            groupVM.ToggleIsFrozenGroupCommand.Execute(null);
+
+            Assert.AreEqual(5, groupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.IsTrue(groupVM.AnnotationModel.IsFrozen);
+
+            // Unfreeze only one node - the group and the rest of the nodes should remain frozen
+            nodeVM.IsFrozen = false;
+
+            Assert.AreEqual(4, groupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
+            Assert.IsTrue(groupVM.AnnotationModel.IsFrozen);
+        }
+
+        [Test]
         public void ConnectorsRemainCollapsedOnUndoCollapsedGroup()
         {
             // Arrange


### PR DESCRIPTION
### Purpose

PR aims to address [DYN-7844](https://jira.autodesk.com/browse/DYN-7844).

Overview
This is a proposal for new functionality that allows users to freeze an entire group from the group's context menu. This action freezes all nodes inside the group, including those within nested groups. Additionally, users can individually freeze/unfreeze nodes within a frozen group.

Behavior : 
- Freezing a group automatically freezes all nodes inside it, including nested groups.
- Users can unfreeze individual nodes within a frozen group, but this does not unfreeze downstream frozen nodes.
- Freezing a group affects downstream nodes outside the group.
- This functionality also works with collapsed groups.

I've assumed including nested groups is within the expected behavior and that the context menu wording is acceptable. Please let me know if any adjustments are needed. 
 
![DYN-7844-Freeze groups](https://github.com/user-attachments/assets/18da6685-9d4d-4395-a540-6289bcd1bbab)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

This is a proposal for new functionality that allows users to freeze an entire group from the group's context menu. This action freezes all nodes inside the group, including those within nested groups. Additionally, users can individually freeze/unfreeze nodes within a frozen group.

### Reviewers
@QilongTang 
@reddyashish 

### FYIs
@dnenov 
@achintyabhat 