### PR TITLE
DYN-6694: Update incorrect resource title

### DIFF
--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -222,7 +222,7 @@ Default value: 1</value>
     <value>Download latest version</value>
     <comment>Button Download Lastest</comment>
   </data>
-  <data name="052465" xml:space="preserve">
+  <data name="ArggOKButton" xml:space="preserve">
     <value>Arrrrg, ok</value>
     <comment>Button OK</comment>
   </data>


### PR DESCRIPTION
### Purpose

The incorrect resource string title was causing an empty button to appear on crash dialog box. It has been fixed in this PR:

![Screenshot 2025-03-24 at 6 04 16 PM](https://github.com/user-attachments/assets/6a81883f-3ff7-43fe-8836-5f898e06d606)

..and the pirates are back!

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

The incorrect resource string title was causing an empty button to appear on crash dialog box, fixed.

### Reviewers

@DynamoDS/dynamo 
