### PR TITLE
[DYN-8628] Investigate why the CurveMapper node executes twice

### DIFF
--- a/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
+++ b/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
@@ -178,7 +178,6 @@ namespace CoreNodeModels
                     minLimitX = value;
                     this.RaisePropertyChanged(nameof(MinLimitX));
                     this.RaisePropertyChanged(nameof(MidValueX));
-                    OnNodeModified();
                 }
             }
         }
@@ -195,7 +194,6 @@ namespace CoreNodeModels
                     maxLimitX = value;
                     this.RaisePropertyChanged(nameof(MaxLimitX));
                     this.RaisePropertyChanged(nameof(MidValueX));
-                    OnNodeModified();
                 }
             }
         }
@@ -212,7 +210,6 @@ namespace CoreNodeModels
                     minLimitY = value;
                     this.RaisePropertyChanged(nameof(MinLimitY));
                     this.RaisePropertyChanged(nameof(MidValueY));
-                    OnNodeModified();
                 }
             }
         }
@@ -229,7 +226,6 @@ namespace CoreNodeModels
                     maxLimitY = value;
                     this.RaisePropertyChanged(nameof(MaxLimitY));
                     this.RaisePropertyChanged(nameof(MidValueY));
-                    OnNodeModified();
                 }
             }
         }
@@ -245,7 +241,6 @@ namespace CoreNodeModels
                 {
                     pointsCount = value;
                     this.RaisePropertyChanged(nameof(PointsCount));
-                    OnNodeModified();
                 }
             }
         }
@@ -270,7 +265,6 @@ namespace CoreNodeModels
             set
             {
                 renderValuesY = value;
-                OnNodeModified();
             }
         }
         /// <summary> Gets or sets the X values used for rendering the curve. </summary>
@@ -281,7 +275,6 @@ namespace CoreNodeModels
             set
             {
                 renderValuesX = value;
-                OnNodeModified();
             }
         }
 
@@ -324,7 +317,6 @@ namespace CoreNodeModels
                     .Cast<GraphTypes>()
                     .FirstOrDefault(e => GetEnumDescription(e) == value);
 
-                RaisePropertyChanged(nameof(SelectedGraphType));
                 RaisePropertyChanged(nameof(SelectedGraphTypeDescription));
             }
         }
@@ -337,9 +329,7 @@ namespace CoreNodeModels
             set
             {
                 selectedGraphType = value;
-                GenerateRenderValues();
                 RaisePropertyChanged(nameof(SelectedGraphType));
-                OnNodeModified();
             }
         }
 
@@ -423,11 +413,6 @@ namespace CoreNodeModels
 
             RegisterAllPorts();
 
-            foreach (var port in InPorts)
-            {
-                port.Connectors.CollectionChanged += Connectors_CollectionChanged;
-            }
-
             SelectedGraphType = GraphTypes.Empty;
             ArgumentLacing = LacingStrategy.Disabled;
 
@@ -439,22 +424,8 @@ namespace CoreNodeModels
         public CurveMapperNodeModel(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts,
             double dynamicCanvasSize = defaultCanvasSize) : base(inPorts, outPorts)
         {
-            foreach (var port in InPorts)
-            {
-                port.Connectors.CollectionChanged += Connectors_CollectionChanged;
-            }
-
             DynamicCanvasSize = dynamicCanvasSize;
             ArgumentLacing = LacingStrategy.Disabled;
-        }
-
-        #endregion
-
-        #region Event Handers
-
-        private void Connectors_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-        {
-            OnNodeModified();
         }
 
         #endregion
@@ -469,6 +440,7 @@ namespace CoreNodeModels
             if (SelectedGraphType == GraphTypes.Empty)
             {
                 RenderValuesX = RenderValuesY = null;
+                OnNodeModified();
                 return;
             }
             if (!IsValidCurve())
@@ -476,9 +448,10 @@ namespace CoreNodeModels
                 Warning(Properties.Resources.CurveMapperWarningMessage, isPersistent: true);
 
                 RenderValuesX = RenderValuesY = null;
+                OnNodeModified();
                 return;
             }
-            else if(!IsResizing)
+            if(!IsResizing)
             {
                 ClearErrorsAndWarnings();
             }
@@ -561,6 +534,11 @@ namespace CoreNodeModels
                 dynamic dynamicCurve = curve;
                 RenderValuesX = dynamicCurve.GetCurveXValues(PointsCount, true);
                 RenderValuesY = dynamicCurve.GetCurveYValues(PointsCount, true);
+
+                if (!IsResizing)
+                {
+                    OnNodeModified();
+                }
             }
         }
 

--- a/src/Libraries/CoreNodeModelsWpf/CurveMapper/CurveMapperControl.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/CurveMapper/CurveMapperControl.xaml.cs
@@ -169,9 +169,8 @@ namespace Dynamo.Wpf.CurveMapper
 
             // Dictionary to map UI control points to their corresponding data
             var controlPointsResetMap = BuildControlPointsDictionary();
-            RecreateControlPoints(controlPointsResetMap);
 
-            curveMapperNodeModel.GenerateRenderValues();
+            RecreateControlPoints(controlPointsResetMap);
             RenderCurve();
         }
 


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-8628](https://jira.autodesk.com/browse/DYN-8628),  which caused the CurveMapper node to execute twice, resulting in multiple calls to BuildOutputAst().

Changes:

- Reduced unnecessary calls to OnNodeModified() to avoid duplicate execution.
- Removed RaisePropertyChanged("SelectedGraphType") from the SelectedGraphTypeDescription setter, as it was causing redundant updates.
- Minimized redundant calls to GenerateRenderValues().
- Removed the Connectors_CollectionChanged handler, since this is already handled by the base model.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

The new changes prevent Curve Mapper always running twice.

### Reviewers
@reddyashish 
@zeusongit 

### FYIs
@dnenov 
@achintyabhat 
