### PR TITLE
DYN-8807 Add the ResolveAssembly event handler before executing PreloadLibraries

### DIFF
--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -89,13 +89,12 @@ namespace Dynamo.Engine
             this.pathManager = pathManager;
             preferenceSettings = preferences;
 
+            AppDomain.CurrentDomain.AssemblyResolve += ResolveAssembly;
             PreloadLibraries(pathManager.PreloadedLibraries);
             PopulateBuiltIns();
             PopulateOperators();
             PopulatePreloadLibraries();
-            LibraryLoadFailed += new EventHandler<LibraryLoadFailedEventArgs>(LibraryLoadFailureHandler);
-
-            AppDomain.CurrentDomain.AssemblyResolve += ResolveAssembly;
+            LibraryLoadFailed += new EventHandler<LibraryLoadFailedEventArgs>(LibraryLoadFailureHandler);         
         }
 
         private Assembly ResolveAssembly(object sender, ResolveEventArgs args)


### PR DESCRIPTION
### Purpose

I am working on an issue in which Dynamo cannot find some assemblies that DynamoRevit needs and it leads to some nodes in a steel connection automation script being unresolved.

In this code, in `PreloadLibraries(pathManager.PreloadedLibraries)` Dynamo loads assembly from an internal package called Steel Connections 4 Dynamo and also tries to load its dependent assemblies. However it doesn't find the path to some dependent assembly at this time (throws an exception `System.IO.FileNotFoundException: 'Could not load file or assembly 'ASObjectsMgd, Version=1.0.9208.20419, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.'`). The assembly will be loaded 5 lines later when ResolveAssembly method will be called to attempt to resolve the missing assembly. However this is too late and what will happen is that the nodes that depend on that assembly that failed to load will be unresolved on the first opening of the script.

Moving the last line before PreloadLibraries would solve this issue because the ResolveAssembly method will be called on time to load ASObjectsMgd.dll that failed to load before.

### Release Notes

Fix an assembly load issue for DynamoRevit internal package

### Reviewers

@aparajit-pratap @Mikhinja
