### PR TITLE
DYN-9999 : fix cluster in Revit context

### DIFF
--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -478,7 +478,7 @@ namespace DynamoUtilities
             string url = null;
             if (o != null)
             {
-                var path = o.GetType().Assembly.Location;
+                var path = o is Assembly ? (o as Assembly).Location : o.GetType().Assembly.Location;
                 var config = ConfigurationManager.OpenExeConfiguration(path);
                 var key = config.AppSettings.Settings[serviceKey];
 

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -31,6 +31,7 @@ using ProtoCore.Utils;
 using RestSharp;
 using Dynamo.Wpf.Utilities;
 using Dynamo.ViewModels;
+using System.Reflection;
 
 namespace Dynamo.NodeAutoComplete.ViewModels
 {
@@ -48,6 +49,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
         private const string nodeAutocompleteMLEndpoint = "MLNodeAutocomplete";
         private const string nodeClusterAutocompleteMLEndpoint = "MLNodeClusterAutocomplete";
         private const double minClusterConfidenceScore = 0.1;
+        private static Assembly dynamoCoreWpfAssembly;
 
         // Lucene search utility to perform indexing operations just for NodeAutocomplete.
         internal LuceneSearchUtility LuceneUtility
@@ -630,7 +632,15 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                 {
                     try
                     {
-                        var uri = DynamoUtilities.PathHelper.GetServiceBackendAddress(dynamoViewModel, nodeClusterAutocompleteMLEndpoint);
+                        if (dynamoCoreWpfAssembly is null)
+                        {
+                            dynamoCoreWpfAssembly = AppDomain.CurrentDomain
+                                .GetAssemblies()
+                                .FirstOrDefault(a => a.GetName().Name.Equals("DynamoCoreWPF", StringComparison.OrdinalIgnoreCase));
+                        }
+
+
+                        var uri = DynamoUtilities.PathHelper.GetServiceBackendAddress(dynamoCoreWpfAssembly, nodeClusterAutocompleteMLEndpoint);
                         var client = new RestClient(uri);
                         var request = new RestRequest(string.Empty, Method.Post);
                         var tkn = tokenprovider?.GetAccessToken();


### PR DESCRIPTION
### Purpose
We need to extract config from DynamoCoreWPF.config ; not a new issue.
All good otherwise in both Revit context.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Reviewers
@DynamoDS/synapse 
