### PR TITLE
[DYN-8560] Chart nodes: Resize handle and Preview icon overlap

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/Charts/BarChartNodeModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/BarChartNodeModel.cs
@@ -67,6 +67,12 @@ namespace CoreNodeModelsWpf.Charts
         {
             PortUpdated?.Invoke(this, args);
         }
+
+        /// <summary>
+        /// Indicates that this node supports resizing via UI.
+        /// </summary>
+        [JsonIgnore]
+        public override bool IsResizable => true;
         #endregion
 
         #region Constructors

--- a/src/Libraries/CoreNodeModelsWpf/Charts/BasicLineChartNodeModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/BasicLineChartNodeModel.cs
@@ -66,6 +66,12 @@ namespace CoreNodeModelsWpf.Charts
         {
             PortUpdated?.Invoke(this, args);
         }
+
+        /// <summary>
+        /// Indicates that this node supports resizing via UI.
+        /// </summary>
+        [JsonIgnore]
+        public override bool IsResizable => true;
         #endregion
 
         #region Constructors

--- a/src/Libraries/CoreNodeModelsWpf/Charts/Controls/BarChartControl.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/Controls/BarChartControl.xaml
@@ -28,7 +28,8 @@
         <Thumb Name ="resizeThumb"
                Grid.Row="1"
                Style="{StaticResource ChartsThumb}"
-               DragDelta="ThumbResizeThumbOnDragDeltaHandler">
+               DragDelta="ThumbResizeThumbOnDragDeltaHandler"
+               Cursor="SizeNWSE">
             <Thumb.ToolTip>
                 <ToolTip Content="{x:Static p:CoreNodeModelWpfResources.ResizeThumbToolTip}" Style="{StaticResource GenericToolTipLight}"/>
             </Thumb.ToolTip>

--- a/src/Libraries/CoreNodeModelsWpf/Charts/Controls/BasicLineChartControl.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/Controls/BasicLineChartControl.xaml
@@ -30,7 +30,7 @@
         <Thumb Name ="resizeThumb"
                Style="{StaticResource ChartsThumb}"
                DragDelta="ThumbResizeThumbOnDragDeltaHandler"
-               >
+               Cursor="SizeNWSE">
             <Thumb.ToolTip>
                 <ToolTip Content="{x:Static p:CoreNodeModelWpfResources.ResizeThumbToolTip}" Style="{StaticResource GenericToolTipLight}"/>
             </Thumb.ToolTip>

--- a/src/Libraries/CoreNodeModelsWpf/Charts/Controls/HeatSeriesControl.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/Controls/HeatSeriesControl.xaml
@@ -29,7 +29,8 @@
 
         <Thumb Name ="resizeThumb"
                Style="{StaticResource ChartsThumb}"
-               DragDelta="ThumbResizeThumbOnDragDeltaHandler">
+               DragDelta="ThumbResizeThumbOnDragDeltaHandler"
+               Cursor="SizeNWSE">
             <Thumb.ToolTip>
                 <ToolTip Content="{x:Static p:CoreNodeModelWpfResources.ResizeThumbToolTip}" Style="{StaticResource GenericToolTipLight}"/>
             </Thumb.ToolTip>

--- a/src/Libraries/CoreNodeModelsWpf/Charts/Controls/PieChartControl.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/Controls/PieChartControl.xaml
@@ -23,7 +23,8 @@
         <lvc:PieChart Style="{StaticResource PieLiveChart}"  x:Name="PieChart" LegendPosition="Bottom"/>
         <Thumb Name ="resizeThumb"
                Style="{StaticResource ChartsThumb}"
-               DragDelta="ThumbResizeThumbOnDragDeltaHandler">
+               DragDelta="ThumbResizeThumbOnDragDeltaHandler"
+               Cursor="SizeNWSE">
             <Thumb.ToolTip>
                 <ToolTip Content="{x:Static p:CoreNodeModelWpfResources.ResizeThumbToolTip}" Style="{StaticResource GenericToolTipLight}"/>
             </Thumb.ToolTip>

