### PR TITLE
DYN-8631 - Block UndoRedo Operation During Cluster Prediction

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -36,7 +36,7 @@ namespace Dynamo.Graph.Workspaces
         {
             get
             {
-                return ((null != undoRecorder) && undoRecorder.CanUndo) && !IsUndoRedoLocked;
+                return (null != undoRecorder && undoRecorder.CanUndo) && !IsUndoRedoLocked;
             }
         }
 
@@ -47,7 +47,7 @@ namespace Dynamo.Graph.Workspaces
         {
             get
             {
-                return ((null != undoRecorder) && undoRecorder.CanRedo) && !IsUndoRedoLocked;
+                return (null != undoRecorder && undoRecorder.CanRedo) && !IsUndoRedoLocked;
             }
         }
 

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -36,11 +36,7 @@ namespace Dynamo.Graph.Workspaces
         {
             get
             {
-                if (UndoRedoLocked)
-                {
-                    return false;
-                }
-                return ((null != undoRecorder) && undoRecorder.CanUndo);
+                return ((null != undoRecorder) && undoRecorder.CanUndo) && !IsUndoRedoLocked;
             }
         }
 
@@ -51,15 +47,11 @@ namespace Dynamo.Graph.Workspaces
         {
             get
             {
-                if (UndoRedoLocked)
-                {
-                    return false;
-                }
-                return ((null != undoRecorder) && undoRecorder.CanRedo);
+                return ((null != undoRecorder) && undoRecorder.CanRedo) && !IsUndoRedoLocked;
             }
         }
 
-        internal bool UndoRedoLocked
+        internal bool IsUndoRedoLocked
         {
             get;
             set;

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -34,7 +34,14 @@ namespace Dynamo.Graph.Workspaces
         /// </summary>
         public bool CanUndo
         {
-            get { return ((null != undoRecorder) && undoRecorder.CanUndo); }
+            get
+            {
+                if (UndoRedoLocked)
+                {
+                    return false;
+                }
+                return ((null != undoRecorder) && undoRecorder.CanUndo);
+            }
         }
 
         /// <summary>
@@ -42,7 +49,20 @@ namespace Dynamo.Graph.Workspaces
         /// </summary>
         public bool CanRedo
         {
-            get { return ((null != undoRecorder) && undoRecorder.CanRedo); }
+            get
+            {
+                if (UndoRedoLocked)
+                {
+                    return false;
+                }
+                return ((null != undoRecorder) && undoRecorder.CanRedo);
+            }
+        }
+
+        internal bool UndoRedoLocked
+        {
+            get;
+            set;
         }
 
         internal void Undo()

--- a/src/DynamoCoreWpf/Utilities/NodeAutoCompleteUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/NodeAutoCompleteUtilities.cs
@@ -129,6 +129,7 @@ namespace Dynamo.Wpf.Utilities
                 {
                     DynamoSelection.Instance.Selection.AddRange(intersectedNodes);
                     wsModel.DoGraphAutoLayout(reuseUndoGroup, true, queryNode.GUID);
+                    DynamoSelection.Instance.Selection.RemoveRange(intersectedNodes);
                 }
             }
 

--- a/src/DynamoCoreWpf/Utilities/NodeAutoCompleteUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/NodeAutoCompleteUtilities.cs
@@ -132,8 +132,6 @@ namespace Dynamo.Wpf.Utilities
                 }
             }
 
-            DynamoSelection.Instance.ClearSelection();
-
             if (finalizer != null)
             {
                 finalizer();

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -198,6 +198,9 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             }
 
             NodeAutoCompleteUtilities.PostAutoLayoutNodes(node.WorkspaceViewModel.Model, node.NodeModel, transientNodes.Select(x => x.NodeModel), true, true, false, null);
+
+            //unlock undo/redo
+            node.WorkspaceViewModel.Model.UndoRedoLocked = false;
         }
 
         /// <summary>
@@ -798,6 +801,8 @@ namespace Dynamo.NodeAutoComplete.ViewModels
 
             var node = PortViewModel.NodeViewModel;
             var wsViewModel = node.WorkspaceViewModel;
