### PR TITLE
[DYN-8661] Curve Mapper copied new node to carry the info

### DIFF
--- a/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
+++ b/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
@@ -955,76 +955,53 @@ namespace CoreNodeModels
         {
             base.SerializeCore(element, context);
 
-            element.SetAttribute("SelectedGraphType", SelectedGraphType.ToString());
+            element.SetAttribute(nameof(SelectedGraphType), SelectedGraphType.ToString());
+            element.SetAttribute(nameof(IsLocked), IsLocked.ToString());
 
-            //// Save only the points needed for the current curve
-            //switch (SelectedGraphType)
-            //{               
-            //    case GraphTypes.LinearCurve:
-            //        SavePointData(element, "Linear1", LinearCurveControlPointData1);
-            //        SavePointData(element, "Linear2", LinearCurveControlPointData2);
-            //        break;
-            //    case GraphTypes.BezierCurve:
-            //        SavePointData(element, "Bezier1", BezierCurveControlPointData1);
-            //        SavePointData(element, "Bezier2", BezierCurveControlPointData2);
-            //        SavePointData(element, "Bezier3", BezierCurveControlPointData3);
-            //        SavePointData(element, "Bezier4", BezierCurveControlPointData4);
-            //        break;
-            //    case GraphTypes.SineWave:
-            //        SavePointData(element, "Sine1", SineWaveControlPointData1);
-            //        SavePointData(element, "Sine2", SineWaveControlPointData2);
-            //        break;
-            //    case GraphTypes.CosineWave:
-            //        SavePointData(element, "Cosine1", CosineWaveControlPointData1);
-            //        SavePointData(element, "Cosine2", CosineWaveControlPointData2);
-            //        break;
-            //    case GraphTypes.ParabolicCurve:
-            //        SavePointData(element, "Parabolic1", ParabolicCurveControlPointData1);
-            //        SavePointData(element, "Parabolic2", ParabolicCurveControlPointData2);
-            //        break;
-            //    case GraphTypes.PerlinNoiseCurve:
-            //        SavePointData(element, "Perlin1", PerlinNoiseControlPointData1);
-            //        SavePointData(element, "Perlin2", PerlinNoiseControlPointData2);
-            //        SavePointData(element, "Perlin3", PerlinNoiseControlPointData3);
-            //        break;
-            //    case GraphTypes.PowerCurve:
-            //        SavePointData(element, "Power1", PowerCurveControlPointData1);
-            //        break;
-            //    case GraphTypes.SquareRootCurve:
-            //        SavePointData(element, "SquareRoot1", SquareRootCurveControlPointData1);
-            //        SavePointData(element, "SquareRoot2", SquareRootCurveControlPointData2);
-            //        break;
-            //    case GraphTypes.GaussianCurve:
-            //        SavePointData(element, "Gaussian1", GaussianCurveControlPointData1);
-            //        SavePointData(element, "Gaussian2", GaussianCurveControlPointData2);
-            //        SavePointData(element, "Gaussian3", GaussianCurveControlPointData3);
-            //        SavePointData(element, "Gaussian4", GaussianCurveControlPointData4);
-            //        break;
-            //}
             // Save only the points needed for the current curve
-            SavePointData(element, "Linear1", LinearCurveControlPointData1);
-            SavePointData(element, "Linear2", LinearCurveControlPointData2);
-            SavePointData(element, "Bezier1", BezierCurveControlPointData1);
-            SavePointData(element, "Bezier2", BezierCurveControlPointData2);
-            SavePointData(element, "Bezier3", BezierCurveControlPointData3);
-            SavePointData(element, "Bezier4", BezierCurveControlPointData4);
-            SavePointData(element, "Sine1", SineWaveControlPointData1);
-            SavePointData(element, "Sine2", SineWaveControlPointData2);
-            SavePointData(element, "Cosine1", CosineWaveControlPointData1);
-            SavePointData(element, "Cosine2", CosineWaveControlPointData2);
-            SavePointData(element, "Parabolic1", ParabolicCurveControlPointData1);
-            SavePointData(element, "Parabolic2", ParabolicCurveControlPointData2);
-            SavePointData(element, "Perlin1", PerlinNoiseControlPointData1);
-            SavePointData(element, "Perlin2", PerlinNoiseControlPointData2);
-            SavePointData(element, "Perlin3", PerlinNoiseControlPointData3);
-            SavePointData(element, "Power1", PowerCurveControlPointData1);
-            SavePointData(element, "SquareRoot1", SquareRootCurveControlPointData1);
-            SavePointData(element, "SquareRoot2", SquareRootCurveControlPointData2);
-            SavePointData(element, "Gaussian1", GaussianCurveControlPointData1);
-            SavePointData(element, "Gaussian2", GaussianCurveControlPointData2);
-            SavePointData(element, "Gaussian3", GaussianCurveControlPointData3);
-            SavePointData(element, "Gaussian4", GaussianCurveControlPointData4);
-
+            switch (SelectedGraphType)
+            {
+                case GraphTypes.LinearCurve:
+                    SavePointData(element, "Linear1", LinearCurveControlPointData1);
+                    SavePointData(element, "Linear2", LinearCurveControlPointData2);
+                    break;
+                case GraphTypes.BezierCurve:
+                    SavePointData(element, "Bezier1", BezierCurveControlPointData1);
+                    SavePointData(element, "Bezier2", BezierCurveControlPointData2);
+                    SavePointData(element, "Bezier3", BezierCurveControlPointData3);
+                    SavePointData(element, "Bezier4", BezierCurveControlPointData4);
+                    break;
+                case GraphTypes.SineWave:
+                    SavePointData(element, "Sine1", SineWaveControlPointData1);
+                    SavePointData(element, "Sine2", SineWaveControlPointData2);
+                    break;
+                case GraphTypes.CosineWave:
+                    SavePointData(element, "Cosine1", CosineWaveControlPointData1);
+                    SavePointData(element, "Cosine2", CosineWaveControlPointData2);
+                    break;
+                case GraphTypes.ParabolicCurve:
+                    SavePointData(element, "Parabolic1", ParabolicCurveControlPointData1);
+                    SavePointData(element, "Parabolic2", ParabolicCurveControlPointData2);
+                    break;
+                case GraphTypes.PerlinNoiseCurve:
+                    SavePointData(element, "Perlin1", PerlinNoiseControlPointData1);
+                    SavePointData(element, "Perlin2", PerlinNoiseControlPointData2);
+                    SavePointData(element, "Perlin3", PerlinNoiseControlPointData3);
+                    break;
+                case GraphTypes.PowerCurve:
+                    SavePointData(element, "Power1", PowerCurveControlPointData1);
+                    break;
+                case GraphTypes.SquareRootCurve:
+                    SavePointData(element, "SquareRoot1", SquareRootCurveControlPointData1);
+                    SavePointData(element, "SquareRoot2", SquareRootCurveControlPointData2);
+                    break;
+                case GraphTypes.GaussianCurve:
+                    SavePointData(element, "Gaussian1", GaussianCurveControlPointData1);
+                    SavePointData(element, "Gaussian2", GaussianCurveControlPointData2);
+                    SavePointData(element, "Gaussian3", GaussianCurveControlPointData3);
+                    SavePointData(element, "Gaussian4", GaussianCurveControlPointData4);
+                    break;
+            }
         }        
 
         protected override void DeserializeCore(XmlElement element, SaveContext context)
