### PR TITLE
DYN-8542 : cluster auto-layout improvements

### DIFF
--- a/src/DynamoCoreWpf/Utilities/NodeAutoCompleteUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/NodeAutoCompleteUtilities.cs
@@ -1,6 +1,6 @@
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
-
+using Dynamo.Search.SearchElements;
 using Dynamo.Selection;
 using Dynamo.Utilities;
 using System;
@@ -18,8 +18,9 @@ namespace Dynamo.Wpf.Utilities
         internal static void PostAutoLayoutNodes(WorkspaceModel wsModel,
             NodeModel queryNode,
             IEnumerable<NodeModel> misplacedNodes,
-            bool clusterLayout,
+            bool skipInitialAutoLayout,
             bool checkWorkspaceNodes,
+            bool reuseUndoGroup,
             Action finalizer)
         {
             if (Application.Current?.Dispatcher != null)
@@ -27,8 +28,9 @@ namespace Dynamo.Wpf.Utilities
                 Application.Current.Dispatcher.BeginInvoke(() => AutoLayoutNodes(wsModel,
                     queryNode,
                     misplacedNodes,
-                    clusterLayout,
+                    skipInitialAutoLayout,
                     checkWorkspaceNodes,
+                    reuseUndoGroup,
                     finalizer), DispatcherPriority.ApplicationIdle);
             }
         }
@@ -98,42 +100,23 @@ namespace Dynamo.Wpf.Utilities
         /// <param name="wsModel">The workspace model containing the nodes to be arranged.</param>
         /// <param name="queryNode">The node used as a starting point for the layout operation.</param>
         /// <param name="misplacedNodes">A collection of nodes that are not properly positioned and need to be arranged.</param>
-        /// <param name="clusterLayout">Ensures misplaced nodes are positioned downstream. Nodes will be moved if necessary.</param>
+        /// <param name="skipInitialAutoLayout">Skip initial AutoLayout when we know that nodes are already in a good position.</param>
         /// <param name="checkWorkspaceNodes">Specifies whether to consider existing nodes in the workspace during the layout operation.</param>
+        /// <param name="reuseUndoGroup">Specify if the AutoLayout should use the existing undo group</param>
         /// <param name="finalizer">An action to be executed after the layout operation is complete, typically for cleanup or further adjustments.</param>
         internal static void AutoLayoutNodes(WorkspaceModel wsModel,
             NodeModel queryNode,
             IEnumerable<NodeModel> misplacedNodes,
-            bool clusterLayout,
+            bool skipInitialAutoLayout,
             bool checkWorkspaceNodes,
+            bool reuseUndoGroup,
             Action finalizer)
         {
             DynamoSelection.Instance.Selection.AddRange(misplacedNodes);
-            wsModel.DoGraphAutoLayout(true, true, queryNode.GUID);
 
-            // For large clusters of nodes, auto-layout may place nodes on both sides of the query node.
-            // While the arrangement is technically fine, we move the entire group downstream for better consistency.
-            if (clusterLayout)
+            if (!skipInitialAutoLayout)
             {
-                double offset = -1;
-                foreach (var node in misplacedNodes)
-                {
-                    if (node.X < queryNode.X)
-                    {
-                        offset = Math.Max(offset, queryNode.X - node.X);
-                    }
-                }
-
-                double balast = 50;
-                if (offset > 0)
-                {
-                    foreach (var node in misplacedNodes)
-                    {
-                        node.X = node.X + offset + queryNode.Width + balast;
-                    }
-
-                    wsModel.DoGraphAutoLayout(true, true, queryNode.GUID);
-                }
+                wsModel.DoGraphAutoLayout(reuseUndoGroup, true, queryNode.GUID);
             }
 
             // Check if the newly added nodes are still intersecting with other nodes in the workspace.
@@ -145,7 +128,7 @@ namespace Dynamo.Wpf.Utilities
                 if (redoAutoLayout)
                 {
                     DynamoSelection.Instance.Selection.AddRange(intersectedNodes);
-                    wsModel.DoGraphAutoLayout(true, true, queryNode.GUID);
+                    wsModel.DoGraphAutoLayout(reuseUndoGroup, true, queryNode.GUID);
                 }
             }
 
