### PR TITLE
[DYN-8546] Curve Mapper: Add Info bubble

### DIFF
--- a/doc/distrib/xml/en-US/DSCoreNodes.xml
+++ b/doc/distrib/xml/en-US/DSCoreNodes.xml
@@ -2187,7 +2187,7 @@
         </member>
         <member name="P:DSCore.Properties.Resources.CurveMapperEqualMinMaxWarning">
             <summary>
-              Looks up a localized string similar to • Min and Max values must not be the same..
+              Looks up a localized string similar to • Min and Max values must be different..
             </summary>
         </member>
         <member name="P:DSCore.Properties.Resources.CurveMapperInvalidCountWarning">

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1766,8 +1766,6 @@ namespace Dynamo.Graph.Nodes
         /// </summary>
         public virtual void ClearInfoMessages()
         {
-            var c1 = State; // active!
-
             // It is very unlikely a node could be in both info state and persistent info state from the current design
             // If that exception happens, we should redesign this function or have particular node override the behavior
             if (State == ElementState.Info)

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1748,6 +1748,10 @@ namespace Dynamo.Graph.Nodes
             // If persistent info is still present, ensure it is reflected in the node state
             if (Infos.Any(x => x.State == ElementState.PersistentInfo))
             {
+                // Ensure state reflects PersistentInfo if any such messages remain.
+                // Prevents info from being stuck or skipped in future updates.
+                // Without this, ClearInfoMessages won't remove them properly.
+                State = ElementState.PersistentInfo;
                 OnNodeWarningMessagesClearing();
             }
             else
@@ -1922,41 +1926,6 @@ namespace Dynamo.Graph.Nodes
         /// <param name="p">The info text.</param>
         /// <param name="isPersistent">Is the info persistent? If true, the info will not be
         /// cleared when the node is next evaluated. If false, the info will be cleared on the next evaluation.</param>
-        //public void Info(string p, bool isPersistent = false)
-        //{
-        //    var initialState = State;
-
-        //    if (isPersistent)
-        //    {
-        //        if (!Infos.Any(x => x.Message.Equals(p) && x.State == ElementState.PersistentInfo))
-        //        {
-        //            State = ElementState.PersistentInfo;
-        //            infos.Add(new Info(p, ElementState.PersistentInfo));
-        //        }
-        //    }
-        //    else
-        //    {
-        //        State = ElementState.Info;
-        //        infos.Add(new Info(p, ElementState.Info));
-        //    }
-
-        //    // Preserve more critical states such as Warning, PersistentWarning, or Error.
-        //    // We don't want to downgrade the node visually or functionally if it already has
-        //    // more important issues that should take precedence over an informational message.
-        //    if (initialState == ElementState.Warning ||
-        //        initialState == ElementState.PersistentWarning ||
-        //        initialState == ElementState.Error)
-        //    {
-        //        State = initialState;
-        //    }
-        //    // ip test
-        //    if (initialState == ElementState.Active)
-        //    {
-        //        State = ElementState.Info;
-        //    }
-
-        //    var c1 = State;
-        //}
         public void Info(string p, bool isPersistent = false)
         {
             var initialState = State;
@@ -1965,27 +1934,24 @@ namespace Dynamo.Graph.Nodes
             {
                 if (!Infos.Any(x => x.Message.Equals(p) && x.State == ElementState.PersistentInfo))
                 {
+                    State = ElementState.PersistentInfo;
                     infos.Add(new Info(p, ElementState.PersistentInfo));
-
-                    // Only set state if it's not already something more critical
-                    if (initialState != ElementState.Warning &&
-                        initialState != ElementState.PersistentWarning &&
-                        initialState != ElementState.Error)
-                    {
-                        State = ElementState.PersistentInfo;
-                    }
                 }
             }
             else
             {
+                State = ElementState.Info;
                 infos.Add(new Info(p, ElementState.Info));
+            }
 
-                if (initialState != ElementState.Warning &&
-                    initialState != ElementState.PersistentWarning &&
-                    initialState != ElementState.Error)
-                {
-                    State = ElementState.Info;
-                }
+            // Preserve more critical states such as Warning, PersistentWarning, or Error.
+            // We don't want to downgrade the node visually or functionally if it already has
+            // more important issues that should take precedence over an informational message.
+            if (initialState == ElementState.Warning ||
+                initialState == ElementState.PersistentWarning ||
+                initialState == ElementState.Error)
+            {
+                State = initialState;
             }
         }
 

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -1016,6 +1016,7 @@ Dynamo.Graph.Nodes.NodeModel.NodeInfos.get -> System.Collections.Generic.List<Dy
 Dynamo.Graph.Nodes.NodeModel.NodeMessagesClearing -> System.Action<Dynamo.Graph.Nodes.NodeModel>
 Dynamo.Graph.Nodes.NodeModel.NodeModel() -> void
 Dynamo.Graph.Nodes.NodeModel.NodeModel(System.Collections.Generic.IEnumerable<Dynamo.Graph.Nodes.PortModel> inPorts, System.Collections.Generic.IEnumerable<Dynamo.Graph.Nodes.PortModel> outPorts) -> void
+Dynamo.Graph.Nodes.NodeModel.NodeWarningMessagesClearing -> System.Action<Dynamo.Graph.Nodes.NodeModel>
 Dynamo.Graph.Nodes.NodeModel.NotifyAstBuildBroken(string p) -> void
 Dynamo.Graph.Nodes.NodeModel.OutPorts.get -> System.Collections.ObjectModel.ObservableCollection<Dynamo.Graph.Nodes.PortModel>
 Dynamo.Graph.Nodes.NodeModel.OutputNodes.get -> System.Collections.Generic.IDictionary<int, System.Collections.Generic.HashSet<System.Tuple<int, Dynamo.Graph.Nodes.NodeModel>>>

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -942,6 +942,7 @@ namespace Dynamo.ViewModels
             }
             logic.NodeMessagesClearing += Logic_NodeMessagesClearing;
             logic.NodeInfoMessagesClearing += Logic_NodeInfoMessagesClearing;