@@ -1032,89 +1009,72 @@ namespace CoreNodeModels
             base.DeserializeCore(element, context);
 
             // Restore the selected graph type
-            var typeAttr = element.GetAttribute("SelectedGraphType");
+            var typeAttr = element.GetAttribute(nameof(SelectedGraphType));
             if (!string.IsNullOrEmpty(typeAttr) && Enum.TryParse(typeAttr, out GraphTypes parsedType))
             {
                 SelectedGraphType = parsedType;
             }
+            if (bool.TryParse(element.GetAttribute(nameof(IsLocked)), out var locked))
+            {
+                IsLocked = locked;
+            }
 
-            //switch (SelectedGraphType)
-            //{                
-            //    case GraphTypes.LinearCurve:
-            //        LinearCurveControlPointData1 = LoadPointData(element, "Linear1");
-            //        LinearCurveControlPointData2 = LoadPointData(element, "Linear2");
-            //        break;
-            //    case GraphTypes.BezierCurve:
-            //        BezierCurveControlPointData1 = LoadPointData(element, "Bezier1");
-            //        BezierCurveControlPointData2 = LoadPointData(element, "Bezier2");
-            //        BezierCurveControlPointData3 = LoadPointData(element, "Bezier3");
-            //        BezierCurveControlPointData4 = LoadPointData(element, "Bezier4");
-            //        break;
-            //    case GraphTypes.SineWave:
-            //        SineWaveControlPointData1 = LoadPointData(element, "Sine1");
-            //        SineWaveControlPointData2 = LoadPointData(element, "Sine2");
-            //        break;
-            //    case GraphTypes.CosineWave:
-            //        CosineWaveControlPointData1 = LoadPointData(element, "Cosine1");
-            //        CosineWaveControlPointData2 = LoadPointData(element, "Cosine2");
-            //        break;
-            //    case GraphTypes.ParabolicCurve:
-            //        ParabolicCurveControlPointData1 = LoadPointData(element, "Parabolic1");
-            //        ParabolicCurveControlPointData2 = LoadPointData(element, "Parabolic2");
-            //        break;
-            //    case GraphTypes.PerlinNoiseCurve:
-            //        PerlinNoiseControlPointData1 = LoadPointData(element, "Perlin1");
-            //        PerlinNoiseControlPointData2 = LoadPointData(element, "Perlin2");
-            //        PerlinNoiseControlPointData3 = LoadPointData(element, "Perlin3");
-            //        break;
-            //    case GraphTypes.PowerCurve:
-            //        PowerCurveControlPointData1 = LoadPointData(element, "Power1");
-            //        break;
-            //    case GraphTypes.SquareRootCurve:
-            //        SquareRootCurveControlPointData1 = LoadPointData(element, "SquareRoot1");
-            //        SquareRootCurveControlPointData2 = LoadPointData(element, "SquareRoot2");
-            //        break;
-            //    case GraphTypes.GaussianCurve:
-            //        GaussianCurveControlPointData1 = LoadPointData(element, "Gaussian1");
-            //        GaussianCurveControlPointData2 = LoadPointData(element, "Gaussian2");
-            //        GaussianCurveControlPointData3 = LoadPointData(element, "Gaussian3");
-            //        GaussianCurveControlPointData4 = LoadPointData(element, "Gaussian4");
-            //        break;
-            //}
-            LinearCurveControlPointData1 = LoadPointData(element, "Linear1");
-            LinearCurveControlPointData2 = LoadPointData(element, "Linear2");
-            BezierCurveControlPointData1 = LoadPointData(element, "Bezier1");
-            BezierCurveControlPointData2 = LoadPointData(element, "Bezier2");
-            BezierCurveControlPointData3 = LoadPointData(element, "Bezier3");
-            BezierCurveControlPointData4 = LoadPointData(element, "Bezier4");
-            SineWaveControlPointData1 = LoadPointData(element, "Sine1");
-            SineWaveControlPointData2 = LoadPointData(element, "Sine2");
-            CosineWaveControlPointData1 = LoadPointData(element, "Cosine1");
-            CosineWaveControlPointData2 = LoadPointData(element, "Cosine2");
-            ParabolicCurveControlPointData1 = LoadPointData(element, "Parabolic1");
-            ParabolicCurveControlPointData2 = LoadPointData(element, "Parabolic2");
-            PerlinNoiseControlPointData1 = LoadPointData(element, "Perlin1");
-            PerlinNoiseControlPointData2 = LoadPointData(element, "Perlin2");
-            PerlinNoiseControlPointData3 = LoadPointData(element, "Perlin3");
-            PowerCurveControlPointData1 = LoadPointData(element, "Power1");
-            SquareRootCurveControlPointData1 = LoadPointData(element, "SquareRoot1");
-            SquareRootCurveControlPointData2 = LoadPointData(element, "SquareRoot2");
-            GaussianCurveControlPointData1 = LoadPointData(element, "Gaussian1");
-            GaussianCurveControlPointData2 = LoadPointData(element, "Gaussian2");
-            GaussianCurveControlPointData3 = LoadPointData(element, "Gaussian3");
-            GaussianCurveControlPointData4 = LoadPointData(element, "Gaussian4");
+            switch (SelectedGraphType)
+            {
+                case GraphTypes.LinearCurve:
+                    LinearCurveControlPointData1 = LoadPointData(element, "Linear1");
+                    LinearCurveControlPointData2 = LoadPointData(element, "Linear2");
+                    break;
+                case GraphTypes.BezierCurve:
+                    BezierCurveControlPointData1 = LoadPointData(element, "Bezier1");
+                    BezierCurveControlPointData2 = LoadPointData(element, "Bezier2");
+                    BezierCurveControlPointData3 = LoadPointData(element, "Bezier3");
+                    BezierCurveControlPointData4 = LoadPointData(element, "Bezier4");
+                    break;
+                case GraphTypes.SineWave:
+                    SineWaveControlPointData1 = LoadPointData(element, "Sine1");
+                    SineWaveControlPointData2 = LoadPointData(element, "Sine2");
+                    break;
+                case GraphTypes.CosineWave:
+                    CosineWaveControlPointData1 = LoadPointData(element, "Cosine1");
+                    CosineWaveControlPointData2 = LoadPointData(element, "Cosine2");
+                    break;
+                case GraphTypes.ParabolicCurve:
+                    ParabolicCurveControlPointData1 = LoadPointData(element, "Parabolic1");
+                    ParabolicCurveControlPointData2 = LoadPointData(element, "Parabolic2");
+                    break;
+                case GraphTypes.PerlinNoiseCurve:
+                    PerlinNoiseControlPointData1 = LoadPointData(element, "Perlin1");
+                    PerlinNoiseControlPointData2 = LoadPointData(element, "Perlin2");
+                    PerlinNoiseControlPointData3 = LoadPointData(element, "Perlin3");
+                    break;
+                case GraphTypes.PowerCurve:
+                    PowerCurveControlPointData1 = LoadPointData(element, "Power1");
+                    break;
+                case GraphTypes.SquareRootCurve:
+                    SquareRootCurveControlPointData1 = LoadPointData(element, "SquareRoot1");
+                    SquareRootCurveControlPointData2 = LoadPointData(element, "SquareRoot2");
+                    break;
+                case GraphTypes.GaussianCurve:
+                    GaussianCurveControlPointData1 = LoadPointData(element, "Gaussian1");
+                    GaussianCurveControlPointData2 = LoadPointData(element, "Gaussian2");
+                    GaussianCurveControlPointData3 = LoadPointData(element, "Gaussian3");
+                    GaussianCurveControlPointData4 = LoadPointData(element, "Gaussian4");
+                    break;
+            }
 
             GenerateRenderValues();
         }
