### PR TITLE
unify import libs in CLI/WPFCLI

### DIFF
--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -187,29 +187,36 @@ namespace Dynamo.Applications
         }
 
         /// <summary>
-        /// Attempts to import an assembly as a node library from a given file path.
+        /// Attempts to import node libraries from assemblies located at the given list of importedPaths.
         /// </summary>
         /// <param name="model"></param>
-        /// <param name="path"></param>
-        internal static void ImportAssembly(DynamoModel model, string path)
+        /// <param name="importedPaths"></param>
+        internal static void ImportAssemblies(DynamoModel model, IEnumerable<string> importedPaths)
         {
-            try
+            if (importedPaths != null)
             {
-                var filePath = new System.IO.FileInfo(path);
-                if (!filePath.Exists)
+                importedPaths.ToList().ForEach(path =>
                 {
-                    Console.WriteLine($"could not find requested import library at path{path}");
-                }
-                else
-                {
-                    Console.WriteLine($"attempting to import assembly {path}");
-                    var assembly = System.Reflection.Assembly.LoadFile(path);
-                    model.LoadNodeLibrary(assembly, true);
-                }
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine($"exception while trying to load assembly {path}: {e}");
+                    try
+                    {
+
+                        var filePath = new System.IO.FileInfo(path);
+                        if (!filePath.Exists)
+                        {
+                            Console.WriteLine($"could not find requested import library at path{path}");
+                        }
+                        else
+                        {
+                            Console.WriteLine($"attempting to import assembly {path}");
+                            var assembly = Assembly.LoadFile(path);
+                            model.LoadNodeLibrary(assembly, true);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine($"exception while trying to load assembly {path}: {e}");
+                    }
+                });
             }
         }
 
@@ -221,8 +228,7 @@ namespace Dynamo.Applications
             bool cliMode = true,
             string userDataFolder = "",
             string commonDataFolder = "",
-            bool serviceMode = false,
-            IEnumerable<string> importedPaths = null)
+            bool serviceMode = false)
         {
             var normalizedCLILocale = string.IsNullOrEmpty(cliLocale) ? null : cliLocale;
             IPathResolver pathResolver = CreatePathResolver(false, string.Empty, string.Empty, string.Empty);
@@ -246,14 +252,6 @@ namespace Dynamo.Applications
             );
             model.IsASMLoaded = isASMloaded;
 
-            if (importedPaths != null)
-            {
-                importedPaths.ToList().ForEach(path =>
-                {
-                    ImportAssembly(model, path);
-                });
-            }
-
             return model;
         }
 
@@ -272,8 +270,9 @@ namespace Dynamo.Applications
                 analyticsInfo: cmdLineArgs.AnalyticsInfo,
                 userDataFolder: cmdLineArgs.UserDataFolder,
                 commonDataFolder: cmdLineArgs.CommonDataFolder,
-                serviceMode: cmdLineArgs.ServiceMode,
-                importedPaths: cmdLineArgs.ImportedPaths);
+                serviceMode: cmdLineArgs.ServiceMode);
+
+            ImportAssemblies(model, cmdLineArgs.ImportedPaths);
             return model;
         }
 

--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -186,6 +186,33 @@ namespace Dynamo.Applications
             return model;
         }
 
+        /// <summary>
+        /// Attempts to import an assembly as a node library from a given file path.
+        /// </summary>
+        /// <param name="model"></param>
+        /// <param name="path"></param>
+        internal static void ImportAssembly(DynamoModel model, string path)
+        {
+            try
+            {
+                var filePath = new System.IO.FileInfo(path);
+                if (!filePath.Exists)
+                {
+                    Console.WriteLine($"could not find requested import library at path{path}");
+                }
+                else
+                {
+                    Console.WriteLine($"attempting to import assembly {path}");
+                    var assembly = System.Reflection.Assembly.LoadFile(path);
+                    model.LoadNodeLibrary(assembly, true);
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"exception while trying to load assembly {path}: {e}");
+            }
+        }
+
         private static DynamoModel PrepareModel(
             string cliLocale,
             string asmPath,
@@ -194,7 +221,8 @@ namespace Dynamo.Applications
             bool cliMode = true,
             string userDataFolder = "",
             string commonDataFolder = "",
-            bool serviceMode = false)
+            bool serviceMode = false,
+            IEnumerable<string> importedPaths = null)
         {
             var normalizedCLILocale = string.IsNullOrEmpty(cliLocale) ? null : cliLocale;
             IPathResolver pathResolver = CreatePathResolver(false, string.Empty, string.Empty, string.Empty);
@@ -217,6 +245,15 @@ namespace Dynamo.Applications
                 cliLocale: normalizedCLILocale
             );
             model.IsASMLoaded = isASMloaded;