+            logic.NodeWarningMessagesClearing += Logic_NodeWarningMessagesClearing;
 
             logic_PropertyChanged(this, new PropertyChangedEventArgs(nameof(IsVisible)));
             UpdateBubbleContent();
@@ -1030,6 +1031,36 @@ namespace Dynamo.ViewModels
             }
         }
 
+        /// <summary>
+        /// Clears only warning messages from the node's info bubble, preserving any existing info messages.
+        /// </summary>
+        /// <param name="obj"></param>
+        private void Logic_NodeWarningMessagesClearing(NodeModel obj)
+        {
+            if (ErrorBubble == null) return;
+
+            var warningsToRemove = ErrorBubble.NodeMessages.Where(x => x.Style == InfoBubbleViewModel.Style.Warning).ToList();
+
+            if (DynamoViewModel.UIDispatcher != null)
+            {
+                DynamoViewModel.UIDispatcher.Invoke(() =>
+                {
+                    foreach (var itemToRemove in warningsToRemove)
+                    {
+                        ErrorBubble.NodeMessages.Remove(itemToRemove);
+                    }
+                });
+            }
+            else
+            {
+                foreach (var itemToRemove in warningsToRemove)
+                {
+                    ErrorBubble.NodeMessages.Remove(itemToRemove);
+                }
+            }
+            return;
+        }
+
         private void DismissedNodeMessages_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             if (!(sender is ObservableCollection<InfoBubbleDataPacket> observableCollection)) return;
@@ -1087,7 +1118,8 @@ namespace Dynamo.ViewModels
 
             NodeModel.NodeMessagesClearing -= Logic_NodeMessagesClearing;
             NodeModel.NodeInfoMessagesClearing -= Logic_NodeInfoMessagesClearing;
-            
+            NodeModel.NodeWarningMessagesClearing -= Logic_NodeWarningMessagesClearing;
+
             if (ErrorBubble != null) DisposeErrorBubble();
 
             DynamoSelection.Instance.Selection.CollectionChanged -= SelectionOnCollectionChanged;

--- a/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
+++ b/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
@@ -24,8 +24,6 @@ namespace CoreNodeModels
         private double maxLimitY = 1;
         private List<Double> pointsCount = new List<double>() { 10.0 };
 
-        private List<double> outputValuesY;
-        private List<double> outputValuesX;
         private List<double> renderValuesY;
         private List<double> renderValuesX;
 
@@ -448,10 +446,11 @@ namespace CoreNodeModels
                 OnNodeModified();
                 return;
             }