+
         private void SavePointData(XmlElement parent, string name, ControlPointData point)
         {
             if (point == null) return;
 
-            var ptElem = parent.OwnerDocument.CreateElement(name);
-            ptElem.SetAttribute("X", point.X.ToString());
-            ptElem.SetAttribute("Y", point.Y.ToString());
-            ptElem.SetAttribute("Tag", point.Tag ?? "");
-            parent.AppendChild(ptElem);
+            var pointElement = parent.OwnerDocument.CreateElement(name);
+            pointElement.SetAttribute("X", point.X.ToString());
+            pointElement.SetAttribute("Y", point.Y.ToString());
+            pointElement.SetAttribute("Tag", point.Tag ?? "");
+            parent.AppendChild(pointElement);
         }
 
         private ControlPointData LoadPointData(XmlElement parent, string name)

--- a/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
+++ b/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
@@ -1,4 +1,5 @@
 using DSCore.CurveMapper;
+using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -8,6 +9,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Xml;
 
 namespace CoreNodeModels
 {
@@ -943,6 +945,144 @@ namespace CoreNodeModels
             );
 
             return new[] { xValuesAssignment, yValuesAssignment, dataBridgeCall };
+        }
+
+        #endregion
+
+        #region Serialization/Deserialization Methods
+
+        protected override void SerializeCore(XmlElement element, SaveContext context)
+        {
+            base.SerializeCore(element, context);
+
+            element.SetAttribute("SelectedGraphType", SelectedGraphType.ToString());
+
+           
+
+            // Save only the points needed for the current curve
+            switch (SelectedGraphType)
+            {               
+                case GraphTypes.LinearCurve:
+                    SavePointData(element, "Linear1", LinearCurveControlPointData1);
+                    SavePointData(element, "Linear2", LinearCurveControlPointData2);
+                    break;
+                case GraphTypes.BezierCurve:
+                    SavePointData(element, "Bezier1", BezierCurveControlPointData1);
+                    SavePointData(element, "Bezier2", BezierCurveControlPointData2);
+                    SavePointData(element, "Bezier3", BezierCurveControlPointData3);
+                    SavePointData(element, "Bezier4", BezierCurveControlPointData4);
+                    break;
+                case GraphTypes.SineWave:
+                    SavePointData(element, "Sine1", SineWaveControlPointData1);
+                    SavePointData(element, "Sine2", SineWaveControlPointData2);
+                    break;
+                case GraphTypes.CosineWave:
+                    SavePointData(element, "Cosine1", CosineWaveControlPointData1);
+                    SavePointData(element, "Cosine2", CosineWaveControlPointData2);
+                    break;
+                case GraphTypes.ParabolicCurve:
+                    SavePointData(element, "Parabolic1", ParabolicCurveControlPointData1);
+                    SavePointData(element, "Parabolic2", ParabolicCurveControlPointData2);
+                    break;
+                case GraphTypes.PerlinNoiseCurve:
+                    SavePointData(element, "Perlin1", PerlinNoiseControlPointData1);
+                    SavePointData(element, "Perlin2", PerlinNoiseControlPointData2);
+                    SavePointData(element, "Perlin3", PerlinNoiseControlPointData3);
+                    break;
+                case GraphTypes.PowerCurve:
+                    SavePointData(element, "Power1", PowerCurveControlPointData1);
+                    break;
+                case GraphTypes.SquareRootCurve:
+                    SavePointData(element, "SquareRoot1", SquareRootCurveControlPointData1);
+                    SavePointData(element, "SquareRoot2", SquareRootCurveControlPointData2);
+                    break;
+                case GraphTypes.GaussianCurve:
+                    SavePointData(element, "Gaussian1", GaussianCurveControlPointData1);
+                    SavePointData(element, "Gaussian2", GaussianCurveControlPointData2);
+                    SavePointData(element, "Gaussian3", GaussianCurveControlPointData3);
+                    SavePointData(element, "Gaussian4", GaussianCurveControlPointData4);
+                    break;
+            }
+        }        
+
+        protected override void DeserializeCore(XmlElement element, SaveContext context)
+        {
+            base.DeserializeCore(element, context);
+
+            // Restore the selected graph type
+            var typeAttr = element.GetAttribute("SelectedGraphType");
+            if (!string.IsNullOrEmpty(typeAttr) && Enum.TryParse(typeAttr, out GraphTypes parsedType))
+            {
+                SelectedGraphType = parsedType;
+            }
+
+            switch (SelectedGraphType)
+            {                
+                case GraphTypes.LinearCurve:
+                    LinearCurveControlPointData1 = LoadPointData(element, "Linear1");
+                    LinearCurveControlPointData2 = LoadPointData(element, "Linear2");
+                    break;
+                case GraphTypes.BezierCurve:
+                    BezierCurveControlPointData1 = LoadPointData(element, "Bezier1");
+                    BezierCurveControlPointData2 = LoadPointData(element, "Bezier2");
+                    BezierCurveControlPointData3 = LoadPointData(element, "Bezier3");
+                    BezierCurveControlPointData4 = LoadPointData(element, "Bezier4");
+                    break;
+                case GraphTypes.SineWave:
+                    SineWaveControlPointData1 = LoadPointData(element, "Sine1");
+                    SineWaveControlPointData2 = LoadPointData(element, "Sine2");
+                    break;
+                case GraphTypes.CosineWave:
+                    CosineWaveControlPointData1 = LoadPointData(element, "Cosine1");
+                    CosineWaveControlPointData2 = LoadPointData(element, "Cosine2");
+                    break;
+                case GraphTypes.ParabolicCurve:
+                    ParabolicCurveControlPointData1 = LoadPointData(element, "Parabolic1");
+                    ParabolicCurveControlPointData2 = LoadPointData(element, "Parabolic2");
+                    break;
+                case GraphTypes.PerlinNoiseCurve:
+                    PerlinNoiseControlPointData1 = LoadPointData(element, "Perlin1");
+                    PerlinNoiseControlPointData2 = LoadPointData(element, "Perlin2");
+                    PerlinNoiseControlPointData3 = LoadPointData(element, "Perlin3");
+                    break;
+                case GraphTypes.PowerCurve:
+                    PowerCurveControlPointData1 = LoadPointData(element, "Power1");
+                    break;
+                case GraphTypes.SquareRootCurve:
+                    SquareRootCurveControlPointData1 = LoadPointData(element, "SquareRoot1");
+                    SquareRootCurveControlPointData2 = LoadPointData(element, "SquareRoot2");
+                    break;
+                case GraphTypes.GaussianCurve:
+                    GaussianCurveControlPointData1 = LoadPointData(element, "Gaussian1");
+                    GaussianCurveControlPointData2 = LoadPointData(element, "Gaussian2");
+                    GaussianCurveControlPointData3 = LoadPointData(element, "Gaussian3");
+                    GaussianCurveControlPointData4 = LoadPointData(element, "Gaussian4");
+                    break;
+            }
+
+            GenerateRenderValues();
+        }
+        private void SavePointData(XmlElement parent, string name, ControlPointData point)
+        {
+            if (point == null) return;
+
+            var ptElem = parent.OwnerDocument.CreateElement(name);
+            ptElem.SetAttribute("X", point.X.ToString());
+            ptElem.SetAttribute("Y", point.Y.ToString());
+            ptElem.SetAttribute("Tag", point.Tag ?? "");
+            parent.AppendChild(ptElem);
+        }
+
+        private ControlPointData LoadPointData(XmlElement parent, string name)
+        {
+            var node = parent[name];
+            if (node == null) return null;
+
+            double.TryParse(node.GetAttribute("X"), out var x);
+            double.TryParse(node.GetAttribute("Y"), out var y);
+            var tag = node.GetAttribute("Tag");
+
+            return new ControlPointData(x, y, tag);
         }
 
         #endregion

