### PR TITLE
RC3.5.0 revert node auto complete work

### DIFF
--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -535,6 +535,11 @@ namespace Dynamo.Graph.Nodes
 
             return null;
         }
+
+        internal bool CanAutoCompleteInput()
+        {
+            return !(PortType == PortType.Input && Connectors?.FirstOrDefault()?.Start?.Owner != null);
+        }
     }
 
     /// <summary>

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
@@ -23,8 +23,8 @@
             <Style x:Key="SearchMemberStyle"
                    BasedOn="{StaticResource MemberGroupMemberStyle}"
                    TargetType="{x:Type ListBoxItem}">
-                <EventSetter Event="PreviewMouseLeftButtonDown"
-                             Handler="OnMouseLeftButtonDown" />
+                <EventSetter Event="PreviewMouseLeftButtonUp"
+                             Handler="OnMouseLeftButtonUp" />
                 <EventSetter Event="MouseEnter"
                              Handler="OnMouseEnter" />
                 <EventSetter Event="MouseLeave"

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -93,7 +93,7 @@ namespace Dynamo.UI.Controls
             }
         }
 
-        private void OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        private void OnMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
             if (!(sender is ListBoxItem listBoxItem) || e.OriginalSource is Thumb) return;
 

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -5102,15 +5102,6 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Click to get Node Autocomplete suggestions.
-        /// </summary>
-        public static string NodeAutoCompleteToolTip {
-            get {
-                return ResourceManager.GetString("NodeAutoCompleteToolTip", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Enable Periodic Update.
         /// </summary>
         public static string NodeContextMenuEnablePeriodicUpdate {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -4137,9 +4137,6 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="PreferencesViewShowDefaultGroupDescription" xml:space="preserve">
     <value>Show default group description</value>
   </data>
-  <data name="NodeAutoCompleteToolTip" xml:space="preserve">
-    <value>Click to get Node Autocomplete suggestions</value>
-  </data>
   <data name="ExportWorkspaceAsImage" xml:space="preserve">
     <value>Workspace has been exported as an image to </value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -4124,9 +4124,6 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="PreferencesViewShowDefaultGroupDescription" xml:space="preserve">
     <value>Show default group description</value>
   </data>
-  <data name="NodeAutoCompleteToolTip" xml:space="preserve">
-    <value>Click to get Node Autocomplete suggestions</value>
-  </data>
   <data name="ExportWorkspaceAsImage" xml:space="preserve">
     <value>Workspace has been exported as an image to </value>
   </data>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -5041,7 +5041,6 @@ static Dynamo.Wpf.Properties.Resources.NextGuideText.get -> string
 static Dynamo.Wpf.Properties.Resources.NodeAutocomplete.get -> string
 static Dynamo.Wpf.Properties.Resources.NodeAutocompleteDocumentationUriString.get -> string
 static Dynamo.Wpf.Properties.Resources.NodeAutoCompleteNotAvailableForCollapsedGroups.get -> string
-static Dynamo.Wpf.Properties.Resources.NodeAutoCompleteToolTip.get -> string
 static Dynamo.Wpf.Properties.Resources.NodeContextMenuEnablePeriodicUpdate.get -> string
 static Dynamo.Wpf.Properties.Resources.NodeContextMenuHelp.get -> string
 static Dynamo.Wpf.Properties.Resources.NodeContextMenuIsInput.get -> string

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -2772,8 +2772,6 @@ Dynamo.ViewModels.PortViewModel.MouseLeftButtonDownOnLevel -> System.EventHandle
 Dynamo.ViewModels.PortViewModel.MouseLeftButtonDownOnLevelCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.PortViewModel.MouseLeftUseLevelCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.PortViewModel.NodeAutoCompleteCommand.get -> Dynamo.UI.Commands.DelegateCommand
-Dynamo.ViewModels.PortViewModel.NodeAutoCompleteMarkerVisible.get -> bool
-Dynamo.ViewModels.PortViewModel.NodeAutoCompleteMarkerVisible.set -> void
 Dynamo.ViewModels.PortViewModel.NodePortContextMenuCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.PortViewModel.PortBackgroundColor.get -> System.Windows.Media.SolidColorBrush
 Dynamo.ViewModels.PortViewModel.PortBackgroundColor.set -> void

--- a/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
@@ -220,13 +220,10 @@
                 >✨</Label>
 
                 <interactivity:Interaction.Triggers>
-                    <interactivity:EventTrigger EventName="PreviewMouseLeftButtonDown">
+                    <interactivity:EventTrigger EventName="PreviewMouseDown">
                         <interactivity:InvokeCommandAction Command="{Binding NodeAutoCompleteCommand}" PassEventArgsToCommand="True"/>
                     </interactivity:EventTrigger>
                 </interactivity:Interaction.Triggers>
-                <Border.ToolTip>
-                    <dynui:DynamoToolTip AttachmentSide="Left" Style="{DynamicResource ResourceKey=SLightToolTip}" Content="{x:Static p:Resources.NodeAutoCompleteToolTip}"/>
-                </Border.ToolTip>
             </Border>
             <Border x:Name="PortBorderHighlight"
                     Grid.Column="1"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
@@ -38,6 +38,11 @@
                 </views:HandlingEventTrigger>
             </interactivity:Interaction.Triggers>
 
+            <!--  Bind NodeAutoComplete to double left click  -->
+            <Grid.InputBindings>
+                <MouseBinding Command="{Binding Path=NodeAutoCompleteCommand}" MouseAction="LeftDoubleClick" />
+            </Grid.InputBindings>
+
             <!--  Enables Port Snapping  -->
             <Rectangle x:Name="PortSnapping"
                        Grid.Column="0"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
@@ -201,35 +201,6 @@
                     IsHitTestVisible="True"
                     SnapsToDevicePixels="True" />
 
-
-            <!--  A border, to initiate the node autocomplete command -->
-            <Border x:Name="NodeAutoCompleteMarker"
-                    Grid.Column="0"
-                    Margin="-18,0,0,0"
-                    Cursor="Hand"
-                    CornerRadius="10"
-                    Height="20px"
-                    Width="20px"
-                    VerticalAlignment="Center"
-                    HorizontalAlignment="Left"
-                    Background="{StaticResource NodeTransientOverlayColor}"
-                    IsHitTestVisible="True"
-                    SnapsToDevicePixels="True"
-                    Visibility="{Binding NodeAutoCompleteMarkerVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
-                <Label
-                    Name="NodeAutoCompleteMarkerLabel"
-                    FontSize="12"
-                    Width="25"
-                    Height="25"
-                    Margin="-3,-3,0,0"
-                >✨</Label>
-
-                <interactivity:Interaction.Triggers>
-                    <interactivity:EventTrigger EventName="PreviewMouseDown">
-                        <interactivity:InvokeCommandAction Command="{Binding NodeAutoCompleteCommand}" PassEventArgsToCommand="True"/>
-                    </interactivity:EventTrigger>
-                </interactivity:Interaction.Triggers>
-            </Border>
             <Border x:Name="PortBorderHighlight"
                     Grid.Column="1"
                     Grid.ColumnSpan="7"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
@@ -4,7 +4,6 @@
                     xmlns:dynui="clr-namespace:Dynamo.UI.Controls;assembly=DynamoCoreWpf"
                     xmlns:interactivity="clr-namespace:Dynamo.Microsoft.Xaml.Behaviors;assembly=Dynamo.Microsoft.Xaml.Behaviors"
                     xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
-                    xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
                     xmlns:viewModels="clr-namespace:Dynamo.ViewModels;assembly=DynamoCoreWpf"
                     xmlns:views="clr-namespace:Dynamo.UI.Views;assembly=DynamoCoreWpf">
     <ResourceDictionary.MergedDictionaries>
@@ -218,13 +217,10 @@
                 >✨</Label>
 
                 <interactivity:Interaction.Triggers>
-                    <interactivity:EventTrigger EventName="PreviewMouseLeftButtonDown">
+                    <interactivity:EventTrigger EventName="PreviewMouseDown">
                         <interactivity:InvokeCommandAction Command="{Binding NodeAutoCompleteCommand}" PassEventArgsToCommand="True"/>
                     </interactivity:EventTrigger>
                 </interactivity:Interaction.Triggers>
-                <Border.ToolTip>
-                    <dynui:DynamoToolTip AttachmentSide="Right" Style="{DynamicResource ResourceKey=SLightToolTip}" Content="{x:Static p:Resources.NodeAutoCompleteToolTip}"/>
-                </Border.ToolTip>
             </Border>
 
             <Border x:Name="PortBorderHighlight"
@@ -236,6 +232,7 @@
                     CornerRadius="11,0,0,11"
                     Visibility="{Binding Highlight, UpdateSourceTrigger=PropertyChanged}"
                     SnapsToDevicePixels="True">
+
             </Border>
         </Grid>
     </DataTemplate>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
@@ -11,9 +11,9 @@
         <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
         <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
     </ResourceDictionary.MergedDictionaries>
-
+        
     <DataTemplate DataType="{x:Type viewModels:OutPortViewModel}">
-
+        
         <!--  Grid that contains the entire port  -->
         <Grid Name="MainGrid"
               Background="Transparent"
@@ -34,6 +34,11 @@
                 </views:HandlingEventTrigger>
             </interactivity:Interaction.Triggers>
 
+            <!--  Bind NodeAutoComplete to double left click  -->
+            <Grid.InputBindings>
+                <MouseBinding Command="{Binding Path=NodeAutoCompleteCommand}" MouseAction="LeftDoubleClick" />
+            </Grid.InputBindings>
+
             <Grid.Style>
                 <Style>
                     <Setter Property="Grid.Height" Value="34px" />
@@ -49,8 +54,8 @@
             <!--  Transparent rectangle used for port snapping, overhangs the edge of the port  -->
             <Rectangle Grid.Column="0"
                        x:Name="PortSnapping"
-                       Margin="0,0,-25,0"
-                       Grid.ColumnSpan="3"
+                       Margin="-25,0,0,0"
+                       Grid.ColumnSpan="7"
                        Canvas.ZIndex="1"
                        Fill="Transparent"
                        IsHitTestVisible="{Binding IsHitTestVisible}"
@@ -113,7 +118,7 @@
                     </Style>
                 </Rectangle.Style>
             </Rectangle>
-    
+       
             <!--  Grid containing the Port Name TextBox  -->
             <Grid Name="PortNameGrid"
                   Grid.Column="0"
@@ -152,7 +157,7 @@
                     </Style>
                 </Grid.Style>
             </Grid>
-
+            
             <!--  A semi-transparent border, which displays when the user's mouse moves over the port  -->
             <Border x:Name="BorderHighlightOverlay"
                     Grid.Column="0"
@@ -192,35 +197,6 @@
                     </dynui:DynamoToolTip>
                 </Border.ToolTip>
 
-            </Border>
-
-            <!--  A border, to initiate the node autocomplete command -->
-            <Border x:Name="NodeAutoCompleteMarker"
-                    Grid.Column="2"
-                    Margin="0,0,-18,0"
-                    Cursor="Hand"
-                    CornerRadius="10"
-                    Height="20px"
-                    Width="20px"
-                    VerticalAlignment="Center"
-                    HorizontalAlignment="Right"
-                    Background="{StaticResource NodeTransientOverlayColor}"
-                    IsHitTestVisible="True"
-                    SnapsToDevicePixels="True"
-                    Visibility="{Binding NodeAutoCompleteMarkerVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
-                <Label
-                    Name="NodeAutoCompleteMarkerLabel"
-                    FontSize="12"
-                    Width="25"
-                    Height="25"
-                    Margin="-3,-3,0,0"
-                >✨</Label>
-
-                <interactivity:Interaction.Triggers>
-                    <interactivity:EventTrigger EventName="PreviewMouseDown">
-                        <interactivity:InvokeCommandAction Command="{Binding NodeAutoCompleteCommand}" PassEventArgsToCommand="True"/>
-                    </interactivity:EventTrigger>
-                </interactivity:Interaction.Triggers>
             </Border>
 
             <Border x:Name="PortBorderHighlight"

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -29,6 +29,7 @@ namespace Dynamo.ViewModels
         private bool showUseLevelMenu;
         private const double autocompletePopupSpacing = 2.5;
         private const double proxyPortContextMenuOffset = 20;
+        internal bool inputPortDisconnectedByConnectCommand = false;
         private bool nodeAutoCompleteMarkerVisible;
         protected static readonly SolidColorBrush PortBackgroundColorPreviewOff = new SolidColorBrush(Color.FromRgb(102, 102, 102));
         protected static readonly SolidColorBrush PortBackgroundColorDefault = new SolidColorBrush(Color.FromRgb(60, 60, 60));
@@ -504,13 +505,24 @@ namespace Dynamo.ViewModels
         {
             //handle the mouse event to prevent connection from starting
             MouseButtonEventArgs evArgs = parameter as MouseButtonEventArgs;
-            if (evArgs != null)
-            {
-                evArgs.Handled = true;
-            }            
+            evArgs.Handled = true;
 
             var wsViewModel = node?.WorkspaceViewModel;
             if (wsViewModel is null || wsViewModel.NodeAutoCompleteSearchViewModel is null)
+            {
+                return;
+            }
+
+            // If the input port is disconnected by the 'Connect' command while triggering Node AutoComplete, undo the port disconnection.
+            if (inputPortDisconnectedByConnectCommand)
+            {
+                wsViewModel.DynamoViewModel.Model.CurrentWorkspace.Undo();
+            }
+
+            // Bail out from connect state
+            wsViewModel.CancelActiveState();
+
+            if (PortModel != null && !PortModel.CanAutoCompleteInput())
             {
                 return;
             }
@@ -535,6 +547,20 @@ namespace Dynamo.ViewModels
             
             var wsViewModel = node.WorkspaceViewModel;
             wsViewModel.NodeAutoCompleteSearchViewModel.PortViewModel = this;
+
+            // If the input port is disconnected by the 'Connect' command while triggering Node AutoComplete, undo the port disconnection.
+            if (this.inputPortDisconnectedByConnectCommand)
+            {
+                wsViewModel.DynamoViewModel.Model.CurrentWorkspace.Undo();
+            }
+
+            // Bail out from connect state
+            wsViewModel.CancelActiveState();
+
+            if (PortModel != null && !PortModel.CanAutoCompleteInput())
+            {
+                return;
+            }
 
             // CreateMockCluster();
 
@@ -676,11 +702,8 @@ namespace Dynamo.ViewModels
             {
                 dynamoViewModel.MainGuideManager.CreateRealTimeInfoWindow(Wpf.Properties.Resources.NodeAutoCompleteNotAvailableForCollapsedGroups);
             }
-
-            // We can AutoComplete if the feature is enabled from Dynamo experiment setting,
-            // if user interaction is not on proxy ports and if the port is not an input already connected.
-            return dynamoViewModel.EnableNodeAutoComplete && !port.IsProxyPort &&
-                !(PortType == PortType.Input && PortModel?.Connectors?.FirstOrDefault()?.Start?.Owner != null);
+            // If the feature is enabled from Dynamo experiment setting and if user interaction is not on proxy ports.
+            return dynamoViewModel.EnableNodeAutoComplete && !port.IsProxyPort;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls.Primitives;
-using System.Windows.Input;
 using System.Windows.Media;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
@@ -30,7 +29,6 @@ namespace Dynamo.ViewModels
         private const double autocompletePopupSpacing = 2.5;
         private const double proxyPortContextMenuOffset = 20;
         internal bool inputPortDisconnectedByConnectCommand = false;
-        private bool nodeAutoCompleteMarkerVisible;
         protected static readonly SolidColorBrush PortBackgroundColorPreviewOff = new SolidColorBrush(Color.FromRgb(102, 102, 102));
         protected static readonly SolidColorBrush PortBackgroundColorDefault = new SolidColorBrush(Color.FromRgb(60, 60, 60));
         protected static readonly SolidColorBrush PortBorderBrushColorDefault = new SolidColorBrush(Color.FromRgb(161, 161, 161));
@@ -108,19 +106,6 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// Controls whether the node autocomplete marker is visible
-        /// </summary>
-        public bool NodeAutoCompleteMarkerVisible
-        {
-            get => nodeAutoCompleteMarkerVisible;
-            set
-            {
-                nodeAutoCompleteMarkerVisible = value;
-                RaisePropertyChanged(nameof(NodeAutoCompleteMarkerVisible));
-            }
-        }
-
-        /// <summary>
         /// The height of port.
         /// </summary>
         public double Height
@@ -157,7 +142,6 @@ namespace Dynamo.ViewModels
             }
         }
 
-        /// <summary>
         /// IsHitTestVisible property gets a value that declares whether 
         /// a Snapping rectangle can possibly be returned as a hit test result.
         /// When FirstActiveConnector is not null, Snapping rectangle handles click events.
@@ -503,10 +487,6 @@ namespace Dynamo.ViewModels
         // Handler to invoke node Auto Complete
         private void AutoComplete(object parameter)
         {
-            //handle the mouse event to prevent connection from starting
-            MouseButtonEventArgs evArgs = parameter as MouseButtonEventArgs;
-            evArgs.Handled = true;
-
             var wsViewModel = node?.WorkspaceViewModel;
             if (wsViewModel is null || wsViewModel.NodeAutoCompleteSearchViewModel is null)
             {
@@ -541,10 +521,6 @@ namespace Dynamo.ViewModels
         // Handler to invoke Node autocomplete cluster
         private void AutoCompleteCluster(object parameter)
         {
-            //handle the mouse event to prevent connection from starting
-            MouseButtonEventArgs evArgs = parameter as MouseButtonEventArgs;
-            evArgs.Handled = true;
-            
             var wsViewModel = node.WorkspaceViewModel;
             wsViewModel.NodeAutoCompleteSearchViewModel.PortViewModel = this;
 

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -12,7 +12,6 @@ using Dynamo.Models;
 using Dynamo.Search.SearchElements;
 using Dynamo.UI.Commands;
 using Dynamo.Utilities;
-using static Dynamo.ViewModels.SearchViewModel;
 
 namespace Dynamo.ViewModels
 {
@@ -115,36 +114,11 @@ namespace Dynamo.ViewModels
             get => nodeAutoCompleteMarkerVisible;
             set
             {
-                if (!IsAutoCompleteMarkerDisabled() && CanHaveAutoCompleteMarker())
-                {
-                    nodeAutoCompleteMarkerVisible = value;
-                }
-                else
-                {
-                    nodeAutoCompleteMarkerVisible = false;
-                }
+                nodeAutoCompleteMarkerVisible = value;
                 RaisePropertyChanged(nameof(NodeAutoCompleteMarkerVisible));
             }
         }
-        private bool IsAutoCompleteMarkerDisabled()
-        {
-            // True if autocomplete is turned off globally
-            // Or a connector is being created now
-            // Or node is frozen.
-            // Or node is transient state.
-            return !NodeViewModel.DynamoViewModel.EnableNodeAutoComplete ||
-                   NodeViewModel.WorkspaceViewModel.IsConnecting ||
-                   NodeViewModel.IsFrozen ||
-                   NodeViewModel.IsTransient;
-        }
-        private bool CanHaveAutoCompleteMarker()
-        {
-            return PortModel.Connectors.Count == 0
-                   && NodeViewModel.NodeModel is not CodeBlockNodeModel
-                   && NodeViewModel.NodeModel is not CoreNodeModels.Watch
-                   && NodeViewModel.NodeModel is not PythonNodeModels.PythonNode
-                   && NodeViewModel.NodeModel is not PythonNodeModels.PythonStringNode;
-        }
+
         /// <summary>
         /// The height of port.
         /// </summary>
@@ -463,7 +437,6 @@ namespace Dynamo.ViewModels
             {
                 case nameof(IsSelected):
                     RaisePropertyChanged(nameof(IsSelected));
-                    NodeAutoCompleteMarkerVisible = IsSelected;
                     break;
                 case nameof(State):
                     RaisePropertyChanged(nameof(State));

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -139,7 +139,7 @@ namespace Dynamo.ViewModels
         }
         private bool CanHaveAutoCompleteMarker()
         {
-            return ((this is InPortViewModel && PortModel.Connectors.Count == 0) || this is OutPortViewModel)
+            return PortModel.Connectors.Count == 0
                    && NodeViewModel.NodeModel is not CodeBlockNodeModel
                    && NodeViewModel.NodeModel is not CoreNodeModels.Watch
                    && NodeViewModel.NodeModel is not PythonNodeModels.PythonNode
@@ -497,7 +497,6 @@ namespace Dynamo.ViewModels
                 case nameof(IsConnected):
                     RaisePropertyChanged(nameof(IsConnected));
                     RefreshPortColors();
-                    NodeAutoCompleteMarkerVisible = IsSelected;
                     break;
                 case nameof(IsEnabled):
                     RaisePropertyChanged(nameof(IsEnabled));

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -1066,6 +1066,10 @@ namespace Dynamo.ViewModels
 
                 var portModel = portViewModel.PortModel;
 
+                // When the connect command is triggered, set portDisconnectedByConnectCommand flag based on the port connectors.
+                // If the current port has any connectors, then it will be disconnected. Otherwise a new connection will be made. 
+                portViewModel.inputPortDisconnectedByConnectCommand = portViewModel.PortType == PortType.Input && portModel.Connectors.Count > 0;
+
                 var workspaceViewModel = owningWorkspace.DynamoViewModel.CurrentSpaceViewModel;
 
                 if (this.currentState != State.Connection) // Not in a connection attempt...

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -340,7 +340,7 @@ namespace Dynamo.Wpf.ViewModels
             
             // Avoid triggering auto complete for an already connected input.
             PortModel portModel = parameter as PortModel;
-            return portModel?.PortType != PortType.Input || portModel?.Connectors?.FirstOrDefault()?.Start?.Owner is null;
+            return parameter as PortModel != null ? portModel.CanAutoCompleteInput() : true;
         }
 
         private Rect2D GetNodesBoundingBox(IEnumerable<NodeModel> nodes)

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -508,6 +508,9 @@ namespace Dynamo.Controls
             // ViewModel.DynamoViewModel.ShowPreviewBubbles will be updated AFTER node mouse enter event occurs
             // so, wait while ShowPreviewBubbles binding updates value
             Dispatcher.BeginInvoke(new Action(TryShowPreviewBubbles), DispatcherPriority.Loaded);
+
+
+            Dispatcher.BeginInvoke(new Action(TryShowAutoCompleteMarker), DispatcherPriority.Loaded);
         }
 
         private void TryShowPreviewBubbles()
@@ -534,6 +537,43 @@ namespace Dynamo.Controls
             Dispatcher.DelayInvoke(previewDelay, BringToFront);
         }
 
+        private void TryShowAutoCompleteMarker()
+        {
+            //show the node autocomplete marker if available, skip codeblocks and watch nodes
+            if (IsAutoCompleteMarkerDisabled())
+            {
+                return;
+            }
+
+            if (ViewModel.NodeModel is not CodeBlockNodeModel && ViewModel.NodeModel is not CoreNodeModels.Watch && ViewModel.NodeModel is not PythonNodeModels.PythonNode && ViewModel.NodeModel is not PythonNodeModels.PythonStringNode)
+            {
+                //For input ports, if there are connectors present, do not show marker.
+                foreach (PortViewModel port in ViewModel.InPorts)
+                {
+                    //We check for connector count because 'IsConnected' returns true for use of default value
+                    port.NodeAutoCompleteMarkerVisible = port.PortModel.Connectors.Count < 1;
+                }
+
+                //For output ports, we always show the marker.
+                foreach (PortViewModel port in ViewModel.OutPorts)
+                {
+                    port.NodeAutoCompleteMarkerVisible = true;
+                }
+            }
+        }
+
+        private void TryHideAutoCompleteMaker()
+        {
+            //hide the node autocomplete marker if mouse leaves the node
+            var ports = new List<PortViewModel>(ViewModel.InPorts);
+            ports.AddRange(ViewModel.OutPorts);
+
+            foreach (PortViewModel port in ports)
+            {
+                port.NodeAutoCompleteMarkerVisible = false;
+            }
+        }
+
         private bool IsPreviewDisabled()
         {
             // True if preview bubbles are turned off globally 
@@ -548,9 +588,23 @@ namespace Dynamo.Controls
                 ViewModel.WorkspaceViewModel.IsSelecting || !previewEnabled ||
                 !ViewModel.IsPreviewInsetVisible || ViewModel.IsFrozen || viewModel.IsTransient;
         }
+        private bool IsAutoCompleteMarkerDisabled()
+        {
+            // True if autocomplete is turned off globally
+            // Or a connector is being created now
+            // Or node is frozen.
+            // Or node is transient state.
+            return !ViewModel.DynamoViewModel.EnableNodeAutoComplete ||
+                   ViewModel.WorkspaceViewModel.IsConnecting ||
+                   ViewModel.IsFrozen ||
+                   viewModel.IsTransient;
+        }
         private void OnNodeViewMouseLeave(object sender, MouseEventArgs e)
         {
             ViewModel.ZIndex = oldZIndex;
+
+            //hide the node autocomplete marker if mouse leaves the node
+           TryHideAutoCompleteMaker();
             
             //Watch nodes doesn't have Preview so we should avoid to use any method/property in PreviewControl class due that Preview is created automatically
             if (ViewModel.NodeModel != null && ViewModel.NodeModel is CoreNodeModels.Watch) return;
@@ -679,6 +733,8 @@ namespace Dynamo.Controls
             {
                 PreviewControl.TransitionToState(PreviewControl.State.Hidden);
             }
+
+            TryHideAutoCompleteMaker();
         }
 
         /// <summary>
@@ -686,7 +742,7 @@ namespace Dynamo.Controls
         /// So we can't use MouseLeave/MouseEnter events.
         /// In this case, when we want to ensure, that mouse really left node, we use HitTest.
         /// </summary>
-        /// <param name="mousePosition">Correct position of mouse</param>
+        /// <param name="mousePosition">Currect position of mouse</param>
         /// <returns>bool</returns>
         private bool IsMouseInsideNodeOrPreview(Point mousePosition)
         {

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -500,7 +499,7 @@ namespace Dynamo.Controls
         }
 
 
-        #region Preview Control Related Event Handlers
+    #region Preview Control Related Event Handlers
 
         private void OnNodeViewMouseEnter(object sender, MouseEventArgs e)
         {
@@ -508,9 +507,6 @@ namespace Dynamo.Controls
             // ViewModel.DynamoViewModel.ShowPreviewBubbles will be updated AFTER node mouse enter event occurs
             // so, wait while ShowPreviewBubbles binding updates value
             Dispatcher.BeginInvoke(new Action(TryShowPreviewBubbles), DispatcherPriority.Loaded);
-
-
-            Dispatcher.BeginInvoke(new Action(TryShowAutoCompleteMarker), DispatcherPriority.Loaded);
         }
 
         private void TryShowPreviewBubbles()
@@ -537,40 +533,6 @@ namespace Dynamo.Controls
             Dispatcher.DelayInvoke(previewDelay, BringToFront);
         }
 
-        private void TryShowAutoCompleteMarker()
-        {
-            //show the node autocomplete marker if available, skip codeblocks and watch nodes
-            if (IsAutoCompleteMarkerDisabled())
-            {
-                return;
-            }
-
-            if (ViewModel.NodeModel is not CodeBlockNodeModel && ViewModel.NodeModel is not CoreNodeModels.Watch && ViewModel.NodeModel is not PythonNodeModels.PythonNode && ViewModel.NodeModel is not PythonNodeModels.PythonStringNode)
-            {
-                var ports = new List<PortViewModel>(ViewModel.InPorts);
-                ports.AddRange(ViewModel.OutPorts);
-
-                foreach (PortViewModel port in ports)
-                {
-                    //if there are connectors present, do not show marker.
-                    //We check for connector count because 'IsConnected' returns true for use of default value
-                    port.NodeAutoCompleteMarkerVisible = port.PortModel.Connectors.Count < 1;
-                }
-            }
-        }
-
-        private void TryHideAutoCompleteMaker()
-        {
-            //hide the node autocomplete marker if mouse leaves the node
-            var ports = new List<PortViewModel>(ViewModel.InPorts);
-            ports.AddRange(ViewModel.OutPorts);
-
-            foreach (PortViewModel port in ports)
-            {
-                port.NodeAutoCompleteMarkerVisible = false;
-            }
-        }
-
         private bool IsPreviewDisabled()
         {
             // True if preview bubbles are turned off globally 
@@ -585,24 +547,11 @@ namespace Dynamo.Controls
                 ViewModel.WorkspaceViewModel.IsSelecting || !previewEnabled ||
                 !ViewModel.IsPreviewInsetVisible || ViewModel.IsFrozen || viewModel.IsTransient;
         }
-        private bool IsAutoCompleteMarkerDisabled()
-        {
-            // True if autocomplete is turned off globally
-            // Or a connector is being created now
-            // Or node is frozen.
-            // Or node is transient state.
-            return !ViewModel.DynamoViewModel.EnableNodeAutoComplete ||
-                   ViewModel.WorkspaceViewModel.IsConnecting ||
-                   ViewModel.IsFrozen ||
-                   viewModel.IsTransient;
-        }
+
         private void OnNodeViewMouseLeave(object sender, MouseEventArgs e)
         {
             ViewModel.ZIndex = oldZIndex;
 
-            //hide the node autocomplete marker if mouse leaves the node
-           TryHideAutoCompleteMaker();
-            
             //Watch nodes doesn't have Preview so we should avoid to use any method/property in PreviewControl class due that Preview is created automatically
             if (ViewModel.NodeModel != null && ViewModel.NodeModel is CoreNodeModels.Watch) return;
 
@@ -730,8 +679,6 @@ namespace Dynamo.Controls
             {
                 PreviewControl.TransitionToState(PreviewControl.State.Hidden);
             }
-
-            TryHideAutoCompleteMaker();
         }
 
         /// <summary>
@@ -828,7 +775,7 @@ namespace Dynamo.Controls
 
                 // We don't stash the same MenuItem multiple times.
                 if (NodeViewCustomizationMenuItems.Contains(menuItem.Header.ToString())) continue;
-
+                
                 // The MenuItem gets stashed.
                 NodeViewCustomizationMenuItems.Add(menuItem.Header.ToString(), menuItem);
             }
@@ -856,7 +803,7 @@ namespace Dynamo.Controls
             // Clearing any existing items in the node's ContextMenu.
             contextMenu.Items.Clear();
             NodeContextMenuBuilder.Build(contextMenu, viewModel, NodeViewCustomizationMenuItems);
-
+            
             contextMenu.DataContext = viewModel;
             contextMenu.IsOpen = true;
 

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -547,17 +547,14 @@ namespace Dynamo.Controls
 
             if (ViewModel.NodeModel is not CodeBlockNodeModel && ViewModel.NodeModel is not CoreNodeModels.Watch && ViewModel.NodeModel is not PythonNodeModels.PythonNode && ViewModel.NodeModel is not PythonNodeModels.PythonStringNode)
             {
-                //For input ports, if there are connectors present, do not show marker.
-                foreach (PortViewModel port in ViewModel.InPorts)
+                var ports = new List<PortViewModel>(ViewModel.InPorts);
+                ports.AddRange(ViewModel.OutPorts);
+
+                foreach (PortViewModel port in ports)
                 {
+                    //if there are connectors present, do not show marker.
                     //We check for connector count because 'IsConnected' returns true for use of default value
                     port.NodeAutoCompleteMarkerVisible = port.PortModel.Connectors.Count < 1;
-                }
-
-                //For output ports, we always show the marker.
-                foreach (PortViewModel port in ViewModel.OutPorts)
-                {
-                    port.NodeAutoCompleteMarkerVisible = true;
                 }
             }
         }


### PR DESCRIPTION
### Purpose

This PR removes the relevant PRs for the Node AutoComplete Marker and re-enables the double click paradigm for Node AutoComplete for 3.5.0 release.

We will target the Node AutoComplete marker for 3.6 release and behind a feature flag for daily builds.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers
@zeusongit @BogdanZavu @QilongTang

### FYIs
@DynamoDS/synapse @DynamoDS/eidos 
