### PR TITLE
DYN-8648: Remove warnings thrown from inside the CurveMapper NodeModel

### DIFF
--- a/doc/distrib/NodeHelpFiles/en-US/GV5KUSHDGL7YVBZAR4HEGY5NIXFIG3XTV6ZQPHC5MWWGEVOSRJ4Q.md
+++ b/doc/distrib/NodeHelpFiles/en-US/GV5KUSHDGL7YVBZAR4HEGY5NIXFIG3XTV6ZQPHC5MWWGEVOSRJ4Q.md
@@ -5,11 +5,11 @@ Define the limits for the x-coordinates by setting the minimum and maximum value
 
 Select a mathematical curve from the provided options, which includes Linear, Sine, Cosine, Perlin Noise, Bezier, Gaussian, Parabolic, Square Root, and Power curves. Use interactive control points to adjust the shape of the selected curve, tailoring it to your specific needs.
 
-You can lock the curve shape using the lock button, preventing further modifications to the curve. Additionally, you can reset the shape to its default state by using the reset button inside the node. If you get NaN or Null as outputs, you can find more details here on why you might be seeing this.
+You can lock the curve shape using the lock button, preventing further modifications to the curve. Additionally, you can reset the shape to its default state by using the reset button inside the node. If you get NaN or Null as outputs, you can find more details [here](https://dynamobim.org/introducing-the-curve-mapper-node-in-dynamo/#CurveMapper_Known_Issues) on why you might be seeing this.
 
 For example, to redistribute 80 points along a sine curve within the range of 0 to 20, set Min to 0, Max to 20, and Values to 80. After selecting the sine curve and adjusting its shape as needed, the `Curve Mapper` node outputs 80 points with x-coordinates that follow the sine curve pattern along the y-axis.
 
-To map unevenly distributed values along a Gaussian curve, set the minimum and maximum range and provide the series of values. After selecting the Gaussian curve and adjusting its shape as needed, the `Curve Mapper` node redistributes the series of values along x-coordinates using the specified range and maps the values along the curve pattern. For in-depth documentation on how the node works and how to set inputs, check out this blog post focusing on the Curve Mapper.
+To map unevenly distributed values along a Gaussian curve, set the minimum and maximum range and provide the series of values. After selecting the Gaussian curve and adjusting its shape as needed, the `Curve Mapper` node redistributes the series of values along x-coordinates using the specified range and maps the values along the curve pattern. For in-depth documentation on how the node works and how to set inputs, check out [this blog post](https://dynamobim.org/introducing-the-curve-mapper-node-in-dynamo) focusing on the Curve Mapper.
 
 
 

--- a/doc/distrib/NodeHelpFiles/en-US/GV5KUSHDGL7YVBZAR4HEGY5NIXFIG3XTV6ZQPHC5MWWGEVOSRJ4Q.md
+++ b/doc/distrib/NodeHelpFiles/en-US/GV5KUSHDGL7YVBZAR4HEGY5NIXFIG3XTV6ZQPHC5MWWGEVOSRJ4Q.md
@@ -5,11 +5,11 @@ Define the limits for the x-coordinates by setting the minimum and maximum value
 
 Select a mathematical curve from the provided options, which includes Linear, Sine, Cosine, Perlin Noise, Bezier, Gaussian, Parabolic, Square Root, and Power curves. Use interactive control points to adjust the shape of the selected curve, tailoring it to your specific needs.
 
-You can lock the curve shape using the lock button, preventing further modifications to the curve. Additionally, you can reset the shape to its default state by using the reset button inside the node. If you get NaN or Null as outputs, you can find more details here on why you might be seeing this
+You can lock the curve shape using the lock button, preventing further modifications to the curve. Additionally, you can reset the shape to its default state by using the reset button inside the node. If you get NaN or Null as outputs, you can find more details here on why you might be seeing this.
 
 For example, to redistribute 80 points along a sine curve within the range of 0 to 20, set Min to 0, Max to 20, and Values to 80. After selecting the sine curve and adjusting its shape as needed, the `Curve Mapper` node outputs 80 points with x-coordinates that follow the sine curve pattern along the y-axis.
 
-To map unevenly distributed values along a Gaussian curve, set the minimum and maximum range and provide the series of values. After selecting the Gaussian curve and adjusting its shape as needed, the `Curve Mapper` node redistributes the series of values along x-coordinates using the specified range and maps the values along the curve pattern. For in-depth documentation on how the node works and how to set inputs, check out this blog post focusing on the Curve Mapper
+To map unevenly distributed values along a Gaussian curve, set the minimum and maximum range and provide the series of values. After selecting the Gaussian curve and adjusting its shape as needed, the `Curve Mapper` node redistributes the series of values along x-coordinates using the specified range and maps the values along the curve pattern. For in-depth documentation on how the node works and how to set inputs, check out this blog post focusing on the Curve Mapper.
 
 
 

--- a/doc/distrib/NodeHelpFiles/en-US/GV5KUSHDGL7YVBZAR4HEGY5NIXFIG3XTV6ZQPHC5MWWGEVOSRJ4Q.md
+++ b/doc/distrib/NodeHelpFiles/en-US/GV5KUSHDGL7YVBZAR4HEGY5NIXFIG3XTV6ZQPHC5MWWGEVOSRJ4Q.md
@@ -5,11 +5,11 @@ Define the limits for the x-coordinates by setting the minimum and maximum value
 
 Select a mathematical curve from the provided options, which includes Linear, Sine, Cosine, Perlin Noise, Bezier, Gaussian, Parabolic, Square Root, and Power curves. Use interactive control points to adjust the shape of the selected curve, tailoring it to your specific needs.
 
-You can lock the curve shape using the lock button, preventing further modifications to the curve. Additionally, you can reset the shape to its default state by using the reset button inside the node.
+You can lock the curve shape using the lock button, preventing further modifications to the curve. Additionally, you can reset the shape to its default state by using the reset button inside the node. If you get NaN or Null as outputs, you can find more details here on why you might be seeing this
 
 For example, to redistribute 80 points along a sine curve within the range of 0 to 20, set Min to 0, Max to 20, and Values to 80. After selecting the sine curve and adjusting its shape as needed, the `Curve Mapper` node outputs 80 points with x-coordinates that follow the sine curve pattern along the y-axis.
 
-To map unevenly distributed values along a Gaussian curve, set the minimum and maximum range and provide the series of values. After selecting the Gaussian curve and adjusting its shape as needed, the `Curve Mapper` node redistributes the series of values along x-coordinates using the specified range and maps the values along the curve pattern.
+To map unevenly distributed values along a Gaussian curve, set the minimum and maximum range and provide the series of values. After selecting the Gaussian curve and adjusting its shape as needed, the `Curve Mapper` node redistributes the series of values along x-coordinates using the specified range and maps the values along the curve pattern. For in-depth documentation on how the node works and how to set inputs, check out this blog post focusing on the Curve Mapper
 
 
 

--- a/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
+++ b/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
@@ -449,8 +449,6 @@ namespace CoreNodeModels
             }
             if (!IsValidCurve())
             {
-                Warning(Properties.Resources.CurveMapperWarningMessage, isPersistent: true);
-
                 RenderValuesX = RenderValuesY = null;
                 OnNodeModified();
                 return;
@@ -828,15 +826,6 @@ namespace CoreNodeModels
             foreach (var propertyName in new[] { nameof(MinLimitX), nameof(MaxLimitX), nameof(MinLimitY), nameof(MaxLimitY), nameof(PointsCount) })
             {
                 RaisePropertyChanged(propertyName);
-            }
-
-            if (!IsValidInput())
-            {
-                Warning(Properties.Resources.CurveMapperWarningMessage, isPersistent: true);
-            }
-            else
-            {
-                this.ClearErrorsAndWarnings();
             }
         }
 

--- a/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
+++ b/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
@@ -834,6 +834,10 @@ namespace CoreNodeModels
             {
                 Warning(Properties.Resources.CurveMapperWarningMessage, isPersistent: true);
             }
+            else
+            {
+                this.ClearErrorsAndWarnings();
+            }
         }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)


### PR DESCRIPTION
### Purpose

To fix this case: https://jira.autodesk.com/browse/DYN-8648

Remove the warning/error message on the CurveMapper node
We are removing the errors/warnings related to the input checks on the CurveMapper node for the 3.5 release. We will polish this workflow and introduce those warning messages back in the next release.

PS: After using ClearErrorsAndWarnings API, when the input port which has a invalid inpassed is replaced with a valid input, the curvemapper node is going into a hand state. This doesn't happen when the first invalid input connection is disconnected and then the valid input is connected in 2 steps. Only happening when the connector is replaced in one step. Will be adding this as part of our improvement task

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
DYN-8648: Remove warnings thrown from inside the CurveMapper NodeModel 

### Reviewers
@zeusongit @achintyabhat 