--- a/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
+++ b/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
@@ -957,52 +957,74 @@ namespace CoreNodeModels
 
             element.SetAttribute("SelectedGraphType", SelectedGraphType.ToString());
 
-           
-
+            //// Save only the points needed for the current curve
+            //switch (SelectedGraphType)
+            //{               
+            //    case GraphTypes.LinearCurve:
+            //        SavePointData(element, "Linear1", LinearCurveControlPointData1);
+            //        SavePointData(element, "Linear2", LinearCurveControlPointData2);
+            //        break;
+            //    case GraphTypes.BezierCurve:
+            //        SavePointData(element, "Bezier1", BezierCurveControlPointData1);
+            //        SavePointData(element, "Bezier2", BezierCurveControlPointData2);
+            //        SavePointData(element, "Bezier3", BezierCurveControlPointData3);
+            //        SavePointData(element, "Bezier4", BezierCurveControlPointData4);
+            //        break;
+            //    case GraphTypes.SineWave:
+            //        SavePointData(element, "Sine1", SineWaveControlPointData1);
+            //        SavePointData(element, "Sine2", SineWaveControlPointData2);
+            //        break;
+            //    case GraphTypes.CosineWave:
+            //        SavePointData(element, "Cosine1", CosineWaveControlPointData1);
+            //        SavePointData(element, "Cosine2", CosineWaveControlPointData2);
+            //        break;
+            //    case GraphTypes.ParabolicCurve:
+            //        SavePointData(element, "Parabolic1", ParabolicCurveControlPointData1);
+            //        SavePointData(element, "Parabolic2", ParabolicCurveControlPointData2);
+            //        break;
+            //    case GraphTypes.PerlinNoiseCurve:
+            //        SavePointData(element, "Perlin1", PerlinNoiseControlPointData1);
+            //        SavePointData(element, "Perlin2", PerlinNoiseControlPointData2);
+            //        SavePointData(element, "Perlin3", PerlinNoiseControlPointData3);
+            //        break;
+            //    case GraphTypes.PowerCurve:
+            //        SavePointData(element, "Power1", PowerCurveControlPointData1);
+            //        break;
+            //    case GraphTypes.SquareRootCurve:
+            //        SavePointData(element, "SquareRoot1", SquareRootCurveControlPointData1);
+            //        SavePointData(element, "SquareRoot2", SquareRootCurveControlPointData2);
+            //        break;
+            //    case GraphTypes.GaussianCurve:
+            //        SavePointData(element, "Gaussian1", GaussianCurveControlPointData1);
+            //        SavePointData(element, "Gaussian2", GaussianCurveControlPointData2);
+            //        SavePointData(element, "Gaussian3", GaussianCurveControlPointData3);
+            //        SavePointData(element, "Gaussian4", GaussianCurveControlPointData4);
+            //        break;
+            //}
             // Save only the points needed for the current curve
