### PR TITLE
DYN-8558 - Set Entry Connector to "IsConnecting" While Cluster Prediction In Progress

### DIFF
--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -163,7 +163,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             }
             set
             {
-                if (selectedIndex != value && value >= 0)
+                if(selectedIndex != value && value >= 0)
                 {
                     ReAddNode(value);
                 }
@@ -177,12 +177,12 @@ namespace Dynamo.NodeAutoComplete.ViewModels
 
         private void ReAddNode(int index)
         {
-            if (FullResults == null)
+            if(FullResults == null)
             {
                 return;
             }
             var results = QualifiedResults.ToList();
-            if (index >= 0 && index < results.Count)
+            if(index >= 0 && index < results.Count)
             {
                 AddCluster(results[index]);
             }

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -883,7 +883,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             });
 
             // Connect the cluster to the original node and port
-            if (targetNodeFromCluster.InPorts.Any())
+            if (targetNodeFromCluster.InPorts.Any() && wsViewModel.Connectors.Any())
             {
                 var newConnector = ConnectorModel.Make(node.NodeModel, targetNodeFromCluster.NodeModel, 0,
                     ClusterResultItem.EntryNodeInPort);

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -832,8 +832,8 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             List<List<NodeItem>> nodeStacks = NodeAutoCompleteUtilities.ComputeNodePlacementHeuristics(clusterConnections, clusterNodes);
 
             //node to connect to from query node
-            var entryNodeId = ClusterResultItem.Topology.Nodes.ToList()[ClusterResultItem.EntryNodeIndex].Id;
-
+            var entryNodeId = ClusterResultItem.Topology.Nodes.Any() ? ClusterResultItem.Topology.Nodes.ToList()[ClusterResultItem.EntryNodeIndex].Id : string.Empty;
+            
             //store our nodes and wires to allow for one undo
             List<ModelBase> newNodesAndWires = new List<ModelBase>();
             Dictionary<string, NodeViewModel> createdNodes = new Dictionary<string, NodeViewModel>();
@@ -863,7 +863,10 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                 }
             }
 
-            targetNodeFromCluster = createdNodes[entryNodeId];
+            if (createdNodes.Any())
+            {
+                targetNodeFromCluster = createdNodes[entryNodeId];
+            }
 
             clusterConnections.ForEach(connection =>
             {
@@ -884,7 +887,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             });
 
             // Connect the cluster to the original node and port
-            if (targetNodeFromCluster.InPorts.Any() && wsViewModel.Connectors.Any())
+            if (targetNodeFromCluster != null && targetNodeFromCluster.InPorts.Any() && wsViewModel.Connectors.Any())
             {
                 var newConnector = ConnectorModel.Make(node.NodeModel, targetNodeFromCluster.NodeModel, 0,
                     ClusterResultItem.EntryNodeInPort);

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -885,25 +885,20 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             // Connect the cluster to the original node and port
             if (targetNodeFromCluster.InPorts.Any())
             {
-                dynamoViewModel.Model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(node.NodeModel.GUID, 0,
-                    PortType.Output, DynamoModel.MakeConnectionCommand.Mode.Begin));
-                dynamoViewModel.Model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(targetNodeFromCluster.NodeModel.GUID, ClusterResultItem.EntryNodeInPort,
-                    PortType.Input, DynamoModel.MakeConnectionCommand.Mode.End));
+                var newConnector = ConnectorModel.Make(node.NodeModel, targetNodeFromCluster.NodeModel, 0,
+                    ClusterResultItem.EntryNodeInPort);
 
                 var lastConnector = wsViewModel.Connectors.Last();
 
                 //check if the last connector is the one we just made
-                if (lastConnector.ConnectorModel.Start.Owner.GUID.Equals(node.NodeModel.GUID))
+                if (lastConnector.ConnectorModel.GUID.Equals(newConnector.GUID))
                 {
-                    //remove the connector creation from undo, we handle that below
-                    wsViewModel.Model.UndoRecorder.PopFromUndoGroup();
-
                     //set connector to be connecting until complete
                     lastConnector.IsConnecting = true;
-                    newNodesAndWires.Add(lastConnector.ConnectorModel);
+                    newNodesAndWires.Add(newConnector);
                 }
             }
