### PR TITLE
DYN-8632 : limit some commands during dna

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1008,6 +1008,23 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
+        /// Return a value indicating whether this node is connected to a transient node.
+        /// </summary>
+        internal bool HasTransientConnections()
+        {
+            var allPorts = InPorts.Concat(OutPorts);
+            foreach (var port in allPorts)
+            {
+                if (port?.HasTransientConnections() is true)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// The default behavior for ModelBase objects is to not serialize the X and Y
         /// properties. This overload allows the serialization of the X property
         /// for NodeModel.

--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -331,6 +331,21 @@ namespace Dynamo.Graph.Nodes
 
         internal bool IsProxyPort { get; set; } = false;
 
+        /// <summary>
+        /// Return a value indicating whether this port is connected to a transient node.
+        /// </summary>
+        internal bool HasTransientConnections()
+        {
+            foreach(var connector in Connectors)
+            {
+                var connectedNode = PortType == PortType.Input ? connector?.Start?.Owner : connector?.End?.Owner;
+                if (connectedNode?.IsTransient is true)
+                    return true;
+            }
+
+            return false;
+        }
+
         [JsonConstructor]
         internal PortModel(string name, string toolTip)
         {

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -586,6 +586,12 @@ namespace Dynamo.Models
                 modelsToDelete.AddRange(command.ModelGuids.Select(guid => CurrentWorkspace.GetModelInternal(guid)));
             }
 
+            if (!command.CanDeleteTransientNodes)
+            {
+                // Remove transient nodes from the list of models to delete.
+                modelsToDelete.RemoveAll(model => (model as NodeModel)?.IsTransient == true);
+            }
+
             DeleteModelInternal(modelsToDelete);
         }
 

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -1689,6 +1689,8 @@ namespace Dynamo.Models
         [DataContract]
         public class DeleteModelCommand : ModelBasedRecordableCommand
         {
+            internal bool CanDeleteTransientNodes { get; set; } = false;
+
             #region Public Class Methods
 
             /// <summary>
@@ -1709,6 +1711,16 @@ namespace Dynamo.Models
             /// </summary>
             /// <param name="modelGuids"></param>
             public DeleteModelCommand(IEnumerable<Guid> modelGuids) : base(modelGuids) { }
+
+            /// <summary>
+            ///
+            /// </summary>
+            /// <param name="modelGuids"></param>
+            /// <param name="canDeleteTransientNodes"></param>
+            internal DeleteModelCommand(IEnumerable<Guid> modelGuids, bool canDeleteTransientNodes) : base(modelGuids)
+            {
+                CanDeleteTransientNodes = canDeleteTransientNodes;
+            }
 
             internal static DeleteModelCommand DeserializeCore(XmlElement element)
             {

--- a/src/DynamoCoreWpf/Commands/PortCommands.cs
+++ b/src/DynamoCoreWpf/Commands/PortCommands.cs
@@ -47,7 +47,7 @@ namespace Dynamo.ViewModels
             {
                 if (nodePortContextMenuCommand == null)
                 {
-                    nodePortContextMenuCommand = new DelegateCommand(NodePortContextMenu);
+                    nodePortContextMenuCommand = new DelegateCommand(NodePortContextMenu, CanShowContextMenu);
                 }
                 return nodePortContextMenuCommand;
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -542,6 +542,12 @@ namespace Dynamo.ViewModels
 
         protected bool CanConnect(object parameter)
         {
+            if (node?.IsTransient is true ||
+                PortModel?.HasTransientConnections() is true)
+            {
+                return false;
+            }
+
             return true;
         }
 
@@ -600,6 +606,17 @@ namespace Dynamo.ViewModels
             
             wsViewModel.CancelActiveState();
             wsViewModel.OnRequestPortContextMenu(ShowHideFlags.Show, this);
+        }
+
+        private bool CanShowContextMenu(object obj)
+        {
+            if (node?.IsTransient is true ||
+                PortModel?.HasTransientConnections() is true)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private bool CanAutoComplete(object parameter)

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -799,6 +799,14 @@ namespace Dynamo.Controls
         /// </summary>
         private void DisplayNodeContextMenu(object sender, RoutedEventArgs e)
         {
+            if (ViewModel?.NodeModel?.IsTransient is true ||
+                ViewModel?.NodeModel?.HasTransientConnections() is true)
+            {
+                e.Handled = true;
+                return;
+            }
+
+
             Guid nodeGuid = ViewModel.NodeModel.GUID;
             ViewModel.WorkspaceViewModel.HideAllPopupCommand.Execute(sender);
             ViewModel.DynamoViewModel.ExecuteCommand(

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -803,7 +803,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             var transientNodes = wsViewModel.Nodes.Where(x => x.IsTransient).ToList();
             if (transientNodes.Any())
             {
-                dynamoViewModel.Model.ExecuteCommand(new DynamoModel.DeleteModelCommand(transientNodes.Select(x => x.Id)));
+                dynamoViewModel.Model.ExecuteCommand(new DynamoModel.DeleteModelCommand(transientNodes.Select(x => x.Id), true));
 
                 //remove the initial layout of the transient nodes from the undo stack
                 wsViewModel.Model.UndoRecorder.PopFromUndoGroup();


### PR DESCRIPTION
### Purpose
Limit some commands during dna : deletion of transient nodes , context menus, wire connections.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers
@DynamoDS/synapse 
