### PR TITLE
DYN-8633: populate default values if missing

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -118,6 +118,7 @@ namespace Dynamo.UI.Views
         {
             CompatibilityMap();
             SetLocale();
+            SetDefaultUserNamePreviewValue();
 
             if (_hasPendingUpdates)
             {
@@ -125,6 +126,7 @@ namespace Dynamo.UI.Views
                 UpdateFromBackEnd();
             }
         }
+
 
         private async void SetLocale()
         {
@@ -567,6 +569,20 @@ namespace Dynamo.UI.Views
             }
         }
 
+        private async void SetDefaultUserNamePreviewValue()
+        {
+            if (!string.IsNullOrEmpty(publishPackageViewModel?.DynamoViewModel?.Model?.AuthenticationManager?.Username))
+            {
+                var payload = new { userName = publishPackageViewModel.DynamoViewModel.Model.AuthenticationManager.Username };
+
+                string jsonPayload = Newtonsoft.Json.JsonConvert.SerializeObject(payload, Formatting.None);
+
+                if (dynWebView?.CoreWebView2 != null)
+                {
+                    await dynWebView.CoreWebView2.ExecuteScriptAsync($"window.receiveDefaultUserName({jsonPayload})");
+                }
+            }
+        }
 
         #endregion
 
@@ -754,6 +770,8 @@ namespace Dynamo.UI.Views
 
         internal void Submit()
         {
+            PrePopulateDefaultValues();
+
             if (publishPackageViewModel == null) return;
             if (publishPackageViewModel.SubmitCommand?.CanExecute() == true)
             {
@@ -763,6 +781,8 @@ namespace Dynamo.UI.Views
 
         internal void Publish()
         {
+            PrePopulateDefaultValues();
+
             if (publishPackageViewModel == null) return;
             if (publishPackageViewModel.PublishLocallyCommand?.CanExecute() == true)
             {
@@ -973,6 +993,25 @@ namespace Dynamo.UI.Views
             this.publishPackageViewModel?.DynamoViewModel?.Model.Logger.Log(logMessage);
         }
 
+        /// <summary>
+        /// Pre-populate default values for the package details
+        /// </summary>
+        private void PrePopulateDefaultValues()
+        {
+            if (publishPackageViewModel == null) return;
+            if (string.IsNullOrEmpty(publishPackageViewModel.CopyrightYear))
+            {
+                publishPackageViewModel.CopyrightYear = DateTime.Now.Year.ToString();
+            }
+            if (string.IsNullOrEmpty(publishPackageViewModel.License))
+            {
+                publishPackageViewModel.License = "MIT";
+            }
+            if (string.IsNullOrEmpty(publishPackageViewModel.CopyrightHolder))
+            {
+                publishPackageViewModel.CopyrightHolder = publishPackageViewModel.DynamoViewModel.Model.AuthenticationManager.Username;
+            }
+        }
         #endregion
 
         #region Dispose


### PR DESCRIPTION
### Purpose

Addresses https://jira.autodesk.com/browse/DYN-8633: Dynamo client PM Publish Wizard does not auto-populate license, year, and publisher info

Works with: https://git.autodesk.com/Dynamo/PackagePublishWizard/pull/43

![image](https://github.com/user-attachments/assets/9dc3ae9d-3b88-4103-813c-e7a0380baf1b)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- now populates the default values for year, username and license type if none are provided
- this is best handled on the back end to avoid hidden form submission on front end, etc
- sends current username value to front end at start

### Reviewers

@reddyashish 
@zeusongit 

### FYIs

@achintyabhat 