+            //lock undo/redo
+            wsViewModel.Model.UndoRedoLocked = true;
 
             DeleteTransientNodes();
 

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -192,9 +192,6 @@ namespace Dynamo.NodeAutoComplete.ViewModels
         {
             var node = PortViewModel.NodeViewModel;
 
-            //unlock undo/redo
-            node.WorkspaceViewModel.Model.IsUndoRedoLocked = false;
-            
             var transientNodes = node.WorkspaceViewModel.Nodes.Where(x => x.IsTransient).ToList();
             foreach (var transientNode in transientNodes)
             {
@@ -203,8 +200,16 @@ namespace Dynamo.NodeAutoComplete.ViewModels
 
             NodeAutoCompleteUtilities.PostAutoLayoutNodes(node.WorkspaceViewModel.Model, node.NodeModel, transientNodes.Select(x => x.NodeModel), true, true, false, null);
 
-            //this allows undo redo to become active again
-            node.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(new DynamoModel.UndoRedoCommand(DynamoModel.UndoRedoCommand.Operation.Redo));
+            ToggleUndoRedoLocked(false);
+        }
+
+        internal void ToggleUndoRedoLocked(bool toggle = true)
+        {
+            var node = PortViewModel.NodeViewModel;
+            //unlock undo/redo
+            node.WorkspaceViewModel.Model.IsUndoRedoLocked = toggle;
+            //allow for undo/redo again
+            node.DynamoViewModel.RaiseCanExecuteUndoRedo();
         }
 
         /// <summary>
@@ -807,7 +812,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             var wsViewModel = node.WorkspaceViewModel;
 
             //lock undo/redo
-            wsViewModel.Model.IsUndoRedoLocked = true;
+            ToggleUndoRedoLocked(true);
 
             DeleteTransientNodes();
 

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -32,7 +32,6 @@ using RestSharp;
 using Dynamo.Wpf.Utilities;
 using Dynamo.ViewModels;
 using System.Reflection;
-using System.Windows.Input;
 using Dynamo.Core;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Graph;

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -193,7 +193,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             var node = PortViewModel.NodeViewModel;
 
             //unlock undo/redo
-            node.WorkspaceViewModel.Model.UndoRedoLocked = false;
+            node.WorkspaceViewModel.Model.IsUndoRedoLocked = false;
             
             var transientNodes = node.WorkspaceViewModel.Nodes.Where(x => x.IsTransient).ToList();
             foreach (var transientNode in transientNodes)
@@ -807,7 +807,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             var wsViewModel = node.WorkspaceViewModel;
 
             //lock undo/redo
-            wsViewModel.Model.UndoRedoLocked = true;
+            wsViewModel.Model.IsUndoRedoLocked = true;
 
             DeleteTransientNodes();
 

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -32,6 +32,7 @@ using RestSharp;
 using Dynamo.Wpf.Utilities;
 using Dynamo.ViewModels;
 using System.Reflection;
+using System.Windows.Input;
 using Dynamo.Core;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Graph;
@@ -191,6 +192,10 @@ namespace Dynamo.NodeAutoComplete.ViewModels
         internal void ConsolidateTransientNodes()
         {
             var node = PortViewModel.NodeViewModel;
+
+            //unlock undo/redo
+            node.WorkspaceViewModel.Model.UndoRedoLocked = false;
+            
             var transientNodes = node.WorkspaceViewModel.Nodes.Where(x => x.IsTransient).ToList();
             foreach (var transientNode in transientNodes)
             {
@@ -199,8 +204,8 @@ namespace Dynamo.NodeAutoComplete.ViewModels
 
             NodeAutoCompleteUtilities.PostAutoLayoutNodes(node.WorkspaceViewModel.Model, node.NodeModel, transientNodes.Select(x => x.NodeModel), true, true, false, null);
 
-            //unlock undo/redo
-            node.WorkspaceViewModel.Model.UndoRedoLocked = false;
+            //this allows undo redo to become active again
+            node.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(new DynamoModel.UndoRedoCommand(DynamoModel.UndoRedoCommand.Operation.Redo));
         }
 
         /// <summary>
@@ -801,6 +806,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
 
             var node = PortViewModel.NodeViewModel;
             var wsViewModel = node.WorkspaceViewModel;
+
             //lock undo/redo
             wsViewModel.Model.UndoRedoLocked = true;
 

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -191,7 +191,6 @@ namespace Dynamo.NodeAutoComplete.ViewModels
         internal void ConsolidateTransientNodes()
         {
             var node = PortViewModel.NodeViewModel;
-
             var transientNodes = node.WorkspaceViewModel.Nodes.Where(x => x.IsTransient).ToList();
             foreach (var transientNode in transientNodes)
             {

--- a/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml.cs
+++ b/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml.cs
@@ -146,6 +146,7 @@ namespace Dynamo.NodeAutoComplete.Views
             Dispatcher.BeginInvoke(new Action(() =>
             {
                 ViewModel?.DeleteTransientNodes();
+                ViewModel?.ToggleUndoRedoLocked(false);
             }), DispatcherPriority.Loaded);
             
             Close();


### PR DESCRIPTION
### Purpose
This PR aims to address the issue, DYN-8631, by disabling the undo/redo process while iterating through cluster results. Additionally, this PR enables preselection of the nodes created by the cluster.

![20250421-clusterUndoBlock](https://github.com/user-attachments/assets/9c80ca96-5afb-4d73-8ea0-6fec488a858b)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes
N/A

### Reviewers
@chubakueno, @QilongTang,

### FYIs
@Jingyi-Wen , @Amoursol , @achintyabhat 
