### PR TITLE
DYN-8586: Update script to use boto3

### DIFF
--- a/tools/autobuild/dynamo_s3.py
+++ b/tools/autobuild/dynamo_s3.py
@@ -1,42 +1,30 @@
-import boto
-from boto.s3.key import Key
+import boto3
 import os
 import datetime
 from decimal import *
 
 def date_string():
-	return datetime.datetime.now().strftime("%Y%m%dT%H%M")
+    return datetime.datetime.now().strftime("%Y%m%dT%H%M")
 
 def mb(num_bytes):
+    return float(num_bytes) / 1000000
 
-	return float(num_bytes) / 1000000
-
-def report_progress( bytes_so_far, total_bytes ):
-	
-	print("Upload progress: %.2f mb / %.2f mb ( %.2f percent )" % (mb(bytes_so_far), mb(total_bytes), 100 * float(bytes_so_far)/total_bytes))
+def report_progress(bytes_so_far, total_bytes):
+    print("Upload progress: %.2f mb / %.2f mb ( %.2f percent )" % (mb(bytes_so_far), mb(total_bytes), 100 * float(bytes_so_far) / total_bytes))
 
 def upload_installer(fn, prefix, include_date, is_dev_build, extension, date_string):
+    s3 = boto3.client('s3')
 
-	s3 = boto.connect_s3()
+    if extension == '.exe' or extension == '.zip':
+        bucket_name = 'dyn-builds-dev' if is_dev_build else 'dyn-builds-data'
+    elif extension == '.sig':
+        bucket_name = 'dyn-builds-dev-sig' if is_dev_build else 'dyn-builds-data-sig'
 
-	if extension == '.exe' or extension == '.zip':
-		if is_dev_build:
-			b = s3.get_bucket('dyn-builds-dev')
-		else:
-			b = s3.get_bucket('dyn-builds-data')
-	elif extension == '.sig':
-		if is_dev_build:
-			b = s3.get_bucket('dyn-builds-dev-sig')
-		else:
-			b = s3.get_bucket('dyn-builds-data-sig')
+    key = 'daily/' + prefix + '_' + date_string + extension if include_date else 'daily/' + prefix + extension
 
-	k = Key(b)
-	
-	key = 'daily/' + prefix + '_' + date_string + extension if include_date else 'daily/' + prefix + extension
-	
-	k.key = os.path.basename( key )
-
-	k.set_contents_from_filename(fn, cb = report_progress, num_cb = 40)
-
-
-
+    s3.upload_file(
+        Filename=fn,
+        Bucket=bucket_name,
+        Key=os.path.basename(key),
+        Callback=lambda bytes_transferred: report_progress(bytes_transferred, os.path.getsize(fn))
+    )


### PR DESCRIPTION
### Purpose

Python version (3.8) that we are using in build machine has officially [EOL](https://devguide.python.org/versions/), in order to update the build machine to latest version of python the PR updates the script to use `boto3` python library, that supports latest(3.13) version of python.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Update s3 script to use boto3

### Reviewers

@DynamoDS/eidos 

