### PR TITLE
DYN-8494 Put Connector Creation into Single Undo Group

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -589,10 +589,11 @@ namespace Dynamo.ViewModels
         {
             bool isCollectionofFiveorMore = false;
 
-            //if model is null or enginecontroller is disposed, return
+            // if model is null or node in Transient state or enginecontroller is disposed, return
             if (model is null ||
                 model.Start is null ||
                 model.Start.Owner is null||
+                model.Start.Owner.IsTransient ||
                 workspaceViewModel.DynamoViewModel.EngineController.IsDisposed == true)
             { return; }
 

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -811,7 +811,7 @@ namespace Dynamo.ViewModels
                     var targetPort = targetNode.InPorts.FirstOrDefault(p => p.Index == connection.EndNode.PortIndex - 1);
 
                     var connector = ConnectorModel.Make(sourceNode, targetNode, connection.StartNode.PortIndex - 1, connection.EndNode.PortIndex - 1);
-                    if (connector != null)
+                    if (connector != null && !targetPort.IsConnected)
                     {
                         wsViewModel.Model.UndoRecorder.RecordCreationForUndo(connector);
                     }
@@ -819,7 +819,7 @@ namespace Dynamo.ViewModels
 
                 // Connect the cluster to the original node and port
                 var connector = ConnectorModel.Make(node.NodeModel, targetNodeFromCluster.NodeModel, 0, ClusterResultItem.EntryNodeInPort);
-                if (connector != null)
+                if (connector != null && !targetNodeFromCluster.OutPorts.FirstOrDefault().IsConnected)
                 {
                     wsViewModel.Model.UndoRecorder.RecordCreationForUndo(connector);
                 }

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -804,8 +804,8 @@ namespace Dynamo.ViewModels
                 clusterConnections.ForEach(connection =>
                 {
                     // Connect the nodes    
-                    var sourceNode = clusterMapping[connection.StartNode.NodeId];
-                    var targetNode = clusterMapping[connection.EndNode.NodeId];
+                    var sourceNode = clusterMapping[connection.StartNode.NodeId].NodeModel;
+                    var targetNode = clusterMapping[connection.EndNode.NodeId].NodeModel;
                     // The port index is 1- based (currently a hack and not expected from service)
                     var sourcePort = sourceNode.OutPorts.FirstOrDefault(p => p.Index == connection.StartNode.PortIndex - 1);
                     var targetPort = targetNode.InPorts.FirstOrDefault(p => p.Index == connection.EndNode.PortIndex - 1);


### PR DESCRIPTION
### Purpose

Re-initiate https://github.com/DynamoDS/Dynamo/pull/15993 plus some crash guard code.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers

@DynamoDS/synapse 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
