### PR TITLE
[DYN-8524] Curve Mapper icons should be a triangle at center - they look weird

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -670,6 +670,7 @@
             Grid.ColumnSpan="3"
             Canvas.ZIndex="7"
             IsHitTestVisible="False"
+            MinWidth="48"
             Margin="0 5 0 0"
             HorizontalAlignment="Stretch"
             VerticalAlignment="Stretch"
@@ -677,55 +678,50 @@
             Visibility="{Binding Path=DataContext.Zoom, 
                                  RelativeSource={RelativeSource FindAncestor, 
                                  AncestorType={x:Type controls:WorkspaceView}}, 
-                                 Converter={StaticResource ZoomToVisibilityCollapsedConverter}}"
-            MinWidth="48">
-            <Grid.RowDefinitions>
-                <RowDefinition
-                    Height="{Binding ImgGlyphThreeSource, Mode=OneWay, Converter={StaticResource EmptyToZeroLengthConverter}, UpdateSourceTrigger=PropertyChanged}" />
-                <RowDefinition></RowDefinition>
-            </Grid.RowDefinitions>
+                                 Converter={StaticResource ZoomToVisibilityCollapsedConverter}}">
 
-            <UniformGrid  Grid.Row="0"
-                Margin="0 10 0 -10"
-                             Columns="1" Rows="1" Name="ZoomGlyphRowZero" 
-                          HorizontalAlignment="Center" VerticalAlignment="Bottom"
-                          Visibility="{Binding ImgGlyphThreeSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}">
-                <Image Stretch="Uniform"  HorizontalAlignment="Center" VerticalAlignment="Bottom" 
-                x:Name="ZoomStateImgOne"
-                Width="64"
-                Source="{Binding ImgGlyphThreeSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
-                Visibility="{Binding ImgGlyphThreeSource,Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" />
-            </UniformGrid>
-            <Grid Grid.Row="1" 
-                  Margin="0 0 0 0"
-                  Name="ZoomGlyphRowOne" 
-                  HorizontalAlignment="Center" VerticalAlignment="Stretch">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="{Binding ImgGlyphOneSource, Mode=OneWay, Converter={StaticResource EmptyToZeroLengthConverter}, UpdateSourceTrigger=PropertyChanged}" />
-                    <ColumnDefinition Width="{Binding ImgGlyphTwoSource, Mode=OneWay, Converter={StaticResource EmptyToZeroLengthConverter}, UpdateSourceTrigger=PropertyChanged}" />
-                </Grid.ColumnDefinitions>
-                <Image Grid.Column="0"
-          
-                    x:Name="ZoomStateImgTwo"
-                    Stretch="Uniform"
-                                              HorizontalAlignment="Left" VerticalAlignment="Center"
-
-
-                    Margin="5 0 "
-                    Width="64"
-                    Source="{Binding ImgGlyphOneSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
-                    Visibility="{Binding ImgGlyphOneSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" />
-
-                <Image Grid.Column="1"
-                       x:Name="ZoomStateImgThree"
-                    Stretch="Uniform"
-                    HorizontalAlignment="Right"
-                    VerticalAlignment="Center"
-                    Margin="5 0"
-                    Width="64"
-                    Source="{Binding ImgGlyphTwoSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
-                    Visibility="{Binding ImgGlyphTwoSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" />
-            </Grid>
+            <StackPanel VerticalAlignment="Center"
+                        HorizontalAlignment="Center">
+                <UniformGrid Name="ZoomGlyphRowZero"
+                             Grid.Row="0"
+                             Margin="0 10 0 10"
+                             Columns="1"
+                             Rows="1"
+                             HorizontalAlignment="Center" VerticalAlignment="Bottom"
+                             Visibility="{Binding ImgGlyphThreeSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}">
+                    <Image x:Name="ZoomStateImgOne"
+                           Stretch="Uniform"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Bottom"
+                           Width="64"
+                           Source="{Binding ImgGlyphThreeSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
+                           Visibility="{Binding ImgGlyphThreeSource,Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" />
+                </UniformGrid>
+                <Grid Name="ZoomGlyphRowOne">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="{Binding ImgGlyphOneSource, Mode=OneWay, Converter={StaticResource EmptyToZeroLengthConverter}, UpdateSourceTrigger=PropertyChanged}" />
+                        <ColumnDefinition Width="{Binding ImgGlyphTwoSource, Mode=OneWay, Converter={StaticResource EmptyToZeroLengthConverter}, UpdateSourceTrigger=PropertyChanged}" />
+                    </Grid.ColumnDefinitions>
+                    <Image x:Name="ZoomStateImgTwo"
+                           Grid.Column="0"
+                           Stretch="Uniform"
+                           HorizontalAlignment="Left"
+                           VerticalAlignment="Center"
+                           Margin="0 10 5 0 "
+                           Width="64"
+                           Source="{Binding ImgGlyphOneSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
+                           Visibility="{Binding ImgGlyphOneSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" />
+                    <Image x:Name="ZoomStateImgThree"
+                           Grid.Column="1"
+                           Stretch="Uniform"
+                           HorizontalAlignment="Right"
+                           VerticalAlignment="Center"
+                           Margin="5 10 0 0"
+                           Width="64"
+                           Source="{Binding ImgGlyphTwoSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
+                           Visibility="{Binding ImgGlyphTwoSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" />
+                </Grid>
+            </StackPanel>
         </Grid>
         <!--  Displays when the node is selected  -->
         <Border Name="selectionBorder"


### PR DESCRIPTION
### Purpose

This PR aims to address [DYN-8524](https://jira.autodesk.com/browse/DYN-8524), which reported that when zoomed out, the status icons (warning, frozen, and preview) on the CurveMapper node (or any tall node) were not visually centered - especially when multiple icons appeared on two rows.

I’ve updated the layout logic in NodeView: replaced the zoomGlyphsGrid's internal Grid based layout with a StackPanel. This allows all glyph icons, whether one or two rows,  are vertically centered as a group, regardless of the node’s size.

![DYN-8524-Proposed](https://github.com/user-attachments/assets/52f737e2-ab3f-4963-91c8-e035c7fad8a6)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

This update ensures that glyph icons (e.g., warning, frozen, preview) are always centered within the node when zoomed out, regardless of the node’s size.

### Reviewers
@reddyashish 
@QilongTang 
@zeusongit 

### FYIs
@dnenov 
@achintyabhat 