### PR TITLE
DYN-8630:asterisk replace, upload canceled

### DIFF
--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1102,6 +1102,7 @@ Dynamo.PackageManager.PublishPackageViewModel.SiteUrl.get -> string
 Dynamo.PackageManager.PublishPackageViewModel.SiteUrl.set -> void
 Dynamo.PackageManager.PublishPackageViewModel.SubmitCommand.get -> Prism.Commands.DelegateCommand
 Dynamo.PackageManager.PublishPackageViewModel.ToggleMoreCommand.get -> Prism.Commands.DelegateCommand
+Dynamo.PackageManager.PublishPackageViewModel.UploadCancelled -> System.Action
 Dynamo.PackageManager.PublishPackageViewModel.UploadHandle.get -> Dynamo.PackageManager.PackageUploadHandle
 Dynamo.PackageManager.PublishPackageViewModel.UploadHandle.set -> void
 Dynamo.PackageManager.PublishPackageViewModel.Uploading.get -> bool

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -986,6 +986,11 @@ namespace Dynamo.PackageManager
         /// </summary>
         private bool IsPublishFromLocalPackage = false;
 
+        /// <summary>
+        /// Notifies the view model that the user has cancelled the upload
+        /// </summary>
+        public event Action UploadCancelled;
+
         #endregion
 
         internal PublishPackageViewModel()
@@ -2348,6 +2353,8 @@ namespace Dynamo.PackageManager
             MessageBoxResult response = DynamoModel.IsTestMode ? MessageBoxResult.OK : MessageBoxService.Show(Owner, Resources.PrePackagePublishMessage, Resources.PrePackagePublishTitle, MessageBoxButton.OKCancel, MessageBoxImage.Information);
             if (response == MessageBoxResult.Cancel)
             {
+                // Notify the front-end that the user has cancelled the upload
+                UploadCancelled?.Invoke();
                 return;
             }
 


### PR DESCRIPTION
### Purpose

Continuation of https://github.com/DynamoDS/Dynamo/pull/16085. Adding the replacement of 'x' with '*' to match the expected server request notation. Also, this PR is adding a notification to the front-end if the user has cancelled out during the Submit process, so the UI can correctly reflect that.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- replace 'x' with '*' before sending submit request
- added route to notify the front end if the user cancels out during the submit action

### Reviewers

@zeusongit 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
