### PR TITLE
[DYN-8596] Curve Mapper : Generate warnings

### DIFF
--- a/doc/distrib/xml/en-US/DSCoreNodes.xml
+++ b/doc/distrib/xml/en-US/DSCoreNodes.xml
@@ -2185,6 +2185,26 @@
               Looks up a localized string similar to The supplied color data is too large to fit in the image bounds..
             </summary>
         </member>
+        <member name="P:DSCore.Properties.Resources.CurveMapperEqualMinMaxWarning">
+            <summary>
+              Looks up a localized string similar to • Min and Max values must not be the same..
+            </summary>
+        </member>
+        <member name="P:DSCore.Properties.Resources.CurveMapperInvalidCountWarning">
+            <summary>
+              Looks up a localized string similar to • Values must be a list of numbers or a single number ≥ 2..
+            </summary>
+        </member>
+        <member name="P:DSCore.Properties.Resources.CurveMapperInvalidCurveWarning">
+            <summary>
+              Looks up a localized string similar to • Control points for the selected curve are not valid..
+            </summary>
+        </member>
+        <member name="P:DSCore.Properties.Resources.CurveMapperInvalidXYFormatWarning">
+            <summary>
+              Looks up a localized string similar to • X and Y inputs must be single numbers (not lists)..
+            </summary>
+        </member>
         <member name="P:DSCore.Properties.Resources.DefineDataSupportedInputValueExceptionMessage">
             <summary>
               Looks up a localized string similar to Input must be a single value or a non-nested list..

