### PR TITLE
DYN-8095: Handle crash by using FirstOrDefault() instead of First()

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -2157,14 +2157,13 @@ namespace Dynamo.PackageManager
             if (fileType.Equals(DependencyType.Assembly))
             {
                 Assemblies.Remove(Assemblies
-                    .First(x => x.Name == fileName));
+                    .FirstOrDefault(x => x.Name == fileName));
             }
             else if (fileName.ToLower().EndsWith(".dll"))
             {
                 fileName = vm.FilePath;
                 AdditionalFiles.Remove(AdditionalFiles
-                    .First(x => x == fileName));
-
+                    .FirstOrDefault(x => x == fileName));
             }
             else if (fileType.Equals(DependencyType.CustomNode) || fileType.Equals(DependencyType.CustomNodePreview))
             {
@@ -2198,7 +2197,7 @@ namespace Dynamo.PackageManager
             {
                 fileName = vm.FilePath;
                 AdditionalFiles.Remove(AdditionalFiles
-                    .First(x => x == fileName));
+                    .FirstOrDefault(x => x == fileName));
             }
         }
 

--- a/test/DynamoCoreWpf3Tests/PublishPackageViewModelTests.cs
+++ b/test/DynamoCoreWpf3Tests/PublishPackageViewModelTests.cs
@@ -98,6 +98,7 @@ namespace DynamoCoreWpfTests
             var item1 = new PackageItemRootViewModel("Geometry.Curve.dyf", "C:\\test\\Geometry.Curve.dyf");
             var item2 = new PackageItemRootViewModel("Building.Curve.dyf", "C:\\test\\Building.Curve.dyf");
             var item3 = new PackageItemRootViewModel("Curve.dyf", "C:\\test\\Curve.dyf");
+            var item4 = new PackageItemRootViewModel("Curve.dll", "C:\\dummy\\Curve.dll");
 
             // Assert
             vm.RemoveSingleItem(item1, DependencyType.CustomNodePreview);
@@ -108,6 +109,9 @@ namespace DynamoCoreWpfTests
 
             vm.RemoveSingleItem(item3, DependencyType.CustomNodePreview);
             Assert.AreEqual(0, vm.CustomNodeDefinitions.Count);
+
+            //assert that the method does not throw exception when the item is not found
+            Assert.DoesNotThrow(() => { vm.RemoveSingleItem(item4, DependencyType.Assembly); });
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

The crash was thrown with `ThrowNoMatchException` from the linq statement. `First()` was used at multiple places, which is now replaced with `FirstOrDefault()` which instead of throwing an exception will return the default value.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Handle crash by using FirstOrDefault() instead of First()

### Reviewers

@DynamoDS/dynamo 