-            switch (SelectedGraphType)
-            {               
-                case GraphTypes.LinearCurve:
-                    SavePointData(element, "Linear1", LinearCurveControlPointData1);
-                    SavePointData(element, "Linear2", LinearCurveControlPointData2);
-                    break;
-                case GraphTypes.BezierCurve:
-                    SavePointData(element, "Bezier1", BezierCurveControlPointData1);
-                    SavePointData(element, "Bezier2", BezierCurveControlPointData2);
-                    SavePointData(element, "Bezier3", BezierCurveControlPointData3);
-                    SavePointData(element, "Bezier4", BezierCurveControlPointData4);
-                    break;
-                case GraphTypes.SineWave:
-                    SavePointData(element, "Sine1", SineWaveControlPointData1);
-                    SavePointData(element, "Sine2", SineWaveControlPointData2);
-                    break;
-                case GraphTypes.CosineWave:
-                    SavePointData(element, "Cosine1", CosineWaveControlPointData1);
-                    SavePointData(element, "Cosine2", CosineWaveControlPointData2);
-                    break;
-                case GraphTypes.ParabolicCurve:
-                    SavePointData(element, "Parabolic1", ParabolicCurveControlPointData1);
-                    SavePointData(element, "Parabolic2", ParabolicCurveControlPointData2);
-                    break;
-                case GraphTypes.PerlinNoiseCurve:
-                    SavePointData(element, "Perlin1", PerlinNoiseControlPointData1);
-                    SavePointData(element, "Perlin2", PerlinNoiseControlPointData2);
-                    SavePointData(element, "Perlin3", PerlinNoiseControlPointData3);
-                    break;
-                case GraphTypes.PowerCurve:
-                    SavePointData(element, "Power1", PowerCurveControlPointData1);
-                    break;
-                case GraphTypes.SquareRootCurve:
-                    SavePointData(element, "SquareRoot1", SquareRootCurveControlPointData1);
-                    SavePointData(element, "SquareRoot2", SquareRootCurveControlPointData2);
-                    break;
-                case GraphTypes.GaussianCurve:
-                    SavePointData(element, "Gaussian1", GaussianCurveControlPointData1);
-                    SavePointData(element, "Gaussian2", GaussianCurveControlPointData2);
-                    SavePointData(element, "Gaussian3", GaussianCurveControlPointData3);
-                    SavePointData(element, "Gaussian4", GaussianCurveControlPointData4);
-                    break;
-            }
+            SavePointData(element, "Linear1", LinearCurveControlPointData1);
+            SavePointData(element, "Linear2", LinearCurveControlPointData2);
+            SavePointData(element, "Bezier1", BezierCurveControlPointData1);
+            SavePointData(element, "Bezier2", BezierCurveControlPointData2);
+            SavePointData(element, "Bezier3", BezierCurveControlPointData3);
+            SavePointData(element, "Bezier4", BezierCurveControlPointData4);
+            SavePointData(element, "Sine1", SineWaveControlPointData1);
+            SavePointData(element, "Sine2", SineWaveControlPointData2);
+            SavePointData(element, "Cosine1", CosineWaveControlPointData1);
+            SavePointData(element, "Cosine2", CosineWaveControlPointData2);
+            SavePointData(element, "Parabolic1", ParabolicCurveControlPointData1);
+            SavePointData(element, "Parabolic2", ParabolicCurveControlPointData2);
+            SavePointData(element, "Perlin1", PerlinNoiseControlPointData1);
+            SavePointData(element, "Perlin2", PerlinNoiseControlPointData2);
+            SavePointData(element, "Perlin3", PerlinNoiseControlPointData3);
+            SavePointData(element, "Power1", PowerCurveControlPointData1);
+            SavePointData(element, "SquareRoot1", SquareRootCurveControlPointData1);
+            SavePointData(element, "SquareRoot2", SquareRootCurveControlPointData2);
+            SavePointData(element, "Gaussian1", GaussianCurveControlPointData1);
+            SavePointData(element, "Gaussian2", GaussianCurveControlPointData2);
+            SavePointData(element, "Gaussian3", GaussianCurveControlPointData3);
+            SavePointData(element, "Gaussian4", GaussianCurveControlPointData4);
+
         }        
 
         protected override void DeserializeCore(XmlElement element, SaveContext context)