--- a/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
+++ b/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
@@ -894,14 +894,14 @@ namespace CoreNodeModels
 
             AssociativeNode buildResultNodeX =
                 AstFactory.BuildFunctionCall(
-                    new Func<List<double>, double, object, object, object, object, object, string, List<double>>(
+                    new Func<List<double>, double, object, object, object, object, List<double>, string, List<double>>(
                         CurveMapperGenerator.CalculateValuesX),
                     curveInputs
                 );
 
             AssociativeNode buildResultNodeY =
                 AstFactory.BuildFunctionCall(
-                    new Func<List<double>, double, object, object, object, object, object, string, List<double>>(
+                    new Func<List<double>, double, object, object, object, object, List<double>, string, List<double>>(
                         CurveMapperGenerator.CalculateValuesY),
                     curveInputs
                 );

--- a/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
+++ b/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
@@ -441,15 +441,10 @@ namespace CoreNodeModels
         /// </summary>
         public void GenerateRenderValues()
         {
-            if (SelectedGraphType == GraphTypes.Empty)
+            if (SelectedGraphType == GraphTypes.Empty || !IsValidCurve())
             {
                 RenderValuesX = RenderValuesY = null;
-                OnNodeModified();
-                return;
-            }
-            if (!IsValidCurve())
-            {
-                RenderValuesX = RenderValuesY = null;
+                // Trigger an update to force the node to output nulls and display a warning bubble
                 OnNodeModified();
                 return;
             }
@@ -680,20 +675,6 @@ namespace CoreNodeModels
 
         #region Private Methods
 
-        private bool IsValidInput()
-        {
-            if (pointsCount == null || pointsCount.Count == 0)
-                return false;
-
-            if (pointsCount.Count == 1 && pointsCount.FirstOrDefault() < 2)
-                return false;
-
-            if (MinLimitX == MaxLimitX || MinLimitY == MaxLimitY)
-                return false;
-
-            return true;
-        }
-
         private bool IsValidCurve()
         {
             // Dictionary mapping graph types to control point validation logic
@@ -832,7 +813,7 @@ namespace CoreNodeModels
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
             // If input is missing or invalid, return nulls
-            if (inputAstNodes == null || inputAstNodes.Count < 5 || SelectedGraphType == GraphTypes.Empty || !IsValidCurve())
+            if (inputAstNodes == null || inputAstNodes.Count < 5 || SelectedGraphType == GraphTypes.Empty)
             {
                 return new[]
                 {
@@ -913,14 +894,14 @@ namespace CoreNodeModels
 
             AssociativeNode buildResultNodeX =
                 AstFactory.BuildFunctionCall(
-                    new Func<List<double>, double, object, object, object, object, List<double>, string, List<double>>(
+                    new Func<List<double>, double, object, object, object, object, object, string, List<double>>(
                         CurveMapperGenerator.CalculateValuesX),
                     curveInputs
                 );
 
             AssociativeNode buildResultNodeY =
                 AstFactory.BuildFunctionCall(
-                    new Func<List<double>, double, object, object, object, object, List<double>, string, List<double>>(
+                    new Func<List<double>, double, object, object, object, object, object, string, List<double>>(
                         CurveMapperGenerator.CalculateValuesY),
                     curveInputs
                 );

--- a/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
+++ b/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
@@ -894,15 +894,15 @@ namespace CoreNodeModels
 
             AssociativeNode buildResultNodeX =
                 AstFactory.BuildFunctionCall(
-                    new Func<List<double>, double, object, object, object, object, List<double>, string, List<double>>(
-                        CurveMapperGenerator.CalculateValuesX),
+                    new Func<List<double>, double, object, object, object, object, object, string, List<double>>(
+                        CurveMapperGenerator.CalculateValuesForX),
                     curveInputs
                 );
 
             AssociativeNode buildResultNodeY =
                 AstFactory.BuildFunctionCall(
-                    new Func<List<double>, double, object, object, object, object, List<double>, string, List<double>>(
-                        CurveMapperGenerator.CalculateValuesY),
+                    new Func<List<double>, double, object, object, object, object, object, string, List<double>>(
+                        CurveMapperGenerator.CalculateValuesForY),
                     curveInputs
                 );
 

--- a/src/Libraries/CoreNodes/CurveMapper/BezierCurve.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/BezierCurve.cs
@@ -1,3 +1,4 @@
+using Autodesk.DesignScript.Runtime;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,6 +8,8 @@ namespace DSCore.CurveMapper
     /// Represents a Bezier curve in the CurveMapper.
     /// A Bezier curve is defined by four control points and provides smooth interpolation.
     /// </summary>
+    
+    [IsVisibleInDynamoLibrary(false)]
     public class BezierCurve : CurveBase
     {
         private double ControlPoint1X;

--- a/src/Libraries/CoreNodes/CurveMapper/ControlLine.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/ControlLine.cs
@@ -1,3 +1,4 @@
+using Autodesk.DesignScript.Runtime;
 using System.Collections.Generic;
 
 namespace DSCore.CurveMapper
@@ -6,6 +7,8 @@ namespace DSCore.CurveMapper
     /// Represents a control line in the CurveMapper.
     /// This is used for auxiliary control of other curves, particularly Bezier curves.
     /// </summary>
+
+    [IsVisibleInDynamoLibrary(false)]
     public class ControlLine : CurveBase
     {
         private double ControlPoint1X;

--- a/src/Libraries/CoreNodes/CurveMapper/CurveBase.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/CurveBase.cs
@@ -1,3 +1,4 @@
+using Autodesk.DesignScript.Runtime;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +9,8 @@ namespace DSCore.CurveMapper
     /// Represents a base class for all curve types in the CurveMapper.
     /// Provides common functionality for generating and retrieving curve values.
     /// </summary>
+    
+    [IsVisibleInDynamoLibrary(false)]
     public abstract class CurveBase
     {
         protected double CanvasSize;

--- a/src/Libraries/CoreNodes/CurveMapper/CurveMapperGenerator.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/CurveMapperGenerator.cs
@@ -158,6 +158,7 @@ namespace DSCore.CurveMapper
             return mappedValues;
         }
 
+        [Obsolete("Use CalculateValuesForX with object pointsCount instead.")]
         public static List<double> CalculateValuesX(
             List<double> controlPoints,
             double canvasSize,
@@ -169,15 +170,13 @@ namespace DSCore.CurveMapper
             string graphType
             )
         {
-            return PrivateCalculateValuesX(
-                controlPoints, canvasSize,
-                minX, maxX, minY, maxY,
-                (object)pointsCount,
-                graphType);
+            // X values must always be calculated first to initialize the cache.
+            // CalculateValuesY() depends on this to avoid redundant calculation.
+            cachedValues = CalculateValues(controlPoints, canvasSize, minX, maxX, minY, maxY, pointsCount, graphType);
+            return cachedValues?[0];
         }
 
-        
-
+        [Obsolete("Use CalculateValuesForY with object pointsCount instead.")]
         public static List<double> CalculateValuesY(
             List<double> controlPoints,
             double canvasSize,
@@ -189,39 +188,40 @@ namespace DSCore.CurveMapper
             string graphType
             )
         {
-            return PrivateCalculateValuesY(
-                controlPoints, canvasSize,
-                minX, maxX, minY, maxY,
-                (object)pointsCount,
-                graphType);
+            if (cachedValues == null)
+            {
+                cachedValues = CalculateValues(controlPoints, canvasSize, minX, maxX, minY, maxY, pointsCount, graphType);
+            }
+            return cachedValues?[1];
         }
 
-        // Preserve original API signature by wrapping to internal object-based version
-        // This allows handling of both scalars and lists while avoiding replication
-        private static List<double> PrivateCalculateValuesX(
+        public static List<double> CalculateValuesForX(
             List<double> controlPoints,
             double canvasSize,
-            object minX,
-            object maxX,
-            object minY,
-            object maxY,
-            object pointsCount,
-            string graphType)
+            [ArbitraryDimensionArrayImport] object minX,
+            [ArbitraryDimensionArrayImport] object maxX,
+            [ArbitraryDimensionArrayImport] object minY,
+            [ArbitraryDimensionArrayImport] object maxY,
+            [ArbitraryDimensionArrayImport] object pointsCount,
+            string graphType
+            )
         {
             // X values must always be calculated first to initialize the cache.
             // CalculateValuesY() depends on this to avoid redundant calculation.
             cachedValues = CalculateValues(controlPoints, canvasSize, minX, maxX, minY, maxY, pointsCount, graphType);
             return cachedValues?[0];
         }
-        private static List<double> PrivateCalculateValuesY(
+
+        public static List<double> CalculateValuesForY(
             List<double> controlPoints,
             double canvasSize,
-            object minX,
-            object maxX,
-            object minY,
-            object maxY,
-            object pointsCount,
-            string graphType)
+            [ArbitraryDimensionArrayImport] object minX,
+            [ArbitraryDimensionArrayImport] object maxX,
+            [ArbitraryDimensionArrayImport] object minY,
+            [ArbitraryDimensionArrayImport] object maxY,
+            [ArbitraryDimensionArrayImport] object pointsCount,
+            string graphType
+            )
         {
             if (cachedValues == null)
             {
@@ -229,5 +229,7 @@ namespace DSCore.CurveMapper
             }
             return cachedValues?[1];
         }
+
+
     }
 }

--- a/src/Libraries/CoreNodes/CurveMapper/CurveMapperGenerator.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/CurveMapperGenerator.cs
@@ -1,8 +1,7 @@
+using Autodesk.DesignScript.Runtime;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using Autodesk.DesignScript.Runtime;
 
 namespace DSCore.CurveMapper
 {
@@ -21,79 +20,125 @@ namespace DSCore.CurveMapper
             [ArbitraryDimensionArrayImport] object maxX,
             [ArbitraryDimensionArrayImport] object minY,
             [ArbitraryDimensionArrayImport] object maxY,
-            List<double> pointsCount,
+            [ArbitraryDimensionArrayImport] object pointsCount,
             string graphType
             )
         {
-            var xValues = new List<double>() { double.NaN };
-            var yValues = new List<double>() { double.NaN };
-
-            // Block input replication and force user to supply scalar values
-            if (
-                minX is IEnumerable ||
-                maxX is IEnumerable ||
-                minY is IEnumerable ||
-                maxY is IEnumerable)
-            {
-                // Ensure nulls so node returns [null, null]
-                cachedValues[0] = null;
-                cachedValues[1] = null;
-
-                throw new ArgumentException("Expects argument type(s): double");
-            }
-
-            // Safety checks
-            // TODO: There are similar checks in CurveMapperNodeModel.
-            // Review and see if they can be removed.
-            if (pointsCount == null || pointsCount.Count == 0 || (pointsCount.Count == 1 && pointsCount[0] < 2))
-                return new List<List<double>> { yValues, xValues };
-
-            if (minX == maxX || minY == maxX)
-                return new List<List<double>> { yValues, xValues };
-            
             // Unpack the control points
             double cp1x = GetCP(controlPoints, 0), cp1y = GetCP(controlPoints, 1);
             double cp2x = GetCP(controlPoints, 2), cp2y = GetCP(controlPoints, 3);
             double cp3x = GetCP(controlPoints, 4), cp3y = GetCP(controlPoints, 5);
             double cp4x = GetCP(controlPoints, 6), cp4y = GetCP(controlPoints, 7);
 
-            object curve = null;
+            //      Validation
+            var errors = new List<string>();
 
-            switch (graphType)
+            // Check if min/max are equal (invalid range)
+            bool isMinMaxEqual = false;
+            try
             {
-                case "LinearCurve":
-                    curve = new LinearCurve(cp1x, cp1y, cp2x, cp2y, canvasSize);
-                    break;
-                case "BezierCurve":
-                    curve = new BezierCurve(cp1x, cp1y, cp2x, cp2y, cp3x, cp3y, cp4x, cp4y, canvasSize);
-                    break;
-                case "SineWave":
-                    curve = new SineWave(cp1x, cp1y, cp2x, cp2y, canvasSize);
-                    break;
-                case "CosineWave":
-                    curve = new SineWave(cp1x, cp1y, cp2x, cp2y, canvasSize);
-                    break;
-                case "ParabolicCurve":
-                    curve = new ParabolicCurve(cp1x, cp1y, cp2x, cp2y, canvasSize);
-                    break;
-                case "PerlinNoiseCurve":
-                    curve = new PerlinNoiseCurve(cp1x, cp1y, cp2x, cp2y, cp3x, cp3y, canvasSize);
-                    break;
-                case "PowerCurve":
-                    curve = new PowerCurve(cp1x, cp1y, canvasSize);
-                    break;
-                case "SquareRootCurve":
-                    curve = new SquareRootCurve(cp1x, cp1y, cp2x, cp2y, canvasSize);
-                    break;
-                case "GaussianCurve":
-                    curve = new GaussianCurve(cp1x, cp1y, cp2x, cp2y, cp3x, cp3y, cp4x, cp4y, canvasSize);
-                    break;
+                double minXVal = Convert.ToDouble(minX);
+                double maxXVal = Convert.ToDouble(maxX);
+                isMinMaxEqual = Math.Abs(minXVal - maxXVal) < 1e-9;
             }
+            catch { }
+
+            try
+            {
+                if (!isMinMaxEqual)
+                {
+                    double minYVal = Convert.ToDouble(minY);
+                    double maxYVal = Convert.ToDouble(maxY);
+                    isMinMaxEqual = Math.Abs(minYVal - maxYVal) < 1e-9;
+                }
+            }
+            catch { }
+
+            if (isMinMaxEqual)
+                errors.Add(Properties.Resources.CurveMapperEqualMinMaxWarning);
+
+            // Parse and validate pointsCount
+            var countValue = new List<double>();
+            bool isCountInvalid = false;            
+
+            try
+            {
+                if (pointsCount is IEnumerable enumerable && !(pointsCount is string))
+                {
+                    foreach (var item in enumerable)
+                    {
+                        if (double.TryParse(item?.ToString(), out var val))
+                            countValue.Add(val);
+                    }
+                }
+                else if (double.TryParse(pointsCount?.ToString(), out var singleVal))
+                {
+                    countValue.Add(singleVal);
+                }
+
+                if (countValue.Count == 0 || (countValue.Count == 1 && countValue[0] < 2))
+                    isCountInvalid = true;
+            }
+            catch
+            {
+                isCountInvalid = true;
+            }
+
+            if (isCountInvalid)
+                errors.Add(Properties.Resources.CurveMapperInvalidCountWarning);
+
+            // Ensure X/Y limits are scalar (not lists)
+            bool isXYFormatInvalid = minX is IEnumerable ||
+                maxX is IEnumerable ||
+                minY is IEnumerable ||
+                maxY is IEnumerable;
+
+            if (isXYFormatInvalid)
+                errors.Add(Properties.Resources.CurveMapperInvalidXYFormatWarning);
+
+            // Validate control point values based on curve type
+            bool isCurveInvalid = graphType switch
+            {
+                "LinearCurve" => cp1x == cp2x,
+                "SineWave" => cp1x == cp2x,
+                "CosineWave" => cp1x == cp2x,
+                "ParabolicCurve" => cp1x == cp2x,
+                "PowerCurve" => cp1x <= 0 || cp1y <= 0 || cp1x >= canvasSize || cp1y >= canvasSize,
+                _ => false
+            };
+
+            if (isCurveInvalid)
+                errors.Add(Properties.Resources.CurveMapperInvalidCurveWarning);
+
+            //      Early exit if validation fails
+            if (errors.Count > 0)
+            {
+                cachedValues = new List<List<double>> { null, null };
+                throw new Exception(string.Join("\n", errors));
+            }
+
+            //      Curve Calculation if all check pass
+            object curve = graphType switch
+            {
+                "LinearCurve" => new LinearCurve(cp1x, cp1y, cp2x, cp2y, canvasSize),
+                "BezierCurve" => new BezierCurve(cp1x, cp1y, cp2x, cp2y, cp3x, cp3y, cp4x, cp4y, canvasSize),
+                "SineWave" => new SineWave(cp1x, cp1y, cp2x, cp2y, canvasSize),
+                "CosineWave" => new SineWave(cp1x, cp1y, cp2x, cp2y, canvasSize),
+                "ParabolicCurve" => new ParabolicCurve(cp1x, cp1y, cp2x, cp2y, canvasSize),
+                "PerlinNoiseCurve" => new PerlinNoiseCurve(cp1x, cp1y, cp2x, cp2y, cp3x, cp3y, canvasSize),
+                "PowerCurve" => new PowerCurve(cp1x, cp1y, canvasSize),
+                "SquareRootCurve" => new SquareRootCurve(cp1x, cp1y, cp2x, cp2y, canvasSize),
+                "GaussianCurve" => new GaussianCurve(cp1x, cp1y, cp2x, cp2y, cp3x, cp3y, cp4x, cp4y, canvasSize),
+                _ => null
+            };
+
+            var xValues = new List<double>();
+            var yValues = new List<double>();
 
             if (curve is CurveBase dynamicCurve)
             {
-                xValues = MapValues(dynamicCurve.GetCurveXValues(pointsCount), Convert.ToDouble(minX), Convert.ToDouble(maxX), canvasSize);
-                yValues = MapValues(dynamicCurve.GetCurveYValues(pointsCount), Convert.ToDouble(minY), Convert.ToDouble(maxY), canvasSize);
+                xValues = MapValues(dynamicCurve.GetCurveXValues(countValue), Convert.ToDouble(minX), Convert.ToDouble(maxX), canvasSize);
+                yValues = MapValues(dynamicCurve.GetCurveYValues(countValue), Convert.ToDouble(minY), Convert.ToDouble(maxY), canvasSize);
             }
 
             return new List<List<double>> { yValues, xValues };
@@ -123,7 +168,7 @@ namespace DSCore.CurveMapper
             [ArbitraryDimensionArrayImport] object maxX,
             [ArbitraryDimensionArrayImport] object minY,
             [ArbitraryDimensionArrayImport] object maxY,
-            List<double> pointsCount,
+            [ArbitraryDimensionArrayImport] object pointsCount,
             string graphType
             )
         {
@@ -141,7 +186,7 @@ namespace DSCore.CurveMapper
             [ArbitraryDimensionArrayImport] object maxX,
             [ArbitraryDimensionArrayImport] object minY,
             [ArbitraryDimensionArrayImport] object maxY,
-            List<double> pointsCount,
+            [ArbitraryDimensionArrayImport] object pointsCount,
             string graphType
             )
         {

--- a/src/Libraries/CoreNodes/CurveMapper/CurveMapperGenerator.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/CurveMapperGenerator.cs
@@ -11,10 +11,8 @@ namespace DSCore.CurveMapper
         private static int rounding = 10;
         private static List<List<double>> cachedValues = null;
 
-        [IsVisibleInDynamoLibrary(false)]
         private static List<List<double>> CalculateValues(
-            List<double>
-            controlPoints,
+            List<double> controlPoints,
             double canvasSize,
             [ArbitraryDimensionArrayImport] object minX,
             [ArbitraryDimensionArrayImport] object maxX,
@@ -161,34 +159,69 @@ namespace DSCore.CurveMapper
         }
 
         public static List<double> CalculateValuesX(
-            List<double>
-            controlPoints,
+            List<double> controlPoints,
             double canvasSize,
             [ArbitraryDimensionArrayImport] object minX,
             [ArbitraryDimensionArrayImport] object maxX,
             [ArbitraryDimensionArrayImport] object minY,
             [ArbitraryDimensionArrayImport] object maxY,
-            [ArbitraryDimensionArrayImport] object pointsCount,
+            List<double> pointsCount,
             string graphType
             )
+        {
+            return PrivateCalculateValuesX(
+                controlPoints, canvasSize,
+                minX, maxX, minY, maxY,
+                (object)pointsCount,
+                graphType);
+        }
+
+        
+
+        public static List<double> CalculateValuesY(
+            List<double> controlPoints,
+            double canvasSize,
+            [ArbitraryDimensionArrayImport] object minX,
+            [ArbitraryDimensionArrayImport] object maxX,
+            [ArbitraryDimensionArrayImport] object minY,
+            [ArbitraryDimensionArrayImport] object maxY,
+            List<double> pointsCount,
+            string graphType
+            )
+        {
+            return PrivateCalculateValuesY(
+                controlPoints, canvasSize,
+                minX, maxX, minY, maxY,
+                (object)pointsCount,
+                graphType);
+        }
+
+        // Preserve original API signature by wrapping to internal object-based version
+        // This allows handling of both scalars and lists while avoiding replication
+        private static List<double> PrivateCalculateValuesX(
+            List<double> controlPoints,
+            double canvasSize,
+            object minX,
+            object maxX,
+            object minY,
+            object maxY,
+            object pointsCount,
+            string graphType)
         {
             // X values must always be calculated first to initialize the cache.
             // CalculateValuesY() depends on this to avoid redundant calculation.
             cachedValues = CalculateValues(controlPoints, canvasSize, minX, maxX, minY, maxY, pointsCount, graphType);
             return cachedValues?[0];
         }
-
-        public static List<double> CalculateValuesY(
-            List<double>
-            controlPoints,
+        private static List<double> PrivateCalculateValuesY(
+            List<double> controlPoints,
             double canvasSize,
-            [ArbitraryDimensionArrayImport] object minX,
-            [ArbitraryDimensionArrayImport] object maxX,
-            [ArbitraryDimensionArrayImport] object minY,
-            [ArbitraryDimensionArrayImport] object maxY,
-            [ArbitraryDimensionArrayImport] object pointsCount,
-            string graphType
-            )
+            object minX,
+            object maxX,
+            object minY,
+            object maxY,
+            object pointsCount,
+            string graphType)
         {
             if (cachedValues == null)
             {

--- a/src/Libraries/CoreNodes/CurveMapper/GaussianCurve.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/GaussianCurve.cs
@@ -1,3 +1,4 @@
+using Autodesk.DesignScript.Runtime;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,6 +8,8 @@ namespace DSCore.CurveMapper
     /// Represents a Gaussian curve in the CurveMapper.
     /// The Gaussian curve follows a bell-shaped distribution defined by four control points.
     /// </summary>
+
+    [IsVisibleInDynamoLibrary(false)]
     public class GaussianCurve : CurveBase
     {
         private double ControlPoint1X;

--- a/src/Libraries/CoreNodes/CurveMapper/LinearCurve.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/LinearCurve.cs
@@ -1,3 +1,4 @@
+using Autodesk.DesignScript.Runtime;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,6 +8,8 @@ namespace DSCore.CurveMapper
     /// Represents a linear curve in the CurveMapper.
     /// A linear curve is a straight line between two control points.
     /// </summary>
+
+    [IsVisibleInDynamoLibrary(false)]
     public class LinearCurve : CurveBase
     {
         private double ControlPoint1X;

--- a/src/Libraries/CoreNodes/CurveMapper/ParabolicCurve.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/ParabolicCurve.cs
@@ -1,3 +1,4 @@
+using Autodesk.DesignScript.Runtime;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,6 +8,8 @@ namespace DSCore.CurveMapper
     /// Represents a parabolic curve in the CurveMapper.
     /// The curve follows a quadratic equation based on two control points.
     /// </summary>
+
+    [IsVisibleInDynamoLibrary(false)]
     public class ParabolicCurve : CurveBase
     {
         private double ControlPoint1X;

--- a/src/Libraries/CoreNodes/CurveMapper/PerlinNoiseCurve.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/PerlinNoiseCurve.cs
@@ -1,3 +1,4 @@
+using Autodesk.DesignScript.Runtime;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +9,8 @@ namespace DSCore.CurveMapper
     /// Represents a Perlin noise curve in the CurveMapper.
     /// The curve generates procedural noise based on control points and Perlin noise functions.
     /// </summary>
+
+    [IsVisibleInDynamoLibrary(false)]
     public class PerlinNoiseCurve : CurveBase
     {
         private double ControlPoint1X;

--- a/src/Libraries/CoreNodes/CurveMapper/PowerCurve.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/PowerCurve.cs
@@ -1,3 +1,4 @@
+using Autodesk.DesignScript.Runtime;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,6 +8,8 @@ namespace DSCore.CurveMapper
     /// Represents a power function curve in the CurveMapper.
     /// The curve is defined by a power equation derived from a control point.
     /// </summary>
+
+    [IsVisibleInDynamoLibrary(false)]
     public class PowerCurve : CurveBase
     {
         private double ControlPoint1X;

--- a/src/Libraries/CoreNodes/CurveMapper/SineWave.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/SineWave.cs
@@ -1,3 +1,4 @@
+using Autodesk.DesignScript.Runtime;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,6 +8,8 @@ namespace DSCore.CurveMapper
     /// Represents a sine wave curve in the CurveMapper.
     /// The sine wave is defined by two control points and follows a trigonometric function.
     /// </summary>
+
+    [IsVisibleInDynamoLibrary(false)]
     public class SineWave : CurveBase
     {
         private double ControlPoint1X;

--- a/src/Libraries/CoreNodes/CurveMapper/SquareRootCurve.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/SquareRootCurve.cs
@@ -1,3 +1,4 @@
+using Autodesk.DesignScript.Runtime;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,6 +8,8 @@ namespace DSCore.CurveMapper
     /// Represents a square root curve in the CurveMapper.
     /// The curve follows a square root function and is influenced by two control points.
     /// </summary>
+
+    [IsVisibleInDynamoLibrary(false)]
     public class SquareRootCurve : CurveBase
     {
         private double ControlPoint1X;

--- a/src/Libraries/CoreNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodes/Properties/Resources.Designer.cs
@@ -70,6 +70,42 @@ namespace DSCore.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to • Min and Max values must not be the same..
+        /// </summary>
+        internal static string CurveMapperEqualMinMaxWarning {
+            get {
+                return ResourceManager.GetString("CurveMapperEqualMinMaxWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to • Values must be a list of numbers or a single number ≥ 2..
+        /// </summary>
+        internal static string CurveMapperInvalidCountWarning {
+            get {
+                return ResourceManager.GetString("CurveMapperInvalidCountWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to • Control points for the selected curve are not valid..
+        /// </summary>
+        internal static string CurveMapperInvalidCurveWarning {
+            get {
+                return ResourceManager.GetString("CurveMapperInvalidCurveWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to • X and Y inputs must be single numbers (not lists)..
+        /// </summary>
+        internal static string CurveMapperInvalidXYFormatWarning {
+            get {
+                return ResourceManager.GetString("CurveMapperInvalidXYFormatWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Input must be a single value or a non-nested list..
         /// </summary>
         internal static string DefineDataSupportedInputValueExceptionMessage {

--- a/src/Libraries/CoreNodes/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodes/Properties/Resources.en-US.resx
@@ -234,4 +234,16 @@
   <data name="DefineDataSupportedInputValueExceptionMessage" xml:space="preserve">
     <value>Input must be a single value or a non-nested list.</value>
   </data>
+  <data name="CurveMapperEqualMinMaxWarning" xml:space="preserve">
+    <value>• Min and Max values must not be the same.</value>
+  </data>
+  <data name="CurveMapperInvalidCountWarning" xml:space="preserve">
+    <value>• Values must be a list of numbers or a single number ≥ 2.</value>
+  </data>
+  <data name="CurveMapperInvalidCurveWarning" xml:space="preserve">
+    <value>• Control points for the selected curve are not valid.</value>
+  </data>
+  <data name="CurveMapperInvalidXYFormatWarning" xml:space="preserve">
+    <value>• X and Y inputs must be single numbers (not lists).</value>
+  </data>
 </root>

--- a/src/Libraries/CoreNodes/Properties/Resources.resx
+++ b/src/Libraries/CoreNodes/Properties/Resources.resx
@@ -234,4 +234,16 @@
   <data name="DefineDataSupportedInputValueExceptionMessage" xml:space="preserve">
     <value>Input must be a single value or a non-nested list.</value>
   </data>
+  <data name="CurveMapperEqualMinMaxWarning" xml:space="preserve">
+    <value>• Min and Max values must not be the same.</value>
+  </data>
+  <data name="CurveMapperInvalidCountWarning" xml:space="preserve">
+    <value>• Values must be a list of numbers or a single number ≥ 2.</value>
+  </data>
+  <data name="CurveMapperInvalidCurveWarning" xml:space="preserve">
+    <value>• Control points for the selected curve are not valid.</value>
+  </data>
+  <data name="CurveMapperInvalidXYFormatWarning" xml:space="preserve">
+    <value>• X and Y inputs must be single numbers (not lists).</value>
+  </data>
 </root>


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-8596](https://jira.autodesk.com/browse/DYN-8596) , along with several related discussions about the types of warnings generated by the CurveMapper node.

As discussed, the node's info bubble should display a single consolidated warning that summarizes any issues related to the input ports. This improves clarity and avoids overwhelming the user with multiple individual messages.

![DYN-8648](https://github.com/user-attachments/assets/6c42f44c-f23d-4714-893d-f5dbc53c9863)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Curve Mapper now generates a consolidated warning message based on its input values.

### Reviewers
@reddyashish 
@zeusongit 

### FYIs
@dnenov 
@achintyabhat 
