### PR TITLE
DYN-8558 : transient node from the get go

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -96,6 +96,7 @@ namespace Dynamo.Models
 
             node.X = command.X;
             node.Y = command.Y;
+            node.IsTransient = command.IsTransient;
 
             AddNodeToCurrentWorkspace(node, centered: command.DefaultPosition);
             CurrentWorkspace.RecordCreatedModel(node);

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -791,12 +791,13 @@ namespace Dynamo.Models
         [DataContract]
         public class CreateNodeCommand : ModelBasedRecordableCommand
         {
-            private void SetProperties(double x, double y, bool defaultPosition, bool transformCoordinates)
+            private void SetProperties(double x, double y, bool defaultPosition, bool transformCoordinates, bool isTransient)
             {
                 X = x;
                 Y = y;
                 DefaultPosition = defaultPosition;
                 TransformCoordinates = transformCoordinates;
+                IsTransient = isTransient;
             }
 
             #region Public Class Methods
@@ -813,7 +814,7 @@ namespace Dynamo.Models
                 : base(node != null ? new[] { node.GUID } : new[] { Guid.Empty })
             {
                 Node = node;
-                SetProperties(x, y, defaultPosition, transformCoordinates);
+                SetProperties(x, y, defaultPosition, transformCoordinates, false);
             }
 
             /// <summary>
@@ -829,7 +830,7 @@ namespace Dynamo.Models
                 : base(new[] { Guid.Empty })
             {
                 NodeXml = node;
-                SetProperties(x, y, defaultPosition, transformCoordinates);
+                SetProperties(x, y, defaultPosition, transformCoordinates, false);
             }
 
             /// <summary>
@@ -846,7 +847,7 @@ namespace Dynamo.Models
                 : base(nodeId)
             {
                 Name = nodeName;
-                SetProperties(x, y, defaultPosition, transformCoordinates);
+                SetProperties(x, y, defaultPosition, transformCoordinates, false);
             }
 
             /// <summary>
@@ -864,7 +865,26 @@ namespace Dynamo.Models
                 : base(new[] { Guid.Parse(nodeId) })
             {
                 Name = nodeName;
-                SetProperties(x, y, defaultPosition, transformCoordinates);
+                SetProperties(x, y, defaultPosition, transformCoordinates, false);
+            }
+
+            /// <summary>
+            ///
+            /// </summary>
+            /// <param name="nodeId"></param>
+            /// <param name="nodeName"></param>
+            /// <param name="x"></param>
+            /// <param name="y"></param>
+            /// <param name="defaultPosition"></param>
+            /// <param name="transformCoordinates"></param>
+            /// <param name="isTransient"></param>
+            [JsonConstructor]
+            internal CreateNodeCommand(string nodeId, string nodeName,
+                double x, double y, bool defaultPosition, bool transformCoordinates, bool isTransient)
+                : base(new[] { Guid.Parse(nodeId) })
+            {
+                Name = nodeName;
+                SetProperties(x, y, defaultPosition, transformCoordinates, isTransient);
             }
 
             internal static CreateNodeCommand DeserializeCore(XmlElement element)
@@ -899,6 +919,8 @@ namespace Dynamo.Models
             // If it was deserialized
             internal XmlElement NodeXml { get; private set; }
 
+            // Node will be creted in transient state.
+            internal bool IsTransient { get; private set; } = false;
 
             [DataMember]
             internal double X { get; private set; }

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -848,7 +848,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                     var typeInfo = wsViewModel.NodeAutoCompleteSearchViewModel.GetInfoFromTypeId(newNode.Type.Id);
 
                     //create node with guid from the cluster response for matching later
-                    dynamoViewModel.Model.ExecuteCommand(new DynamoModel.CreateNodeCommand(Guid.NewGuid().ToString(), typeInfo.FullName, xoffset, node.NodeModel.Y, false, false));
+                    dynamoViewModel.Model.ExecuteCommand(new DynamoModel.CreateNodeCommand(Guid.NewGuid().ToString(), typeInfo.FullName, xoffset, node.NodeModel.Y, false, false, true));
 
                     //disallow the node creation command from the undo group, we group node creation and wires below
                     wsViewModel.Model.UndoRecorder.PopFromUndoGroup();
@@ -857,7 +857,6 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                     createdNodes.Add(newNode.Id,nodeFromCluster);
                     newNodesAndWires.Add(nodeFromCluster.NodeModel);
 
-                    nodeFromCluster.IsTransient = true;
                     nodeFromCluster.IsHidden = true;
                     clusterMapping.Add(newNode.Id, nodeFromCluster);
                 }

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -207,6 +207,8 @@ namespace Dynamo.NodeAutoComplete.ViewModels
 
             NodeAutoCompleteUtilities.PostAutoLayoutNodes(node.WorkspaceViewModel.Model, node.NodeModel, transientNodes.Select(x => x.NodeModel), true, true, false, null);
 
+            (node.WorkspaceViewModel.Model as HomeWorkspaceModel)?.MarkNodesAsModifiedAndRequestRun(transientNodes.Select(x => x.NodeModel));
+
             ToggleUndoRedoLocked(false);
         }
 


### PR DESCRIPTION
### Purpose
Create a transient node from the get go so that it will not execute when is added to the workspace.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes
N/A

### Reviewers
@DynamoDS/synapse 