-            if(!IsResizing)
-            {
-                ClearErrorsAndWarnings();
-            }
+            //// DO WE NEED THSI?
+            //if(!IsResizing)
+            //{
+            //    ClearErrorsAndWarnings();
+            //}
 
             object curve = null;
 
@@ -526,16 +525,18 @@ namespace CoreNodeModels
                     break;
             }
 
-            if (curve is not null)
+            if (curve is CurveBase dynamicCurve)
             {
-                dynamic dynamicCurve = curve;
                 RenderValuesX = dynamicCurve.GetCurveXValues(PointsCount, true);
                 RenderValuesY = dynamicCurve.GetCurveYValues(PointsCount, true);
 
+                if (dynamicCurve.IsYOutOfRange)
+                    Info(Properties.Resources.CurveMapperInfoMessage, true);
+                else
+                    ClearInfoMessages();
+
                 if (!IsResizing)
-                {
                     OnNodeModified();
-                }
             }
         }
 

--- a/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
+++ b/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
@@ -446,11 +446,6 @@ namespace CoreNodeModels
                 OnNodeModified();
                 return;
             }
-            //// DO WE NEED THSI?
-            //if(!IsResizing)
-            //{
-            //    ClearErrorsAndWarnings();
-            //}
 
             object curve = null;
 

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -297,6 +297,15 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to When mapping numbers along the curve, some Y values fall outside the specified Y-value domain range..
+        /// </summary>
+        public static string CurveMapperInfoMessage {
+            get {
+                return ResourceManager.GetString("CurveMapperInfoMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to graph;curve;mapper;math.
         /// </summary>
         public static string CurveMapperSearchTags {

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -748,4 +748,7 @@ double[]</value>
   <data name="ColorPalettePortDataResultToolTip" xml:space="preserve">
     <value>Selected color</value>
   </data>
+  <data name="CurveMapperInfoMessage" xml:space="preserve">
+    <value>When mapping numbers along the curve, some Y values fall outside the specified Y-value domain range.</value>
+  </data>
 </root>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -748,4 +748,7 @@ double[]</value>
   <data name="ColorPalettePortDataResultToolTip" xml:space="preserve">
     <value>Selected color</value>
   </data>
+  <data name="CurveMapperInfoMessage" xml:space="preserve">
+    <value>When mapping numbers along the curve, some Y values fall outside the specified Y-value domain range.</value>
+  </data>
 </root>

--- a/src/Libraries/CoreNodes/CurveMapper/CurveBase.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/CurveBase.cs
@@ -16,6 +16,13 @@ namespace DSCore.CurveMapper
         protected double CanvasSize;
         protected const double renderIncrementX = 1.0;
 
+        private bool isYOutOfRange;
+        public bool IsYOutOfRange
+        {
+            get => isYOutOfRange;
+            set => isYOutOfRange = value;
+        }
+
         protected CurveBase(double canvasSize)
         {
             CanvasSize = canvasSize;

--- a/src/Libraries/CoreNodes/CurveMapper/GaussianCurve.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/GaussianCurve.cs
@@ -64,6 +64,8 @@ namespace DSCore.CurveMapper
 
             if (isRender)
             {
+                IsYOutOfRange = A > CanvasSize;
+
                 for (double x = 0; x <= ControlPoint2X; x += renderIncrementX)
                 {
                     double y = CanvasSize - ComputeGaussianY(x, A, mu, sigma);

--- a/src/Libraries/CoreNodes/CurveMapper/LinearCurve.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/LinearCurve.cs
@@ -74,6 +74,8 @@ namespace DSCore.CurveMapper
 
             if (isRender)
             {
+                IsYOutOfRange = (lowY < 0 || lowY > CanvasSize || highY < 0 || highY > CanvasSize);
+
                 valuesX = new List<double> { System.Math.Clamp(leftX, 0, CanvasSize), System.Math.Clamp(rightX, 0, CanvasSize) };
 
                 valuesY = (flipHorizontally ^ flipVertically)

--- a/src/Libraries/CoreNodes/CurveMapper/ParabolicCurve.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/ParabolicCurve.cs
@@ -60,6 +60,8 @@ namespace DSCore.CurveMapper
                 double minX = Math.Max(0, Math.Min(startX, endX));
                 double maxX = Math.Min(CanvasSize, Math.Max(startX, endX));
 
+                IsYOutOfRange = minX > 0 || maxX < CanvasSize;
+
                 // First point
                 double firstY = SolveParabolaForY(minX);
 

--- a/src/Libraries/CoreNodes/CurveMapper/PerlinNoiseCurve.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/PerlinNoiseCurve.cs
@@ -167,6 +167,7 @@ namespace DSCore.CurveMapper
         {
             var valuesX = new List<double>();
             var valuesY = new List<double>();
+            bool outOfRange = false;
 
             double scalingFactor = CanvasSize / initialWidth;
             scale = (CanvasSize - ControlPoint1X) / (CanvasSize * 3.0);
@@ -184,7 +185,13 @@ namespace DSCore.CurveMapper
                         valuesX.Add(x);
                         valuesY.Add(y);
                     }
+                    else
+                    {
+                        outOfRange = true;
+                    }
                 }
+
+                IsYOutOfRange = outOfRange;
 
                 // Add the intersection points & sort the values
                 var intersectionValuesX = GetBoundaryIntersections();

--- a/src/Libraries/CoreNodes/CurveMapper/SquareRootCurve.cs
+++ b/src/Libraries/CoreNodes/CurveMapper/SquareRootCurve.cs
@@ -64,6 +64,7 @@ namespace DSCore.CurveMapper
         {
             var valuesX = new List<double>();
             var valuesY = new List<double>();
+            bool outOfRange = false;
 
             double sqrtFactor = ComputeSquareRootFactor();
 
@@ -92,7 +93,13 @@ namespace DSCore.CurveMapper
                         valuesX.Add(x);
                         valuesY.Add(y);
                     }
+                    else
+                    {
+                        outOfRange = true;
+                    }
                 }
+
+                IsYOutOfRange = outOfRange || startX > 0;
             }
             else if (pointsDomain.Count == 1)
             {

--- a/src/Libraries/CoreNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodes/Properties/Resources.Designer.cs
@@ -70,7 +70,7 @@ namespace DSCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to • Min and Max values must not be the same..
+        ///   Looks up a localized string similar to • Min and Max values must be different..
         /// </summary>
         internal static string CurveMapperEqualMinMaxWarning {
             get {

--- a/src/Libraries/CoreNodes/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodes/Properties/Resources.en-US.resx
@@ -235,7 +235,7 @@
     <value>Input must be a single value or a non-nested list.</value>
   </data>
   <data name="CurveMapperEqualMinMaxWarning" xml:space="preserve">
-    <value>• Min and Max values must not be the same.</value>
+    <value>• Min and Max values must be different.</value>
   </data>
   <data name="CurveMapperInvalidCountWarning" xml:space="preserve">
     <value>• Values must be a list of numbers or a single number ≥ 2.</value>

--- a/src/Libraries/CoreNodes/Properties/Resources.resx
+++ b/src/Libraries/CoreNodes/Properties/Resources.resx
@@ -235,7 +235,7 @@
     <value>Input must be a single value or a non-nested list.</value>
   </data>
   <data name="CurveMapperEqualMinMaxWarning" xml:space="preserve">
-    <value>• Min and Max values must not be the same.</value>
+    <value>• Min and Max values must be different.</value>
   </data>
   <data name="CurveMapperInvalidCountWarning" xml:space="preserve">
     <value>• Values must be a list of numbers or a single number ≥ 2.</value>


### PR DESCRIPTION
### Purpose

This PR aims to address [DYN-8546](https://jira.autodesk.com/browse/DYN-8546) by adding an info bubble to the node when one or more output Y-values fall outside the specified domain range.

Changes to the code include:
-ClearErrorsAndWarnings() now reassigns the node’s state to PersistentInfo if any persistent info messages remain.
- Info() preserves higher-priority states (e.g., warnings or errors) when adding new info messages.
- Introduced Logic_NodeWarningMessagesClearing() to remove only warning messages, leaving info messages intact.
- All curve types now include logic to flag if any calculated Y-values fall outside the domain.
- Minor update to a warning message as requested in [DYN-8596](https://jira.autodesk.com/browse/DYN-8596)

![DYN-8546-Info bubble 2](https://github.com/user-attachments/assets/473ff008-1c7c-4a62-9487-ee84bcde7337)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

New info bubble to inform users if any Y values are outside the domain.

### Reviewers
@reddyashish 
@zeusongit 

### FYIs
@dnenov 
@achintyabhat 
