### PR TITLE
[DYN-8596] Updated input resources for CurveMapper

### DIFF
--- a/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
+++ b/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
@@ -332,6 +332,7 @@ namespace CoreNodeModels
             set
             {
                 selectedGraphType = value;
+                GenerateRenderValues();
                 RaisePropertyChanged(nameof(SelectedGraphType));
             }
         }

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -268,7 +268,7 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to count.
+        ///   Looks up a localized string similar to values.
         /// </summary>
         public static string CurveMapperCountInputPortName {
             get {
@@ -277,7 +277,7 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Number of values to generate.
+        ///   Looks up a localized string similar to Number of values to map or List of values to map.
         ///
         ///Default value (int): {0}.
         /// </summary>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -268,7 +268,7 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to values.
+        ///   Looks up a localized string similar to count.
         /// </summary>
         public static string CurveMapperCountInputPortName {
             get {
@@ -277,9 +277,9 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Number of values to map or List of values to map.
+        ///   Looks up a localized string similar to Number of values to generate.
         ///
-        ///Default value (int): {10}.
+        ///Default value (int): {0}.
         /// </summary>
         public static string CurveMapperCountInputPortToolTip {
             get {

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -268,7 +268,7 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to count.
+        ///   Looks up a localized string similar to values.
         /// </summary>
         public static string CurveMapperCountInputPortName {
             get {
@@ -277,9 +277,9 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Number of values to generate.
+        ///   Looks up a localized string similar to Number of values to map or List of values to map.
         ///
-        ///Default value (int): {0}.
+        ///Default value (int): {10}.
         /// </summary>
         public static string CurveMapperCountInputPortToolTip {
             get {

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -681,10 +681,10 @@ In Generative Design workflows, this node should be used to control and block th
 default value: G</value>
   </data>
   <data name="CurveMapperCountInputPortName" xml:space="preserve">
-    <value>count</value>
+    <value>values</value>
   </data>
   <data name="CurveMapperCountInputPortToolTip" xml:space="preserve">
-    <value>Number of values to generate.
+    <value>Number of values to map or List of values to map.
 
 Default value (int): {0}</value>
   </data>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -681,10 +681,12 @@ In Generative Design workflows, this node should be used to control and block th
 default value: G</value>
   </data>
   <data name="CurveMapperCountInputPortName" xml:space="preserve">
-    <value>count</value>
+    <value>values</value>
   </data>
   <data name="CurveMapperCountInputPortToolTip" xml:space="preserve">
-    <value>Number of values to generate.
+    <value>Number of values to map or List of values to map.
+
+Default value (int): {10}
 
 Default value (int): {0}</value>
   </data>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -681,12 +681,10 @@ In Generative Design workflows, this node should be used to control and block th
 default value: G</value>
   </data>
   <data name="CurveMapperCountInputPortName" xml:space="preserve">
-    <value>values</value>
+    <value>count</value>
   </data>
   <data name="CurveMapperCountInputPortToolTip" xml:space="preserve">
-    <value>Number of values to map or List of values to map.
-
-Default value (int): {10}
+    <value>Number of values to generate.
 
 Default value (int): {0}</value>
   </data>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -681,10 +681,10 @@ In Generative Design workflows, this node should be used to control and block th
 default value: G</value>
   </data>
   <data name="CurveMapperCountInputPortName" xml:space="preserve">
-    <value>count</value>
+    <value>values</value>
   </data>
   <data name="CurveMapperCountInputPortToolTip" xml:space="preserve">
-    <value>Number of values to generate.
+    <value>Number of values to map or List of values to map.
 
 Default value (int): {0}</value>
   </data>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -681,12 +681,12 @@ In Generative Design workflows, this node should be used to control and block th
 default value: G</value>
   </data>
   <data name="CurveMapperCountInputPortName" xml:space="preserve">
-    <value>count</value>
+    <value>values</value>
   </data>
   <data name="CurveMapperCountInputPortToolTip" xml:space="preserve">
-    <value>Number of values to generate.
+    <value>Number of values to map or List of values to map.
 
-Default value (int): {0}</value>
+Default value (int): {10}</value>
   </data>
   <data name="CurveMapperDescription" xml:space="preserve">
     <value>Redistributes x-coordinates along y-coordinates based on a selected mathematical curve, providing precise control over point distribution.</value>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -681,12 +681,12 @@ In Generative Design workflows, this node should be used to control and block th
 default value: G</value>
   </data>
   <data name="CurveMapperCountInputPortName" xml:space="preserve">
-    <value>values</value>
+    <value>count</value>
   </data>
   <data name="CurveMapperCountInputPortToolTip" xml:space="preserve">
-    <value>Number of values to map or List of values to map.
+    <value>Number of values to generate.
 
-Default value (int): {10}</value>
+Default value (int): {0}</value>
   </data>
   <data name="CurveMapperDescription" xml:space="preserve">
     <value>Redistributes x-coordinates along y-coordinates based on a selected mathematical curve, providing precise control over point distribution.</value>


### PR DESCRIPTION
### Purpose

Part of [DYN-8595](https://jira.autodesk.com/browse/DYN-8595).

Updated resources for the count (now values) input port.
Brought back GenerateRenderValues in SelectedGraphType, so that the curve is generated saved graph is open.

![image](https://github.com/user-attachments/assets/6529a29e-d969-4078-8ebd-394bc43f5a7b)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Updated resources for the count (now values) input port.

### Reviewers
@reddyashish 
@zeusongit 

### FYIs
@dnenov 
