### PR TITLE
[DYN-6039] Toast notification for exporting images.

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2918,6 +2918,24 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Workspace has been exported as a 3D image to .
+        /// </summary>
+        public static string ExportWorkspaceAs3DImage {
+            get {
+                return ResourceManager.GetString("ExportWorkspaceAs3DImage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Workspace has been exported as an image to .
+        /// </summary>
+        public static string ExportWorkspaceAsImage {
+            get {
+                return ResourceManager.GetString("ExportWorkspaceAsImage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Extension tab added to the extensions side bar..
         /// </summary>
         public static string ExtensionAdded {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -4140,4 +4140,10 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="NodeAutoCompleteToolTip" xml:space="preserve">
     <value>Click to get Node Autocomplete suggestions</value>
   </data>
+  <data name="ExportWorkspaceAsImage" xml:space="preserve">
+    <value>Workspace has been exported as an image to </value>
+  </data>
+  <data name="ExportWorkspaceAs3DImage" xml:space="preserve">
+    <value>Workspace has been exported as a 3D image to </value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -4127,4 +4127,10 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="NodeAutoCompleteToolTip" xml:space="preserve">
     <value>Click to get Node Autocomplete suggestions</value>
   </data>
+  <data name="ExportWorkspaceAsImage" xml:space="preserve">
+    <value>Workspace has been exported as an image to </value>
+  </data>
+  <data name="ExportWorkspaceAs3DImage" xml:space="preserve">
+    <value>Workspace has been exported as a 3D image to </value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -4800,6 +4800,8 @@ static Dynamo.Wpf.Properties.Resources.ExitTourWindowContent.get -> string
 static Dynamo.Wpf.Properties.Resources.ExportPreferencesText.get -> string
 static Dynamo.Wpf.Properties.Resources.ExportSettingsDialogTitle.get -> string
 static Dynamo.Wpf.Properties.Resources.ExportSettingsFailedMessage.get -> string
+static Dynamo.Wpf.Properties.Resources.ExportWorkspaceAsImage.get -> string
+static Dynamo.Wpf.Properties.Resources.ExportWorkspaceAs3DImage.get -> string
 static Dynamo.Wpf.Properties.Resources.ExtensionAdded.get -> string
 static Dynamo.Wpf.Properties.Resources.ExtensionAlreadyPresent.get -> string
 static Dynamo.Wpf.Properties.Resources.FileDialogAllFiles.get -> string

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -3397,6 +3397,10 @@ namespace Dynamo.ViewModels
         {
             OnRequestSaveImage(this, new ImageSaveEventArgs(parameters.ToString()));
 
+            string message = String.Concat(WpfResources.ExportWorkspaceAsImage, parameters.ToString());
+
+            MainGuideManager?.CreateRealTimeInfoWindow(message, true);
+
             Dynamo.Logging.Analytics.TrackTaskCommandEvent("ImageCapture",
                 "NodeCount", CurrentSpace.Nodes.Count());
         }
@@ -3405,6 +3409,10 @@ namespace Dynamo.ViewModels
         {
             // Save the parameters
             OnRequestSave3DImage(this, new ImageSaveEventArgs(parameters.ToString()));
+
+            string message = String.Concat(WpfResources.ExportWorkspaceAs3DImage, parameters.ToString());
+
+            MainGuideManager?.CreateRealTimeInfoWindow(message, true);
         }
 
         internal bool CanSaveImage(object parameters)


### PR DESCRIPTION
### Purpose

Task: https://jira.autodesk.com/browse/DYN-6039

Shows a toast notification after exporting the workspace as an image.

We don't the functionality to open the folder from the toast notification, so just showing the message with the location where it was saved. The option to open the folder from toast notification can be implemented as an improvement later on if needed.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
[DYN-6039] Toast notification for exporting images.

### Reviewers
@zeusongit 

