### PR TITLE
[DYN-8549] Curve Mapper: Tooltip for control points needs to adjust to show both x & y coordinates 

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/CurveMapper/CurveMapperControlPoint.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/CurveMapper/CurveMapperControlPoint.xaml
@@ -11,8 +11,6 @@
     <Thumb.Resources>
         <Style x:Key="GenericToolTipLight" TargetType="ToolTip">
             <Setter Property="OverridesDefaultStyle" Value="true" />
-            <Setter Property="Width" Value="190" />
-            <Setter Property="HorizontalOffset" Value="-95" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="ToolTip">
@@ -60,6 +58,7 @@
     <Thumb.Template>
         <ControlTemplate>
             <Ellipse
+                x:Name="ControlPointEllipse"
                 Width="12"
                 Height="12"
                 Fill="#ffffff"
@@ -67,10 +66,22 @@
                 StrokeThickness="3">
                 <Ellipse.ToolTip>
                     <ToolTip Style="{StaticResource GenericToolTipLight}">
-                        <StackPanel>
-                            <TextBlock FontWeight="Bold" Text="{Binding ScaledCoordinates}" />
-                            <TextBlock Text="{x:Static rexs:CoreNodeModelWpfResources.CurveMapperControlPointToolTip}" />
-                        </StackPanel>
+                        <Grid MaxWidth="250">
+                            <Grid.RowDefinitions>
+                                <RowDefinition />
+                                <RowDefinition />
+                            </Grid.RowDefinitions>
+                            <TextBlock
+                                Grid.Row="0"
+                                Text="{Binding ScaledCoordinates}"
+                                TextWrapping="Wrap"
+                                FontWeight="Bold" />
+                            <TextBlock
+                                Grid.Row="1"
+                                Text="{x:Static rexs:CoreNodeModelWpfResources.CurveMapperControlPointToolTip}"
+                                TextWrapping="Wrap"
+                                Margin="0,5,0,0" />
+                        </Grid>
                     </ToolTip>
                 </Ellipse.ToolTip>
             </Ellipse>

--- a/src/Libraries/CoreNodeModelsWpf/CurveMapper/CurveMapperControlPoint.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/CurveMapper/CurveMapperControlPoint.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Shapes;
 
 namespace Dynamo.Wpf.CurveMapper
 {
@@ -115,6 +116,18 @@ namespace Dynamo.Wpf.CurveMapper
                     RaisePropertyChanged(nameof(ScaledCoordinates));
                 }
             };
+
+            // Find the tooltip once it's loaded
+            this.Loaded += (s, e) =>
+            {
+                if (this.Template.FindName("ControlPointEllipse", this) is Ellipse ellipse && ellipse.ToolTip is ToolTip tooltip)
+                {
+                    tooltip.Opened += (sender, args) =>
+                    {
+                        CenterTooltip(tooltip);
+                    };
+                }
+            };
         }
 
         private void Thumb_DragDelta(object sender, DragDeltaEventArgs e)
@@ -188,6 +201,17 @@ namespace Dynamo.Wpf.CurveMapper
         /// </summary>
         private static void OnPropertyUpdated(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
+        }
+
+        private void CenterTooltip(ToolTip tooltip)
+        {
+            tooltip.Dispatcher.BeginInvoke(new Action(() =>
+            {
+                tooltip.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+                double actualWidth = tooltip.DesiredSize.Width;
+                tooltip.HorizontalOffset = -actualWidth / 2.0;
+            }),
+            System.Windows.Threading.DispatcherPriority.Loaded);
         }
     }
 }


### PR DESCRIPTION
### Purpose

This PR aims to address [DYN-8549](https://jira.autodesk.com/browse/DYN-8549), where the tooltip for the CurveMapper control point was not fully displaying long coordinate values.
The tooltip's width and height are no longer fixed, allowing it to expand based on its content. Additionally, the text inside the tooltip now wraps when it exceeds the maximum width. The tooltip remains horizontally centered beneath the control point.

![DYN-8549-Proposal](https://github.com/user-attachments/assets/a1b631c7-4195-420f-bce1-868f4c7a5be4)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

The CurveMapper control point tooltip now dynamically adjusts its width and height based on content. Long text will wrap when exceeding the maximum width, and the tooltip remains horizontally centered beneath the control point.

### Reviewers
@reddyashish 
@QilongTang 
@zeusongit 

### FYIs
@achintyabhat 
@dnenov 