### PR TITLE
DYN-8374 : highlight port when DNA

### DIFF
--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -198,7 +198,11 @@ namespace Dynamo.UI.Controls
         {
             bool visible = (bool)e.NewValue;
 
-            ViewModel.PortViewModel.Highlight = visible ? Visibility.Visible : Visibility.Collapsed;
+            if (ViewModel?.PortViewModel != null)
+            {
+                ViewModel.PortViewModel.Highlight = visible ? Visibility.Visible : Visibility.Collapsed;
+            }
+                
             // If visibility  is false, then stop processing it.
             if (!visible)
             {

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -196,9 +196,14 @@ namespace Dynamo.UI.Controls
 
         private void OnNodeAutoCompleteSearchControlVisibilityChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
+            bool visible = (bool)e.NewValue;
+
+            ViewModel.PortViewModel.Highlight = visible ? Visibility.Visible : Visibility.Collapsed;
             // If visibility  is false, then stop processing it.
-            if (!(bool)e.NewValue)
+            if (!visible)
+            {
                 return;
+            }
 
             // When launching this control, always start with clear search term.
             SearchTextBox.Clear();

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -2748,6 +2748,8 @@ Dynamo.ViewModels.PortViewModel.ConnectCommand.get -> Dynamo.UI.Commands.Delegat
 Dynamo.ViewModels.PortViewModel.EventType.get -> Dynamo.Graph.Nodes.PortEventType
 Dynamo.ViewModels.PortViewModel.EventType.set -> void
 Dynamo.ViewModels.PortViewModel.Height.get -> double
+Dynamo.ViewModels.PortViewModel.Highlight.get -> System.Windows.Visibility
+Dynamo.ViewModels.PortViewModel.Highlight.set -> void
 Dynamo.ViewModels.PortViewModel.IsConnected.get -> bool
 Dynamo.ViewModels.PortViewModel.IsEnabled.get -> bool
 Dynamo.ViewModels.PortViewModel.IsHitTestVisible.get -> bool

--- a/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
@@ -200,6 +200,31 @@
                     CornerRadius="0,11,11,0"
                     IsHitTestVisible="True"
                     SnapsToDevicePixels="True" />
+
+            <Border x:Name="PortBorderHighlight"
+                    Grid.Column="1"
+                    Grid.ColumnSpan="7"
+                    BorderBrush="Purple"
+                    Height="29px"
+                    Margin="-7,0,0,0"
+                    BorderThickness="3,3,3,3"
+                    CornerRadius="0,11,11,0"
+                    Visibility="{Binding Highlight, UpdateSourceTrigger=PropertyChanged}"
+                    SnapsToDevicePixels="True">
+
+                <Border.Triggers>
+                    <EventTrigger RoutedEvent="Border.Loaded">
+                        <BeginStoryboard>
+                            <Storyboard RepeatBehavior="Forever" AutoReverse="True">
+                                <ColorAnimation Storyboard.TargetProperty="(Border.BorderBrush).(SolidColorBrush.Color)"
+                                    From="Purple" To="Transparent"
+                                    Duration="0:0:1"/>
+                            </Storyboard>
+                        </BeginStoryboard>
+                    </EventTrigger>
+                </Border.Triggers>
+
+            </Border>
         </Grid>
     </DataTemplate>
 </ResourceDictionary>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
@@ -204,25 +204,13 @@
             <Border x:Name="PortBorderHighlight"
                     Grid.Column="1"
                     Grid.ColumnSpan="7"
-                    BorderBrush="Purple"
+                    BorderBrush="{StaticResource NodeTransientOverlayColor}"
                     Height="29px"
                     Margin="-7,0,0,0"
                     BorderThickness="3,3,3,3"
                     CornerRadius="0,11,11,0"
                     Visibility="{Binding Highlight, UpdateSourceTrigger=PropertyChanged}"
                     SnapsToDevicePixels="True">
-
-                <Border.Triggers>
-                    <EventTrigger RoutedEvent="Border.Loaded">
-                        <BeginStoryboard>
-                            <Storyboard RepeatBehavior="Forever" AutoReverse="True">
-                                <ColorAnimation Storyboard.TargetProperty="(Border.BorderBrush).(SolidColorBrush.Color)"
-                                    From="Purple" To="Transparent"
-                                    Duration="0:0:1"/>
-                            </Storyboard>
-                        </BeginStoryboard>
-                    </EventTrigger>
-                </Border.Triggers>
 
             </Border>
         </Grid>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
@@ -198,6 +198,30 @@
                 </Border.ToolTip>
 
             </Border>
+
+            <Border x:Name="PortBorderHighlight"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="2"
+                    BorderBrush="Purple"
+                    Height="29px"
+                    BorderThickness="3,3,3,3"
+                    CornerRadius="11,0,0,11"
+                    Visibility="{Binding Highlight, UpdateSourceTrigger=PropertyChanged}"
+                    SnapsToDevicePixels="True">
+
+                <Border.Triggers>
+                    <EventTrigger RoutedEvent="Border.Loaded">
+                        <BeginStoryboard>
+                            <Storyboard RepeatBehavior="Forever" AutoReverse="True">
+                                <ColorAnimation Storyboard.TargetProperty="(Border.BorderBrush).(SolidColorBrush.Color)"
+                                    From="Purple" To="Transparent"
+                                    Duration="0:0:1"/>
+                            </Storyboard>
+                        </BeginStoryboard>
+                    </EventTrigger>
+                </Border.Triggers>
+
+            </Border>
         </Grid>
     </DataTemplate>
 </ResourceDictionary>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
@@ -202,24 +202,12 @@
             <Border x:Name="PortBorderHighlight"
                     Grid.Column="0"
                     Grid.ColumnSpan="2"
-                    BorderBrush="Purple"
+                    BorderBrush="{StaticResource NodeTransientOverlayColor}"
                     Height="29px"
                     BorderThickness="3,3,3,3"
                     CornerRadius="11,0,0,11"
                     Visibility="{Binding Highlight, UpdateSourceTrigger=PropertyChanged}"
                     SnapsToDevicePixels="True">
-
-                <Border.Triggers>
-                    <EventTrigger RoutedEvent="Border.Loaded">
-                        <BeginStoryboard>
-                            <Storyboard RepeatBehavior="Forever" AutoReverse="True">
-                                <ColorAnimation Storyboard.TargetProperty="(Border.BorderBrush).(SolidColorBrush.Color)"
-                                    From="Purple" To="Transparent"
-                                    Duration="0:0:1"/>
-                            </Storyboard>
-                        </BeginStoryboard>
-                    </EventTrigger>
-                </Border.Triggers>
 
             </Border>
         </Grid>

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -490,14 +490,6 @@ namespace Dynamo.ViewModels
                 return;
             }
 
-            var existingPort = wsViewModel.NodeAutoCompleteSearchViewModel.PortViewModel;
-            if (existingPort != null)
-            {
-                existingPort.Highlight = Visibility.Collapsed;
-            }
-
-            wsViewModel.NodeAutoCompleteSearchViewModel.PortViewModel = this;
-
             // If the input port is disconnected by the 'Connect' command while triggering Node AutoComplete, undo the port disconnection.
             if (inputPortDisconnectedByConnectCommand)
             {
@@ -512,6 +504,13 @@ namespace Dynamo.ViewModels
                 return;
             }
 
+            var existingPort = wsViewModel.NodeAutoCompleteSearchViewModel.PortViewModel;
+            if (existingPort != null)
+            {
+                existingPort.Highlight = Visibility.Collapsed;
+            }
+
+            wsViewModel.NodeAutoCompleteSearchViewModel.PortViewModel = this;
 
             wsViewModel.OnRequestNodeAutoCompleteSearch(ShowHideFlags.Show);
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -484,11 +484,22 @@ namespace Dynamo.ViewModels
         // Handler to invoke node Auto Complete
         private void AutoComplete(object parameter)
         {
-            var wsViewModel = node.WorkspaceViewModel;
+            var wsViewModel = node?.WorkspaceViewModel;
+            if (wsViewModel is null || wsViewModel.NodeAutoCompleteSearchViewModel is null)
+            {
+                return;
+            }
+
+            var existingPort = wsViewModel.NodeAutoCompleteSearchViewModel.PortViewModel;
+            if (existingPort != null)
+            {
+                existingPort.Highlight = Visibility.Collapsed;
+            }
+
             wsViewModel.NodeAutoCompleteSearchViewModel.PortViewModel = this;
 
             // If the input port is disconnected by the 'Connect' command while triggering Node AutoComplete, undo the port disconnection.
-            if (this.inputPortDisconnectedByConnectCommand)
+            if (inputPortDisconnectedByConnectCommand)
             {
                 wsViewModel.DynamoViewModel.Model.CurrentWorkspace.Undo();
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -31,6 +31,8 @@ namespace Dynamo.ViewModels
         protected static readonly SolidColorBrush PortBorderBrushColorDefault = new SolidColorBrush(Color.FromRgb(161, 161, 161));
         private SolidColorBrush portBorderBrushColor = PortBorderBrushColorDefault;
         private SolidColorBrush portBackgroundColor = PortBackgroundColorDefault;
+        private Visibility highlight = Visibility.Collapsed;
+        
         /// <summary>
         /// Port model.
         /// </summary>
@@ -190,6 +192,19 @@ namespace Dynamo.ViewModels
             {
                 portBorderBrushColor = value;
                 RaisePropertyChanged(nameof(PortBorderBrushColor));
+            }
+        }
+
+        /// <summary>
+        /// Highlight or clear highlight of the port.
+        /// </summary>
+        public Visibility Highlight
+        {
+            get => highlight;
+            set
+            {
+                highlight = value;
+                RaisePropertyChanged(nameof(Highlight));
             }
         }
 


### PR DESCRIPTION
### Purpose
Highlight port when using Node Auto Complete.
The highlight border is only visible during DNA and does not exist in the visual tree otherwise. 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
