### PR TITLE
DYN-8494 - Group Cluster Node and Wire Creation into One Undo

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
@@ -38,8 +38,11 @@ namespace Dynamo.Graph.Workspaces
 
             GenerateCombinedGraph(workspace, isGroupLayout, out layoutSubgraphs, out subgraphClusters);
 
-
-            RecordUndoGraphLayout(workspace, isGroupLayout, reuseUndoRedoGroup);
+            //only record graph layout undo when it is not node autocomplete
+            if (!isNodeAutoComplete)
+            {
+                RecordUndoGraphLayout(workspace, isGroupLayout, reuseUndoRedoGroup);
+            }
             
             // Generate subgraphs separately for each cluster
             subgraphClusters.ForEach(

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -3763,7 +3763,7 @@ namespace Dynamo.Models
             return result;
         }
 
-        private void RecordUndoModels(WorkspaceModel workspace, List<ModelBase> undoItems)
+        internal static void RecordUndoModels(WorkspaceModel workspace, List<ModelBase> undoItems)
         {
             var userActionDictionary = new Dictionary<ModelBase, UndoRedoRecorder.UserAction>();
             //Add models that were newly created

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -814,7 +814,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                 xoffset += node.NodeModel.Width;
                 foreach(var newNode in nodeStack)
                 {
-                    // Retreive assembly name and node full name from type.id.
+                    // Retrieve assembly name and node full name from type.id.
                     var typeInfo = wsViewModel.NodeAutoCompleteSearchViewModel.GetInfoFromTypeId(newNode.Type.Id);
 
                     var nodeTest = dynamoViewModel.Model.SearchModel.Entries.Where(n => n.FullName.Contains("Slider")).ToList();
@@ -891,6 +891,8 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             //Add models that were newly created
             foreach (var undoItem in undoItems)
             {
+                if(undoItem is null) continue;
+
                 userActionDictionary.Add(undoItem, UndoRedoRecorder.UserAction.Creation);
             }
 

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -889,21 +889,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             NodeAutoCompleteUtilities.PostAutoLayoutNodes(wsViewModel.DynamoViewModel.CurrentSpace, node.NodeModel, clusterNodesModel.Select(x => x.NodeModel), false, false, false, finalizer);
 
             //record all node and wire creation as one undo
-            RecordUndoModels(wsViewModel.Model, newNodesAndWires);
-        }
-
-        private void RecordUndoModels(WorkspaceModel workspace, List<ModelBase> undoItems)
-        {
-            var userActionDictionary = new Dictionary<ModelBase, UndoRedoRecorder.UserAction>();
-            //Add models that were newly created
-            foreach (var undoItem in undoItems)
-            {
-                if(undoItem is null) continue;
-
-                userActionDictionary.Add(undoItem, UndoRedoRecorder.UserAction.Creation);
-            }
-
-            WorkspaceModel.RecordModelsForUndo(userActionDictionary, workspace.UndoRecorder);
+            DynamoModel.RecordUndoModels(wsViewModel.Model, newNodesAndWires);
         }
 
         /// <summary>

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -806,7 +806,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             List<List<NodeItem>> nodeStacks = NodeAutoCompleteUtilities.ComputeNodePlacementHeuristics(clusterConnections, clusterNodes);
 
             //store our nodes and wires to allow for one undo
-            List<ModelBase> newNodesAddWires = new List<ModelBase>();
+            List<ModelBase> newNodesAndWires = new List<ModelBase>();
 
             double xoffset = node.X + node.NodeModel.Width;
             foreach (var nodeStack in nodeStacks)
@@ -816,8 +816,6 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                 {
                     // Retrieve assembly name and node full name from type.id.
                     var typeInfo = wsViewModel.NodeAutoCompleteSearchViewModel.GetInfoFromTypeId(newNode.Type.Id);
-
-                    var nodeTest = dynamoViewModel.Model.SearchModel.Entries.Where(n => n.FullName.Contains("Slider")).ToList();
                     var foundNode = dynamoViewModel.Model.SearchModel.Entries.FirstOrDefault(n => n.CreationName.Contains(typeInfo.FullName));
                     var nodeModel = foundNode.CreateNode();
 
@@ -825,7 +823,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
 
                     var nodeFromCluster = wsViewModel.Nodes.LastOrDefault();
 
-                    newNodesAddWires.Add(nodeModel);
+                    newNodesAndWires.Add(nodeModel);
 
                     nodeFromCluster.IsTransient = true;
                     nodeFromCluster.IsHidden = true;
@@ -851,15 +849,15 @@ namespace Dynamo.NodeAutoComplete.ViewModels
 
                 var connector = ConnectorModel.Make(sourceNode, targetNode, connection.StartNode.PortIndex - 1, connection.EndNode.PortIndex - 1);
 
-                newNodesAddWires.Add(connector);
+                newNodesAndWires.Add(connector);
             });
 
             // Connect the cluster to the original node and port
             var connector = ConnectorModel.Make(node.NodeModel, targetNodeFromCluster.NodeModel, 0, ClusterResultItem.EntryNodeInPort);