--- a/src/Libraries/CoreNodeModelsWpf/Charts/Controls/ScatterPlotControl.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/Controls/ScatterPlotControl.xaml
@@ -29,7 +29,8 @@
 
         <Thumb Name ="resizeThumb"
                Style="{StaticResource ChartsThumb}"
-               DragDelta="ThumbResizeThumbOnDragDeltaHandler">
+               DragDelta="ThumbResizeThumbOnDragDeltaHandler"
+               Cursor="SizeNWSE">
             <Thumb.ToolTip>
                 <ToolTip Content="{x:Static p:CoreNodeModelWpfResources.ResizeThumbToolTip}" Style="{StaticResource GenericToolTipLight}"/>
             </Thumb.ToolTip>

--- a/src/Libraries/CoreNodeModelsWpf/Charts/Controls/XYLineChartControl.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/Controls/XYLineChartControl.xaml
@@ -29,7 +29,8 @@
 
         <Thumb Name ="resizeThumb"
                Style="{StaticResource ChartsThumb}"
-               DragDelta="ThumbResizeThumbOnDragDeltaHandler">
+               DragDelta="ThumbResizeThumbOnDragDeltaHandler"
+               Cursor="SizeNWSE">
             <Thumb.ToolTip>
                 <ToolTip Content="{x:Static p:CoreNodeModelWpfResources.ResizeThumbToolTip}" Style="{StaticResource GenericToolTipLight}"/>
             </Thumb.ToolTip>

--- a/src/Libraries/CoreNodeModelsWpf/Charts/HeatSeriesNodeModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/HeatSeriesNodeModel.cs
@@ -74,6 +74,12 @@ namespace CoreNodeModelsWpf.Charts
         {
             PortUpdated?.Invoke(this, args);
         }
+
+        /// <summary>
+        /// Indicates that this node supports resizing via UI.
+        /// </summary>
+        [JsonIgnore]
+        public override bool IsResizable => true;
         #endregion
 
         #region Constructors

--- a/src/Libraries/CoreNodeModelsWpf/Charts/PieChartNodeModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/PieChartNodeModel.cs
@@ -67,6 +67,12 @@ namespace CoreNodeModelsWpf.Charts
         {
             PortUpdated?.Invoke(this, args);
         }
+
+        /// <summary>
+        /// Indicates that this node supports resizing via UI.
+        /// </summary>
+        [JsonIgnore]
+        public override bool IsResizable => true;
         #endregion
 
         #region Constructors

--- a/src/Libraries/CoreNodeModelsWpf/Charts/ScatterPlotNodeModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/ScatterPlotNodeModel.cs
@@ -74,6 +74,12 @@ namespace CoreNodeModelsWpf.Charts
         {
             PortUpdated?.Invoke(this, args);
         }
+
+        /// <summary>
+        /// Indicates that this node supports resizing via UI.
+        /// </summary>
+        [JsonIgnore]
+        public override bool IsResizable => true;
         #endregion
 
         #region Constructors

--- a/src/Libraries/CoreNodeModelsWpf/Charts/XYLineChartNodeModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/XYLineChartNodeModel.cs
@@ -73,6 +73,12 @@ namespace CoreNodeModelsWpf.Charts
         {
             PortUpdated?.Invoke(this, args);
         }
+
+        /// <summary>
+        /// Indicates that this node supports resizing via UI.
+        /// </summary>
+        [JsonIgnore]
+        public override bool IsResizable => true;
         #endregion
 
         #region Constructors


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-8560](https://jira.autodesk.com/browse/DYN-8560),  which reported an issue where the resize thumb and the preview icon overlap, making the thumb difficult or impossible to use.

To resolve this, I’ve applied the same approach used in Curve Mapper to all chart nodes by setting their IsResizable property to true. This adjustment shifts the glyph icon to the left, creating room for the resize thumb.

I’ve also updated the cursor appearance when hovering over the resize thumb to match the behavior seen in Curve Mapper.

![DYN-8560](https://github.com/user-attachments/assets/8ac552a5-7599-4610-8190-d8f9ef8308ba)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Chart nodes are now resizable, with improved cursor behavior and layout adjustments to prevent overlap between the resize thumb and preview icon.

### Reviewers
@reddyashish 
@zeusongit 

### FYIs
@dnenov 
@achintyabhat 