-            
+
             // Make connectors invisible ( just like the cluster nodes ) before they get a chance to be drawn.
             var clusterNodesModel = clusterMapping.Values.ToList();
             clusterNodesModel.ForEach(nodeInCluster => nodeInCluster?.NodeModel?.AllConnectors?.ToList().ForEach(connector =>

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -425,7 +425,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
 
                 if (startNode.Equals(nodeInfo) || endNode.Equals(nodeInfo) || upstreamAndDownstreamNodes.Contains(startNode) || upstreamAndDownstreamNodes.Contains(endNode))
                 {
-                    var startPortName = (startNode is VariableInputNode || startNode is DSVarArgFunction) ? ParseVariableInputPortName(connector.Start.Name) : connector.Start.Name;
+                    var startPortName = (startNode is VariableInputNode || startNode is DSVarArgFunction) ? ParseVariableInputPortName(connector.Start.Name): connector.Start.Name;
                     var endPortName = (endNode is VariableInputNode || endNode is DSVarArgFunction) ? ParseVariableInputPortName(connector.End.Name) : connector.End.Name;
 
                     var connectorRequest = new ConnectionItem
@@ -611,13 +611,13 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                 {
                     var uri = DynamoUtilities.PathHelper.GetServiceBackendAddress(this, nodeAutocompleteMLEndpoint);
                     var client = new RestClient(uri);
-                    var request = new RestRequest(string.Empty, Method.Post);
+                    var request = new RestRequest(string.Empty,Method.Post);
                     var tkn = tokenprovider?.GetAccessToken();
                     if (string.IsNullOrEmpty(tkn))
                     {
                         throw new Exception("Authentication required.");
                     }
-                    request.AddHeader("Authorization", $"Bearer {tkn}");
+                    request.AddHeader("Authorization",$"Bearer {tkn}");
                     request = request.AddJsonBody(requestJSON);
                     request.RequestFormat = DataFormat.Json;
                     RestResponse response = client.Execute(request);
@@ -838,7 +838,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             foreach (var nodeStack in nodeStacks)
             {
                 xoffset += node.NodeModel.Width;
-                foreach (var newNode in nodeStack)
+                foreach(var newNode in nodeStack)
                 {
                     // Retrieve assembly name and node full name from type.id.
                     var typeInfo = wsViewModel.NodeAutoCompleteSearchViewModel.GetInfoFromTypeId(newNode.Type.Id);

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -919,7 +919,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             NodeAutoCompleteUtilities.PostAutoLayoutNodes(wsViewModel.DynamoViewModel.CurrentSpace, node.NodeModel, clusterNodesModel.Select(x => x.NodeModel), false, false, false, finalizer);
 
             //record all node and wire creation as one undo
-            DynamoModel.RecordUndoModels(wsViewModel.Model, newNodesAndWires);
+            DynamoModel.RecordUndoModels(wsViewModel.Model, newNodesAndWires.Where(n => n != null).ToList());
         }
 
         /// <summary>

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -883,17 +883,25 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             });
 
             // Connect the cluster to the original node and port
-            dynamoViewModel.Model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(node.NodeModel.GUID, 0,
-                PortType.Output, DynamoModel.MakeConnectionCommand.Mode.Begin));
-            dynamoViewModel.Model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(targetNodeFromCluster.NodeModel.GUID, ClusterResultItem.EntryNodeInPort,
-                PortType.Input, DynamoModel.MakeConnectionCommand.Mode.End));
-            //remove the connector creation from undo, we handle that below
-            wsViewModel.Model.UndoRecorder.PopFromUndoGroup();
+            try
+            {
+                dynamoViewModel.Model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(node.NodeModel.GUID, 0,
+                    PortType.Output, DynamoModel.MakeConnectionCommand.Mode.Begin));
+                dynamoViewModel.Model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(targetNodeFromCluster.NodeModel.GUID, ClusterResultItem.EntryNodeInPort,
+                    PortType.Input, DynamoModel.MakeConnectionCommand.Mode.End));
+                //remove the connector creation from undo, we handle that below
+                wsViewModel.Model.UndoRecorder.PopFromUndoGroup();
 
-            //set connector to be connecting until complete
-            var lastConnector = wsViewModel.Connectors.Last();
-            lastConnector.IsConnecting = true;
-            newNodesAndWires.Add(lastConnector.ConnectorModel);
+                //set connector to be connecting until complete
+                var lastConnector = wsViewModel.Connectors.Last();
+                lastConnector.IsConnecting = true;
+                newNodesAndWires.Add(lastConnector.ConnectorModel);
+            }
+            catch (Exception e)
+            {
+                //ignore for now as we need to work out the cluster predictions as the wrong targetNode is reported sometimes.
+            }
+
 
             // Make connectors invisible ( just like the cluster nodes ) before they get a chance to be drawn.
             var clusterNodesModel = clusterMapping.Values.ToList();

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -182,7 +182,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                 return;
             }
             var results = QualifiedResults.ToList();
-            if(index >= 0 && index < results.Count)
+            if(index >=  0 && index  < results.Count)
             {
                 AddCluster(results[index]);
             }


### PR DESCRIPTION
### Purpose
This switches the connector to be created with recordable commands instead of ConnectorModel.Make, to be able to get the `ConnectorViewModel` from the workspace. This allows for the connector to be ghosted via the "`IsConnecting`" property on the `ConnectorViewModel`.

This _helps_ a little bit with the executing of the cluster results as well.

![image](https://github.com/user-attachments/assets/174311b3-a1ff-4172-a272-8014cd1578d5)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers
@BogdanZavu @QilongTang @chubakueno 

### FYIs
@jnealb @Amoursol 
