### PR TITLE
DYN-8646 - Expand AutoComplete (Node Type Match) to Provide More Accurate Results

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -585,16 +585,16 @@ namespace Dynamo.ViewModels
             {
                 switch (PortViewModel.PortModel.GetInputPortType())
                 {
-                    case "int":
+                    case string inputPortType when inputPortType.Contains("int"):
                         FilteredResults = DefaultResults.Where(e => e.Name == "Number Slider" || e.Name == "Integer Slider").ToList();
                         break;
-                    case "double":
+                    case { } inputPortType when inputPortType.Contains("double"):
                         FilteredResults = DefaultResults.Where(e => e.Name == "Number Slider" || e.Name == "Integer Slider").ToList();
                         break;
-                    case "string":
+                    case { } inputPortType when inputPortType.Contains("string"):
                         FilteredResults = DefaultResults.Where(e => e.Name == "String").ToList();
                         break;
-                    case "bool":
+                    case { } inputPortType when inputPortType.Contains("bool"):
                         FilteredResults = DefaultResults.Where(e => e.Name == "Boolean").ToList();
                         break;
                     default:

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -585,7 +585,7 @@ namespace Dynamo.ViewModels
             {
                 switch (PortViewModel.PortModel.GetInputPortType())
                 {
-                    case string inputPortType when inputPortType.Contains("int"):
+                    case { } inputPortType when inputPortType.Contains("int"):
                         FilteredResults = DefaultResults.Where(e => e.Name == "Number Slider" || e.Name == "Integer Slider").ToList();
                         break;
                     case { } inputPortType when inputPortType.Contains("double"):


### PR DESCRIPTION
### Purpose
Currently node type match fails to find a match if the input port's data type is not explicitly one of the predefined. Eg. a node's input can be `List<string>`, resulting in the suggestions in the Before GIF below. By switching to `string.contains` instead of equals, we get results that closer match expectations.

Behavior Before:
![DYN-8646_Before](https://github.com/user-attachments/assets/678cd333-8742-4bc2-924b-4d999034ed5c)

Behavior After:
![DYN-8646_After](https://github.com/user-attachments/assets/6b58a1c5-5aa0-489f-970f-c854f49ed290)

Note: while this is not a perfect fix, this does help at least work toward being a more correct suggestion, rather than defaulting to all of the default inputs. Node type match isn't the highest priority, but we wanted to give it a little attention. I do think that we can expand this further as well because NodeModels still have failures using node type match. Eg. Curve Mapper.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes
N/A

### Reviewers
@DynamoDS/synapse 

### FYIs
@Jingyi-Wen @achintyabhat @jnealb @mjkkirschner 