@@ -1016,49 +1038,71 @@ namespace CoreNodeModels
                 SelectedGraphType = parsedType;
             }
 
-            switch (SelectedGraphType)
-            {                
-                case GraphTypes.LinearCurve:
-                    LinearCurveControlPointData1 = LoadPointData(element, "Linear1");
-                    LinearCurveControlPointData2 = LoadPointData(element, "Linear2");
-                    break;
-                case GraphTypes.BezierCurve:
-                    BezierCurveControlPointData1 = LoadPointData(element, "Bezier1");
-                    BezierCurveControlPointData2 = LoadPointData(element, "Bezier2");
-                    BezierCurveControlPointData3 = LoadPointData(element, "Bezier3");
-                    BezierCurveControlPointData4 = LoadPointData(element, "Bezier4");
-                    break;
-                case GraphTypes.SineWave:
-                    SineWaveControlPointData1 = LoadPointData(element, "Sine1");
-                    SineWaveControlPointData2 = LoadPointData(element, "Sine2");
-                    break;
-                case GraphTypes.CosineWave:
-                    CosineWaveControlPointData1 = LoadPointData(element, "Cosine1");
-                    CosineWaveControlPointData2 = LoadPointData(element, "Cosine2");
-                    break;
-                case GraphTypes.ParabolicCurve:
-                    ParabolicCurveControlPointData1 = LoadPointData(element, "Parabolic1");
-                    ParabolicCurveControlPointData2 = LoadPointData(element, "Parabolic2");
-                    break;
-                case GraphTypes.PerlinNoiseCurve:
-                    PerlinNoiseControlPointData1 = LoadPointData(element, "Perlin1");
-                    PerlinNoiseControlPointData2 = LoadPointData(element, "Perlin2");
-                    PerlinNoiseControlPointData3 = LoadPointData(element, "Perlin3");
-                    break;
-                case GraphTypes.PowerCurve:
-                    PowerCurveControlPointData1 = LoadPointData(element, "Power1");
-                    break;
-                case GraphTypes.SquareRootCurve:
-                    SquareRootCurveControlPointData1 = LoadPointData(element, "SquareRoot1");
-                    SquareRootCurveControlPointData2 = LoadPointData(element, "SquareRoot2");
-                    break;
-                case GraphTypes.GaussianCurve:
-                    GaussianCurveControlPointData1 = LoadPointData(element, "Gaussian1");
-                    GaussianCurveControlPointData2 = LoadPointData(element, "Gaussian2");
-                    GaussianCurveControlPointData3 = LoadPointData(element, "Gaussian3");
-                    GaussianCurveControlPointData4 = LoadPointData(element, "Gaussian4");
-                    break;
-            }
+            //switch (SelectedGraphType)
+            //{                
+            //    case GraphTypes.LinearCurve:
+            //        LinearCurveControlPointData1 = LoadPointData(element, "Linear1");
+            //        LinearCurveControlPointData2 = LoadPointData(element, "Linear2");
+            //        break;
+            //    case GraphTypes.BezierCurve:
+            //        BezierCurveControlPointData1 = LoadPointData(element, "Bezier1");
+            //        BezierCurveControlPointData2 = LoadPointData(element, "Bezier2");
+            //        BezierCurveControlPointData3 = LoadPointData(element, "Bezier3");
+            //        BezierCurveControlPointData4 = LoadPointData(element, "Bezier4");
+            //        break;
+            //    case GraphTypes.SineWave:
+            //        SineWaveControlPointData1 = LoadPointData(element, "Sine1");
+            //        SineWaveControlPointData2 = LoadPointData(element, "Sine2");
+            //        break;
+            //    case GraphTypes.CosineWave:
+            //        CosineWaveControlPointData1 = LoadPointData(element, "Cosine1");
+            //        CosineWaveControlPointData2 = LoadPointData(element, "Cosine2");
+            //        break;
+            //    case GraphTypes.ParabolicCurve:
+            //        ParabolicCurveControlPointData1 = LoadPointData(element, "Parabolic1");
+            //        ParabolicCurveControlPointData2 = LoadPointData(element, "Parabolic2");
+            //        break;
+            //    case GraphTypes.PerlinNoiseCurve:
+            //        PerlinNoiseControlPointData1 = LoadPointData(element, "Perlin1");
+            //        PerlinNoiseControlPointData2 = LoadPointData(element, "Perlin2");
+            //        PerlinNoiseControlPointData3 = LoadPointData(element, "Perlin3");
+            //        break;
+            //    case GraphTypes.PowerCurve:
+            //        PowerCurveControlPointData1 = LoadPointData(element, "Power1");
+            //        break;
+            //    case GraphTypes.SquareRootCurve:
+            //        SquareRootCurveControlPointData1 = LoadPointData(element, "SquareRoot1");
+            //        SquareRootCurveControlPointData2 = LoadPointData(element, "SquareRoot2");
+            //        break;
+            //    case GraphTypes.GaussianCurve:
+            //        GaussianCurveControlPointData1 = LoadPointData(element, "Gaussian1");
+            //        GaussianCurveControlPointData2 = LoadPointData(element, "Gaussian2");
+            //        GaussianCurveControlPointData3 = LoadPointData(element, "Gaussian3");
+            //        GaussianCurveControlPointData4 = LoadPointData(element, "Gaussian4");
+            //        break;
+            //}
+            LinearCurveControlPointData1 = LoadPointData(element, "Linear1");
+            LinearCurveControlPointData2 = LoadPointData(element, "Linear2");
+            BezierCurveControlPointData1 = LoadPointData(element, "Bezier1");
+            BezierCurveControlPointData2 = LoadPointData(element, "Bezier2");
+            BezierCurveControlPointData3 = LoadPointData(element, "Bezier3");
+            BezierCurveControlPointData4 = LoadPointData(element, "Bezier4");
+            SineWaveControlPointData1 = LoadPointData(element, "Sine1");
+            SineWaveControlPointData2 = LoadPointData(element, "Sine2");
+            CosineWaveControlPointData1 = LoadPointData(element, "Cosine1");
+            CosineWaveControlPointData2 = LoadPointData(element, "Cosine2");
+            ParabolicCurveControlPointData1 = LoadPointData(element, "Parabolic1");
+            ParabolicCurveControlPointData2 = LoadPointData(element, "Parabolic2");
+            PerlinNoiseControlPointData1 = LoadPointData(element, "Perlin1");
+            PerlinNoiseControlPointData2 = LoadPointData(element, "Perlin2");
+            PerlinNoiseControlPointData3 = LoadPointData(element, "Perlin3");
+            PowerCurveControlPointData1 = LoadPointData(element, "Power1");
+            SquareRootCurveControlPointData1 = LoadPointData(element, "SquareRoot1");
+            SquareRootCurveControlPointData2 = LoadPointData(element, "SquareRoot2");
+            GaussianCurveControlPointData1 = LoadPointData(element, "Gaussian1");
+            GaussianCurveControlPointData2 = LoadPointData(element, "Gaussian2");
+            GaussianCurveControlPointData3 = LoadPointData(element, "Gaussian3");
+            GaussianCurveControlPointData4 = LoadPointData(element, "Gaussian4");
 
             GenerateRenderValues();
         }

