### PR TITLE
DYN-8577 Invalid Locale DynamoSettings Bug

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2892,6 +2892,9 @@ namespace Dynamo.Models
         {
             if (string.IsNullOrWhiteSpace(locale)) return;
 
+            //Validate that the provided locale against the supported locales
+            locale = Configurations.SupportedLocaleDic.FirstOrDefault(x => x.Value == locale).Value ?? Configurations.SupportedLocaleDic.FirstOrDefault().Value;
+
             // Setting the locale for Dynamo from loaded Preferences, with Default handled differently
             // between a non-in-process integration case (when HostAnalyticsInfo.HostName is unspecified)
             // and in-process integration case. In later case, Default setting means following host locale.


### PR DESCRIPTION
### Purpose

Fixing locale bug reported during testing when having `<Locale>xyz</Locale>` in DynamoSettings.xml 
When <Locale>xyz</Locale> in DynamoSettings.xml and opening the Package Manager, the help was appearing in a different language so with this fix now when opening the help will appear in the same language than the Language Dropdown in Preferences


### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing locale bug reported during testing when having `<Locale>xyz</Locale>` in DynamoSettings.xml 

### Reviewers

@zeusongit 

### FYIs

@jnealb 