@@ -155,6 +138,40 @@ namespace Dynamo.Wpf.Utilities
             {
                 finalizer();
             }
+        }
+
+        internal static List<List<NodeItem>> ComputeNodePlacementHeuristics(List<ConnectionItem> connections, List<NodeItem> clusterNodes)
+        {
+            List<List<NodeItem>> resultNodesColumns = new List<List<NodeItem>>();
+            List<NodeItem> remainingNodes = [.. clusterNodes];
+            List<ConnectionItem> remainingConnections = [.. connections];
+
+            while (true)
+            {
+                //mark nodes with input connections
+                Dictionary<string, bool> nodesWithInputs = new Dictionary<string, bool>();
+                remainingConnections.ForEach(connection => nodesWithInputs[connection.EndNode.NodeId] = true);
+
+                //extract nodes without input connections
+                var currentNodesColumn = remainingNodes.Where(node => !nodesWithInputs.ContainsKey(node.Id)).ToList();
+
+                //store the current set of inputs
+                resultNodesColumns.Add(currentNodesColumn);
+
+                //remove connections that start with current set of inputs
+                var currentNodesColumnIds = currentNodesColumn.Select(node => node.Id).ToList();
+                remainingConnections = remainingConnections.Where(connection => !currentNodesColumnIds.Contains(connection.StartNode.NodeId)).ToList();
+
+                //remove current inputs from the remaining nodes
+                remainingNodes = remainingNodes.Except(currentNodesColumn).ToList();
+
+                if (remainingNodes.Count == 0)
+                {
+                    break;
+                }
+            }
+
+            return resultNodesColumns;
         }
     }
 }

--- a/src/DynamoCoreWpf/Utilities/NodeAutoCompleteUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/NodeAutoCompleteUtilities.cs
@@ -140,13 +140,14 @@ namespace Dynamo.Wpf.Utilities
             }
         }
 
