### PR TITLE
[DYN-8055] Placement of UI pop up for input/output ports is not accurate

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -106,6 +106,7 @@ namespace Dynamo.Graph.Nodes
         #endregion
 
         internal const double HeaderHeight = 46;
+        internal const double CustomNodeTopBorderHeight = 8;
         internal static string ExtensionNode = "ExtensionNode";
 
         #region public members

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -444,11 +444,12 @@ namespace Dynamo.ViewModels
             // Calculate absolute popup halfheight to deduct from the overall y pos
             // Then add the header, port height and port index position
             var popupHeightOffset = - popupSize.Height * 0.5;
-            var headerHeightOffset = 2 * NodeModel.HeaderHeight * zoom;
+            var headerHeightOffset = NodeModel.HeaderHeight * zoom;
             var portHalfHeight = PortModel.Height * 0.5 * zoom;
-            var rowOffset = PortModel.Index * (1.5 * PortModel.Height) * zoom;
+            var rowOffset = PortModel.Index * PortModel.Height * zoom;
+            var customNodeOffset = NodeModel.CustomNodeTopBorderHeight * zoom;
 
-            var y = popupHeightOffset + headerHeightOffset + portHalfHeight + rowOffset;
+            var y = popupHeightOffset + headerHeightOffset + portHalfHeight + rowOffset + customNodeOffset;
 
             var placement = new CustomPopupPlacement(new Point(x, y), PopupPrimaryAxis.None);
 


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-8055](https://jira.autodesk.com/browse/DYN-8055), which reports incorrect vertical placement of the port context menu popup.

The issue was caused by the incorrect original placement formula and not accounting for the top border used in custom nodes. This has now been resolved by adjusting the Y-offset calculation to include the height of the custom node’s top borders.

To keep layout logic consistent, the top border height has been added as a constant in `NodeModel`, similar to the existing `HeaderHeight` constant.

![DYN-8055-Proposal_250415](https://github.com/user-attachments/assets/146e2430-7744-4a24-a907-c5eb25de8e5e)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixed incorrect positioning of port context menus by updating the placement logic.

### Reviewers
@reddyashish 
@zeusongit 

### FYIs
@dnenov 
@achintyabhat 