-            newNodesAddWires.Add(connector);
+            newNodesAndWires.Add(connector);
 
             //record all node and wire creation as one undo
-            RecordUndoModels(wsViewModel.Model, newNodesAddWires);
+            RecordUndoModels(wsViewModel.Model, newNodesAndWires);
 
             //Make connectors invisible ( just like the cluster nodes ) before they get a chance to be drawn.
             var clusterNodesModel = clusterMapping.Values.ToList();

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -836,7 +836,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                     var targetPort = targetNode.InPorts.FirstOrDefault(p => p.Index == connection.EndNode.PortIndex - 1);
 
                     var connector = ConnectorModel.Make(sourceNode, targetNode, connection.StartNode.PortIndex - 1, connection.EndNode.PortIndex - 1);
-                    if (connector != null && !targetPort.IsConnected)
+                    if (connector != null && targetPort.Connectors.Count == 0)
                     {
                         wsViewModel.Model.UndoRecorder.RecordCreationForUndo(connector);
                     }
@@ -844,7 +844,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
 
                 // Connect the cluster to the original node and port
                 var connector = ConnectorModel.Make(node.NodeModel, targetNodeFromCluster.NodeModel, 0, ClusterResultItem.EntryNodeInPort);
-                if (connector != null && !targetNodeFromCluster.OutPorts.FirstOrDefault().IsConnected)
+                if (connector != null && targetNodeFromCluster.OutPorts.FirstOrDefault().PortModel.Connectors.Count == 0)
                 {
                     wsViewModel.Model.UndoRecorder.RecordCreationForUndo(connector);
                 }

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -912,12 +912,12 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                 {
                     if (!IsOpen)
                     {
-                        // view dissapeared while the background thread was waiting for the server response.
+                        // view disappeared while the background thread was waiting for the server response.
                         // Ignore the results are we're no longer interested.
                         return;
                     }
 
-                    // this runs synchronously on the UI thread, so the UI can't dissapear during execution
+                    // this runs synchronously on the UI thread, so the UI can't disappear during execution
                     ClusterResults = comboboxResults;
                     if (QualifiedResults.Any())
                     {

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -823,7 +823,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                     var typeInfo = wsViewModel.NodeAutoCompleteSearchViewModel.GetInfoFromTypeId(newNode.Type.Id);
                     dynamoViewModel.Model.ExecuteCommand(new DynamoModel.CreateNodeCommand(Guid.NewGuid().ToString(), typeInfo.FullName, xoffset, node.NodeModel.Y, false, false));
 
-                    //disallow the node creation command from the undo group, we are adding those later
+                    //disallow the node creation command from the undo group, we group node creation and wires below
                     wsViewModel.Model.UndoRecorder.PopFromUndoGroup();
 
                     var nodeFromCluster = wsViewModel.Nodes.LastOrDefault();

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -821,14 +821,14 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                 {
                     // Retrieve assembly name and node full name from type.id.
                     var typeInfo = wsViewModel.NodeAutoCompleteSearchViewModel.GetInfoFromTypeId(newNode.Type.Id);
-                    var foundNode = dynamoViewModel.Model.SearchModel.Entries.FirstOrDefault(n => n.CreationName.Contains(typeInfo.FullName));
-                    var nodeModel = foundNode.CreateNode();
+                    dynamoViewModel.Model.ExecuteCommand(new DynamoModel.CreateNodeCommand(Guid.NewGuid().ToString(), typeInfo.FullName, xoffset, node.NodeModel.Y, false, false));
 
-                    wsViewModel.Model.AddAndRegisterNode(nodeModel);
+                    //disallow the node creation command from the undo group, we are adding those later
+                    wsViewModel.Model.UndoRecorder.PopFromUndoGroup();
 
                     var nodeFromCluster = wsViewModel.Nodes.LastOrDefault();
 
-                    newNodesAndWires.Add(nodeModel);
+                    newNodesAndWires.Add(nodeFromCluster.NodeModel);
 
                     nodeFromCluster.IsTransient = true;
                     nodeFromCluster.IsHidden = true;


### PR DESCRIPTION
### Purpose
This PR expands upon DYN-8494 by grouping actions within the cluster creation into one undo group. It also disallows undo of clusters that were previewed, but not used. 

Behavior Before:
![20250415-cluster-Before](https://github.com/user-attachments/assets/7217c495-6ec9-4ef6-a2d0-b9b17b5189f8)

Behavior Now:
![20250416-cluster-After](https://github.com/user-attachments/assets/9897b433-a125-48aa-91d0-5ed83ac13836)
![20250416-cluster-After2](https://github.com/user-attachments/assets/e0b19681-bf10-4218-8d6d-3dc8a2a97a57)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes
N/A

### Reviewers
@BogdanZavu _(after vacation)_  @QilongTang @chubakueno 

### FYIs
@Amoursol @Jingyi-Wen 