+
+            if (importedPaths != null)
+            {
+                importedPaths.ToList().ForEach(path =>
+                {
+                    ImportAssembly(model, path);
+                });
+            }
+
             return model;
         }
 
@@ -235,7 +272,8 @@ namespace Dynamo.Applications
                 analyticsInfo: cmdLineArgs.AnalyticsInfo,
                 userDataFolder: cmdLineArgs.UserDataFolder,
                 commonDataFolder: cmdLineArgs.CommonDataFolder,
-                serviceMode: cmdLineArgs.ServiceMode);
+                serviceMode: cmdLineArgs.ServiceMode,
+                importedPaths: cmdLineArgs.ImportedPaths);
             return model;
         }
 

--- a/src/DynamoCLI/CommandLineRunner.cs
+++ b/src/DynamoCLI/CommandLineRunner.cs
@@ -48,10 +48,7 @@ namespace DynamoCLI
 
             DynamoModel.HostAnalyticsInfo = cmdLineArgs.AnalyticsInfo;
 
-            cmdLineArgs.ImportedPaths.ToList().ForEach(path =>
-            {
-                ImportAssembly(model, path);
-            });
+            StartupUtils.ImportAssemblies(model, cmdLineArgs.ImportedPaths);
 
             model.OpenFileFromPath(cmdLineArgs.OpenFilePath, true);
             Console.WriteLine("loaded file");
@@ -86,33 +83,6 @@ namespace DynamoCLI
             }
 
             return doc;
-        }
-
-        /// <summary>
-        /// Attempts to import an assembly as a node library from a given file path.
-        /// </summary>
-        /// <param name="model"></param>
-        /// <param name="path"></param>
-        protected internal static void ImportAssembly(DynamoModel model, string path)
-        {
-            try
-            {
-                var filePath = new System.IO.FileInfo(path);
-                if (!filePath.Exists)
-                {
-                    Console.WriteLine($"could not find requested import library at path{path}");
-                }
-                else
-                {
-                    Console.WriteLine($"attempting to import assembly {path}");
-                    var assembly = System.Reflection.Assembly.LoadFile(path);
-                    model.LoadNodeLibrary(assembly, true);
-                }
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine($"exception while trying to load assembly {path}: {e}");
-            }
         }
 
         protected static string GetStringRepOfCollection(ProtoCore.Mirror.MirrorData value)

--- a/src/DynamoCLI/Program.cs
+++ b/src/DynamoCLI/Program.cs
@@ -108,10 +108,7 @@ namespace DynamoCLI
 
             model.ShutdownCompleted += (m) => { ShutDown(); };
 
-            cmdLineArgs.ImportedPaths?.ToList().ForEach(path =>
-            {
-                CommandLineRunner.ImportAssembly(model, path);
-            });
+            StartupUtils.ImportAssemblies(model, cmdLineArgs.ImportedPaths);
 
             return model;
         }

--- a/src/DynamoWPFCLI/Program.cs
+++ b/src/DynamoWPFCLI/Program.cs
@@ -110,10 +110,7 @@ namespace DynamoWPFCLI
                     }
                 });
 
-            cmdLineArgs.ImportedPaths.ToList().ForEach(path =>
-            {
-                StartupUtils.ImportAssembly(model, path);
-            });
+            StartupUtils.ImportAssemblies(model, cmdLineArgs.ImportedPaths);
 
             return viewModel;
         }

--- a/src/DynamoWPFCLI/Program.cs
+++ b/src/DynamoWPFCLI/Program.cs
@@ -112,7 +112,7 @@ namespace DynamoWPFCLI
 
             cmdLineArgs.ImportedPaths.ToList().ForEach(path =>
             {
-                ImportAssembly(model, path);
+                StartupUtils.ImportAssembly(model, path);
             });
 
             return viewModel;
@@ -136,33 +136,6 @@ namespace DynamoWPFCLI
             catch
             {
                 Console.WriteLine("Server is shutting down due to an error");
-            }
-        }
-
-        /// <summary>
-        /// Attempts to import an assembly as a node library from a given file path.
-        /// </summary>
-        /// <param name="model"></param>
-        /// <param name="path"></param>
-        private static void ImportAssembly(DynamoModel model, string path)
-        {
-            try
-            {
-                var filePath = new System.IO.FileInfo(path);
-                if (!filePath.Exists)
-                {
-                    Console.WriteLine($"could not find requested import library at path{path}");
-                }
-                else
-                {
-                    Console.WriteLine($"attempting to import assembly {path}");
-                    var assembly = System.Reflection.Assembly.LoadFile(path);
-                    model.LoadNodeLibrary(assembly, true);
-                }
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine($"exception while trying to load assembly {path}: {e}");
             }
         }
 


### PR DESCRIPTION
### Purpose

Add import libs to the `MakeCLIModel(CommandLineArguments cmdLineArgs)` API

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