--- a/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
+++ b/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
@@ -957,6 +957,7 @@ namespace CoreNodeModels
 
             element.SetAttribute(nameof(SelectedGraphType), SelectedGraphType.ToString());
             element.SetAttribute(nameof(IsLocked), IsLocked.ToString());
+            element.SetAttribute(nameof(DynamicCanvasSize), DynamicCanvasSize.ToString());
 
             // Save only the points needed for the current curve
             switch (SelectedGraphType)
@@ -1011,13 +1012,13 @@ namespace CoreNodeModels
             // Restore the selected graph type
             var typeAttr = element.GetAttribute(nameof(SelectedGraphType));
             if (!string.IsNullOrEmpty(typeAttr) && Enum.TryParse(typeAttr, out GraphTypes parsedType))
-            {
                 SelectedGraphType = parsedType;
-            }
+
             if (bool.TryParse(element.GetAttribute(nameof(IsLocked)), out var locked))
-            {
                 IsLocked = locked;
-            }
+
+            if (double.TryParse(element.GetAttribute(nameof(DynamicCanvasSize)), out var canvasSize))
+                DynamicCanvasSize = canvasSize;
 
             switch (SelectedGraphType)
             {
@@ -1064,6 +1065,7 @@ namespace CoreNodeModels
             }
 
             GenerateRenderValues();
