### PR TITLE
[DYN-5722] Use default style for render precision slider.

### DIFF
--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -1352,6 +1352,7 @@
                                         <Slider Width="100"
                                             Minimum="8"
                                             Maximum="512"
+                                            Style="{StaticResource SliderStyle}"
                                             Value="{Binding Path=TessellationDivisions, Mode=TwoWay}">
                                         </Slider>
                                         <TextBlock Text="{x:Static p:Resources.DynamoViewSettingMenuHighRenderPrecision}"


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-5722

Use default style for render precision slider.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
[DYN-5722] Use default style for render precision slider.

### Reviewers
@DynamoDS/eidos  
