### PR TITLE
DYN-7844: Track node frozen state to match with groups frozen state

### DIFF
--- a/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
+++ b/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
@@ -526,6 +526,9 @@ namespace Dynamo.Graph.Annotations
                 case nameof(NodeModel.State):
                     UpdateErrorAndWarningIconVisibility();
                     break;
+                case nameof(NodeModel.IsFrozen):
+                    UpdateGroupFrozenStatus();
+                    break;
             }
         }
 
@@ -544,7 +547,32 @@ namespace Dynamo.Graph.Annotations
                 UpdateBoundaryFromSelection();
             }
         }
-      
+
+        /// <summary>
+        /// The method updates the group frozen status. If all nodes and nested groups are frozen, it sets to true, else false.
+        /// </summary>
+        /// <returns>Frozen state of a group</returns>
+        internal void UpdateGroupFrozenStatus()
+        {
+            // Check for any non-frozen node in the group
+            var nonFrozenNodeInGroup = this.Nodes.OfType<NodeModel>().Any(x => !x.IsFrozen);
+            if (nonFrozenNodeInGroup)
+            {
+                this.IsFrozen = false;
+                return;
+            }
+
+            // Check for any non-frozen nested group in the group
+            var nonFrozenGroupInGroup = this.Nodes.OfType<AnnotationModel>().Any(x => !x.IsFrozen);
+            if (nonFrozenGroupInGroup)
+            {
+                this.IsFrozen = false;
+                return;
+            }
+
+            this.IsFrozen = true;
+        }
+
         /// <summary>
         /// Updates the group boundary based on the nodes / notes selection.
         /// </summary>      

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -1307,6 +1307,7 @@ namespace Dynamo.ViewModels
             }
 
             WorkspaceViewModel.HasUnsavedChanges = true;
+            this.AnnotationModel.UpdateGroupFrozenStatus();
         }
 
         private void RemoveKeyFromCutGeometryDictionary(Guid groupGuid)

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -1515,12 +1515,12 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(parentGroupVM.AnnotationModel.IsFrozen);
             Assert.IsTrue(nestedGroupVM.AnnotationModel.IsFrozen);
 
-            // Unfreeze only nested group - parent should remain frozen
+            // Unfreeze only nested group - parent should also become unfrozen
             nestedGroupVM.ToggleIsFrozenGroupCommand.Execute(null);
 
             Assert.AreEqual(2, parentGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
             Assert.AreEqual(0, nestedGroupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
-            Assert.IsTrue(parentGroupVM.AnnotationModel.IsFrozen);
+            Assert.IsTrue(!parentGroupVM.AnnotationModel.IsFrozen);
             Assert.IsTrue(!nestedGroupVM.AnnotationModel.IsFrozen);
 
             // Freeze nested group again
@@ -1608,7 +1608,7 @@ namespace DynamoCoreWpfTests
             nodeVM.IsFrozen = false;
 
             Assert.AreEqual(4, groupVM.Nodes.OfType<NodeModel>().Count(x => x.IsFrozen));
-            Assert.IsTrue(groupVM.AnnotationModel.IsFrozen);
+            Assert.IsTrue(!groupVM.AnnotationModel.IsFrozen);
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

This PR is a follow up to the previous PR that implemented this feature.

What this PR changes: 
- Will update the group frozen state if a child node is un/frozen.
- Will update the group frozen state if a child group is un/frozen.
- Will update the group frozen state if an un/frozen node is added/removed from the group.

What this PR does not change:
- Frozen state of a node when added to a frozen group.
- Frozen state of a group when added to a frozen group.

![DynamoSandbox_B19PNNa266](https://github.com/user-attachments/assets/111cac19-f1cb-4ff2-8d76-3ec64312f4b8)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Track node frozen state to match with groups frozen state

### FYIs

@achintyabhat 
