### PR TITLE
DYN-8522: Hide CurveMapperGenerator from library.

### DIFF
--- a/src/Libraries/CoreNodes/CurveMapper/CurveMapperGenerator.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/CurveMapperGenerator.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using Autodesk.DesignScript.Runtime;
 
 namespace DSCore.CurveMapper
 {
+    [IsVisibleInDynamoLibrary(false)]
     public class CurveMapperGenerator
     {
         private static int rounding = 10;
@@ -11,7 +13,7 @@ namespace DSCore.CurveMapper
             List<double> controlPoints, double canvasSize,
             double minX, double maxX, double minY, double maxY,
             int pointsCount, string graphType
-            )
+            )   
         {
             var xValues = new List<double>() { double.NaN };
             var yValues = new List<double>() { double.NaN };

--- a/src/Libraries/CoreNodes/CurveMapper/CurveMapperGenerator.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/CurveMapperGenerator.cs
@@ -13,7 +13,7 @@ namespace DSCore.CurveMapper
             List<double> controlPoints, double canvasSize,
             double minX, double maxX, double minY, double maxY,
             int pointsCount, string graphType
-            )   
+            )
         {
             var xValues = new List<double>() { double.NaN };
             var yValues = new List<double>() { double.NaN };


### PR DESCRIPTION
### Purpose

Hide CurveMapperGenerator from library.

https://jira.autodesk.com/browse/DYN-8522

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
Do not show CurveMapperGenerator in the library.

### Reviewers
@zeusongit @ivaylo-matov 