+        //Order cluster nodes from left to right based on their connections.
         internal static List<List<NodeItem>> ComputeNodePlacementHeuristics(List<ConnectionItem> connections, List<NodeItem> clusterNodes)
         {
             List<List<NodeItem>> resultNodesColumns = new List<List<NodeItem>>();
             List<NodeItem> remainingNodes = [.. clusterNodes];
             List<ConnectionItem> remainingConnections = [.. connections];
 
-            while (true)
+            while (remainingNodes.Count > 0)
             {
                 //mark nodes with input connections
                 Dictionary<string, bool> nodesWithInputs = new Dictionary<string, bool>();
@@ -164,11 +165,6 @@ namespace Dynamo.Wpf.Utilities
 
                 //remove current inputs from the remaining nodes
                 remainingNodes = remainingNodes.Except(currentNodesColumn).ToList();
-
-                if (remainingNodes.Count == 0)
-                {
-                    break;
-                }
             }
 
             return resultNodesColumns;

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -32,6 +32,7 @@ using ProtoCore.Mirror;
 using ProtoCore.Utils;
 using RestSharp;
 using Dynamo.Graph.Workspaces;
+using Dynamo.Wpf.Utilities;
 
 namespace Dynamo.ViewModels
 {
@@ -171,10 +172,12 @@ namespace Dynamo.ViewModels
         {
             var node = PortViewModel.NodeViewModel;
             var transientNodes = node.WorkspaceViewModel.Nodes.Where(x => x.IsTransient).ToList();
-            foreach(var transientNode in transientNodes)
+            foreach (var transientNode in transientNodes)
             {
                 transientNode.IsTransient = false;
             }
+
+            NodeAutoCompleteUtilities.PostAutoLayoutNodes(node.WorkspaceViewModel.Model, node.NodeModel, transientNodes.Select(x => x.NodeModel), true, true, false, null);
         }
 
         /// <summary>
@@ -767,49 +770,75 @@ namespace Dynamo.ViewModels
 
             var index = 0;
             // A map of the cluster result v.s. actual nodes created for node connection look up
-            var clusterMapping = new Dictionary<string, NodeViewModel>();
+            var clusterMapping = new Dictionary<string, NodeModel>();
             // Convert topology to actual cluster
-            ClusterResultItem.Topology.Nodes.ToList().ForEach(node =>
-            {
-                // Retreive assembly name and node full name from type.id.
-                var typeInfo = wsViewModel.NodeAutoCompleteSearchViewModel.GetInfoFromTypeId(node.Type.Id);
-                dynamoViewModel.Model.ExecuteCommand(new DynamoModel.CreateNodeCommand(Guid.NewGuid().ToString(), typeInfo.FullName, 0, 0, false, false));
-                var nodeFromCluster = wsViewModel.Nodes.LastOrDefault();
-                nodeFromCluster.IsTransient = true;
-                clusterMapping.Add(node.Id, nodeFromCluster);
-                // Add the node to the selection to prepare for autolayout later
-                if (index == ClusterResultItem.EntryNodeIndex)
-                {
-                    // This is the target node from cluster that should connect to the query node
-                    targetNodeFromCluster = nodeFromCluster;
-                }
-                index++;
-            });
-            using (var undoGroup = wsViewModel.Model.UndoRecorder.BeginActionGroup())
-            {
-                ClusterResultItem.Topology.Connections.ToList().ForEach(connection =>
-                {
-                    // Connect the nodes
-                    var sourceNode = clusterMapping[connection.StartNode.NodeId];
-                    var targetNode = clusterMapping[connection.EndNode.NodeId];
-                    // The port index is 1- based (currently a hack and not expected from service)
-                    var sourcePort = sourceNode.OutPorts.FirstOrDefault(p => p.PortModel.Index == connection.StartNode.PortIndex - 1);
-                    var targetPort = targetNode.InPorts.FirstOrDefault(p => p.PortModel.Index == connection.EndNode.PortIndex - 1);
-                    var connector = ConnectorModel.Make(sourceNode.NodeModel, targetNode.NodeModel, connection.StartNode.PortIndex - 1, connection.EndNode.PortIndex - 1);
-                    wsViewModel.Model.UndoRecorder.RecordCreationForUndo(connector);
-                });
+            var clusterNodes = ClusterResultItem.Topology.Nodes.ToList();
+            var clusterConnections = ClusterResultItem.Topology.Connections.ToList();
 
-                // Connect the cluster to the original node and port
-                var connector = ConnectorModel.Make(node.NodeModel, targetNodeFromCluster.NodeModel, 0, ClusterResultItem.EntryNodeInPort);
-                wsViewModel.Model.UndoRecorder.RecordCreationForUndo(connector);
+            List<List<NodeItem>> nodeStacks = NodeAutoCompleteUtilities.ComputeNodePlacementHeuristics(clusterConnections, clusterNodes);
 
-                // AutoLayout should be called after all nodes are connected
-                foreach (var clusterNode in clusterMapping.Values)
+            double xoffset = node.X + node.NodeModel.Width;
+            foreach (var nodeStack in nodeStacks)
+            {
+                xoffset += node.NodeModel.Width;
+                foreach(var newNode in nodeStack)
                 {
-                    wsViewModel.DynamoViewModel.Model.AddToSelection(clusterNode.NodeModel);
+                    // Retreive assembly name and node full name from type.id.
+                    var typeInfo = wsViewModel.NodeAutoCompleteSearchViewModel.GetInfoFromTypeId(newNode.Type.Id);
+                    dynamoViewModel.Model.ExecuteCommand(new DynamoModel.CreateNodeCommand(Guid.NewGuid().ToString(), typeInfo.FullName, xoffset, node.NodeModel.Y, false, false));
+                    var nodeFromCluster = wsViewModel.Nodes.LastOrDefault();
+                    nodeFromCluster.IsTransient = true;
+                    clusterMapping.Add(newNode.Id, nodeFromCluster.NodeModel);
+                    // Add the node to the selection to prepare for autolayout later
+                    if (index == ClusterResultItem.EntryNodeIndex)
+                    {
+                        // This is the target node from cluster that should connect to the query node
+                        targetNodeFromCluster = nodeFromCluster;
+                    }
+                    index++;
                 }
-                wsViewModel.Model.DoGraphAutoLayout(true, true, node.Id);
             }
+
+            clusterConnections.ForEach(connection =>
+            {
+                // Connect the nodes
+                var sourceNode = clusterMapping[connection.StartNode.NodeId];
+                var targetNode = clusterMapping[connection.EndNode.NodeId];
+                // The port index is 1- based (currently a hack and not expected from service)
+                var sourcePort = sourceNode.OutPorts.FirstOrDefault(p => p.Index == connection.StartNode.PortIndex - 1);
+                var targetPort = targetNode.InPorts.FirstOrDefault(p => p.Index == connection.EndNode.PortIndex - 1);
+                var commands = new List<DynamoModel.ModelBasedRecordableCommand>
+                    {
+                        new DynamoModel.MakeConnectionCommand(sourceNode.GUID.ToString(), connection.StartNode.PortIndex - 1, PortType.Output, DynamoModel.MakeConnectionCommand.Mode.Begin),
+                        new DynamoModel.MakeConnectionCommand(targetNode.GUID.ToString(), connection.EndNode.PortIndex - 1, PortType.Input, DynamoModel.MakeConnectionCommand.Mode.End),
+                    };
+                commands.ForEach(c =>
+                {
+                    try
+                    {
+                        wsViewModel.DynamoViewModel.Model.ExecuteCommand(c);
+                    }
+                    catch (Exception) { }
+                });
+            });
+
+            // Connect the cluster to the original node and port
+            var finalCommands = new List<DynamoModel.ModelBasedRecordableCommand>
+                {
+                    new DynamoModel.MakeConnectionCommand(node.Id.ToString(), 0, PortType.Output, DynamoModel.MakeConnectionCommand.Mode.Begin),
+                    new DynamoModel.MakeConnectionCommand(targetNodeFromCluster?.Id.ToString(), ClusterResultItem.EntryNodeInPort, PortType.Input, DynamoModel.MakeConnectionCommand.Mode.End),
+                };
+            finalCommands.ForEach(c =>
+            {
+                try
+                {
+                    wsViewModel.DynamoViewModel.Model.ExecuteCommand(c);
+                }
+                catch (Exception) { }
+            });
+
+            // AutoLayout should be called after all nodes are connected
+            NodeAutoCompleteUtilities.PostAutoLayoutNodes(wsViewModel.DynamoViewModel.CurrentSpace, node.NodeModel, clusterMapping.Values.ToList(), false, false, false, null);
         }
         /// <summary>
         /// Key function to populate node autocomplete results to display

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -320,7 +320,7 @@ namespace Dynamo.Wpf.ViewModels
 
             Action ensureUndoGroup = () => undoRecorderGroup?.Dispose();
 
-            NodeAutoCompleteUtilities.PostAutoLayoutNodes(dynamoViewModel.CurrentSpace, initialNode, misplacedNodes, false, true, ensureUndoGroup);
+            NodeAutoCompleteUtilities.PostAutoLayoutNodes(dynamoViewModel.CurrentSpace, initialNode, misplacedNodes, false, true, true, ensureUndoGroup);
         }
 
         protected virtual bool CanCreateAndConnectToPort(object parameter)


### PR DESCRIPTION
### Purpose
Auto-layout cluster nodes downstream both in preview and final placement.
In preview mode we don't consider existing nodes in the graph to avoid unnecessary layout disruptions.
When a cluster is chosen to be permanent we will do an auto-layout considering nodes in the workspace.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Reviewers
@DynamoDS/synapse 



![flyout](https://github.com/user-attachments/assets/ca7d4f57-ed0a-4e87-81f7-9befddee3278)

