### PR TITLE
[DYN-8338] Allow AutoComplete Marker on OutPorts with Connections

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -139,7 +139,7 @@ namespace Dynamo.ViewModels
         }
         private bool CanHaveAutoCompleteMarker()
         {
-            return PortModel.Connectors.Count == 0
+            return ((this is InPortViewModel && PortModel.Connectors.Count == 0) || this is OutPortViewModel)
                    && NodeViewModel.NodeModel is not CodeBlockNodeModel
                    && NodeViewModel.NodeModel is not CoreNodeModels.Watch
                    && NodeViewModel.NodeModel is not PythonNodeModels.PythonNode

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -497,6 +497,7 @@ namespace Dynamo.ViewModels
                 case nameof(IsConnected):
                     RaisePropertyChanged(nameof(IsConnected));
                     RefreshPortColors();
+                    NodeAutoCompleteMarkerVisible = IsSelected;
                     break;
                 case nameof(IsEnabled):
                     RaisePropertyChanged(nameof(IsEnabled));


### PR DESCRIPTION
### Purpose

This expands the auto-complete marker to allow it to display on output ports with connections. As you may know, Dynamo allows for multiple connections on OutPorts, so this supports that.

related to DYN-8338
![20250324-portUpdates2](https://github.com/user-attachments/assets/60cc7b34-f9d3-4547-9df5-7fa0effd2f9e)



### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes
Introduction of a new in canvas marker (outside the port). This new marker, the Node Autocomplete Marker, allows for launching of the node autocomplete service.

### Reviewers
@BogdanZavu @QilongTang 

### FYIs
@Amoursol @emru-y 