+            RaisePropertyChanged("ControlPointsDeserialized");
         }
 
         private void SavePointData(XmlElement parent, string name, ControlPointData point)

--- a/src/Libraries/CoreNodeModelsWpf/CurveMapper/CurveMapperControl.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/CurveMapper/CurveMapperControl.xaml.cs
@@ -69,6 +69,32 @@ namespace Dynamo.Wpf.CurveMapper
         /// </summary>
         public event PropertyChangedEventHandler PropertyChanged;
 
+        [Obsolete("Use the overload with NodeViewModel.")]
+        public CurveMapperControl(CurveMapperNodeModel model, double canvasSize)
+        {
+            InitializeComponent();
+            this.curveMapperNodeModel = model;
+            DataContext = model;
+
+            Width = canvasSize + controlLabelsWidth;
+            Height = canvasSize + controlLabelsHeight;
+
+
+            model.PropertyChanged += NodeModel_PropertyChanged;
+            this.Unloaded += Unload;
+
+            DrawGrid();
+
+            // Dictionary to map UI control points to their corresponding data
+            var controlPointsMap = BuildControlPointsDictionary();
+            RecreateControlPoints(controlPointsMap);
+
+            RenderCurve();
+
+            ToggleControlPointsLock();
+            UpdateLockButton();
+        }
+
         public CurveMapperControl(CurveMapperNodeModel model, double canvasSize, NodeViewModel nodeViewModel)
         {
             InitializeComponent();

--- a/src/Libraries/CoreNodeModelsWpf/CurveMapper/CurveMapperControl.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/CurveMapper/CurveMapperControl.xaml.cs
@@ -243,6 +243,13 @@ namespace Dynamo.Wpf.CurveMapper
             {
                 UpdateGaussianControlPoint(gaussianCurveControlPoint4, curveMapperNodeModel.GaussianCurveControlPointData4);
             }
+
+            if (e.PropertyName == "ControlPointsDeserialized")
+            {
+                var controlPointsMap = BuildControlPointsDictionary();
+                RecreateControlPoints(controlPointsMap);
+                RenderCurve();
+            }
         }
 
         private void Unload(object sender, RoutedEventArgs e)

--- a/src/Libraries/CoreNodeModelsWpf/CurveMapper/CurveMapperNodeView.cs
+++ b/src/Libraries/CoreNodeModelsWpf/CurveMapper/CurveMapperNodeView.cs
@@ -11,7 +11,7 @@ namespace Dynamo.Wpf.CurveMapper
         public void CustomizeView(CurveMapperNodeModel model, NodeView nodeView)
         {
             curveMapperNodeModel = model;
-            curveMapperControl = new CurveMapperControl(model, model.DynamicCanvasSize);
+            curveMapperControl = new CurveMapperControl(model, model.DynamicCanvasSize, nodeView.ViewModel);
             curveMapperControl.DataContext = model;
             curveMapperNodeModel = model;
 


### PR DESCRIPTION
### Purpose

This PR aims to address [DYN-8661](https://jira.autodesk.com/browse/DYN-8661). When the user copies the Curve Mapper node, the following state is now correctly preserved:
- The selected curve type
- The control points for the selected curve
- The lock state of the node
- The node size

- Also removes a duplicate call to GenerateRenderValues() from the control view. Now handled inside the SelectedGraphType setter.

![DYN-8661-Proposal](https://github.com/user-attachments/assets/3a360c0c-5917-4724-b591-dcf1dd3c46ea)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

When the user copies the Curve Mapper node, the following state is now correctly preserved:
- The selected curve type
- The control points for the selected curve
- The lock state of the node
- The node size

### Reviewers
@reddyashish 
@zeusongit 

### FYIs
@dnenov 
@achintyabhat 
