### PR TITLE
DYN-8606 : make dna api obsolete

### DIFF
--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -25,6 +25,7 @@ namespace Dynamo.UI.Controls
     /// Notice this control shares a lot of logic with InCanvasSearchControl for now
     /// But they will diverge eventually because of UI improvements to auto complete.
     /// </summary>
+    [Obsolete("This class will be removed in a future version of Dynamo")]
     public partial class NodeAutoCompleteSearchControl : IDisposable
     {
         ListBoxItem HighlightedItem;
@@ -38,8 +39,10 @@ namespace Dynamo.UI.Controls
         /// <summary>
         /// Node AutoComplete Search ViewModel DataContext
         /// </summary>
+        [Obsolete("This method will be removed in a future version of Dynamo")]
         public NodeAutoCompleteSearchViewModel ViewModel => DataContext as NodeAutoCompleteSearchViewModel;
 
+        [Obsolete("This method will be removed in a future version of Dynamo")]
         public NodeAutoCompleteSearchControl()
         {
             InitializeComponent();
@@ -431,6 +434,7 @@ namespace Dynamo.UI.Controls
         /// <summary>
         /// Dispose the control
         /// </summary>
+        [Obsolete("This method will be removed in a future version of Dynamo")]
         public void Dispose()
         {
             NodeAutoCompleteSearchControl_Unloaded(this,null);

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -34,6 +34,7 @@ namespace Dynamo.ViewModels
     /// <summary>
     /// Search View Model for Node AutoComplete Search Bar
     /// </summary>
+    [Obsolete("This class will be removed in a future version of Dynamo")]
     public class NodeAutoCompleteSearchViewModel : SearchViewModel
     {
         internal PortViewModel PortViewModel { get; set; }
@@ -69,6 +70,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// For checking if the ML method is selected
         /// </summary>
+        [Obsolete("This method will be removed in a future version of Dynamo")]
         public bool IsDisplayingMLRecommendation
         {
             get
@@ -80,6 +82,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// If MLAutocompleteTOU is approved
         /// </summary>
+        [Obsolete("This method will be removed in a future version of Dynamo")]
         public bool IsMLAutocompleteTOUApproved
         {
             get
@@ -91,6 +94,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// If true, autocomplete method options are hidden from UI 
         /// </summary>
+        [Obsolete("This method will be removed in a future version of Dynamo")]
         public bool HideAutocompleteMethodOptions
         {
             get
@@ -102,6 +106,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// The No Recommendations or Low Confidence Title
         /// </summary>
+        [Obsolete("This method will be removed in a future version of Dynamo")]
         public string AutocompleteMLTitle
         {
             get { return autocompleteMLTitle; }
@@ -115,6 +120,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// The No Recommendations or Low Confidence message
         /// </summary>
+        [Obsolete("This method will be removed in a future version of Dynamo")]
         public string AutocompleteMLMessage
         {
             get { return autocompleteMLMessage; }
@@ -128,6 +134,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Indicates the No recommendations / Low confidence message should be displayed (image and texts)
         /// </summary>
+        [Obsolete("This method will be removed in a future version of Dynamo")]
         public bool DisplayAutocompleteMLStaticPage
         {
             get { return displayAutocompleteMLStaticPage; }
@@ -141,6 +148,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Indicates if display the Low confidence option and Tooltip
         /// </summary>
+        [Obsolete("This method will be removed in a future version of Dynamo")]
         public bool DisplayLowConfidence
         {
             get { return displayLowConfidence; }
@@ -906,6 +914,7 @@ namespace Dynamo.ViewModels
                 this.core = core;
             }
 
+            [Obsolete("This method will be removed in a future version of Dynamo")]
             public int Compare(NodeSearchElement x, NodeSearchElement y)
             {
                 return CompareNodeSearchElementByTypeDistance(x, y, typeNameToCompareTo, core);

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -4,14 +4,11 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Threading;
 using Dynamo.Configuration;
-using Dynamo.Controls;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
 using Dynamo.Search.SearchElements;
-using Dynamo.Selection;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Utilities;
@@ -249,6 +246,7 @@ namespace Dynamo.Wpf.ViewModels
         /// <summary>
         /// Create the search element as node and connect to target port
         /// </summary>
+        [Obsolete("This command will be removed in a future version of Dynamo")]
         public ICommand CreateAndConnectCommand { get; }
 
         /// <summary>

--- a/src/NodeAutoCompleteViewExtension/NodeAutoCompleteViewExtension.cs
+++ b/src/NodeAutoCompleteViewExtension/NodeAutoCompleteViewExtension.cs
@@ -80,7 +80,7 @@ namespace Dynamo.NodeAutoComplete
 
         public override void Shutdown()
         {
-            // Do nothing for now
+            WorkspaceView.RequesNodeAutoCompleteBar -= OnNodeAutoCompleteBarRequested;
         }
 
         public override void Startup(ViewStartupParams viewStartupParams)
@@ -145,14 +145,13 @@ namespace Dynamo.NodeAutoComplete
             WorkspaceView.RequesNodeAutoCompleteBar += OnNodeAutoCompleteBarRequested;
 
         }
+
         public override void Closed()
         {
             if (this.nodeAutocompleteMenuItem != null)
             {
                 this.nodeAutocompleteMenuItem.IsChecked = false;
             }
-
-            WorkspaceView.RequesNodeAutoCompleteBar -= OnNodeAutoCompleteBarRequested;
         }
 
         internal void ShowClusterNodeAutocompleteResults(MLNodeClusterAutoCompletionResponse results)


### PR DESCRIPTION
### Purpose
Declare existing NodeAutoComplete api obsolete.
We are moving NodeAutoComplete feature to it's own extension. 
Existing apis were created mostly due to technical limitations and we don't see a good reason to keep them.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Reviewers
@DynamoDS/synapse 

