### PR TITLE
DYN-8802: Use Panel based port size calculation only for CodeBlockNodes

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1762,6 +1762,30 @@ namespace Dynamo.Controls
         }
     }
 
+    /// <summary>
+    /// Used to set the port style of a Code Block node.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign",
+        "RS0016:Add public types and members to the declared API",
+        Justification = "Converters are not part of the API")]
+    public class NodeModelToPortStyleConverter : IValueConverter
+    {
+        public Style PortStyle { get; set; }
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is CodeBlockNodeModel)
+            {
+                return PortStyle;
+            }
+            return DependencyProperty.UnsetValue;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
     public class LacingToVisibilityConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -2791,6 +2791,9 @@
             </Setter.Value>
         </Setter>
     </Style>
+    <conv:NodeModelToPortStyleConverter
+        x:Key="NodeModelToPortStyleConverter"
+        PortStyle="{StaticResource InOutPortControlStyle}" />
 
     <Style x:Key="{x:Type dynui:ImageCheckBox}" TargetType="{x:Type dynui:ImageCheckBox}">
         <Setter Property="SnapsToDevicePixels" Value="true" />

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -407,7 +407,7 @@
                       HorizontalContentAlignment="Stretch"
                       Canvas.ZIndex="6"
                       ItemsSource="{Binding Path=InPorts}"
-                      Style="{StaticResource InOutPortControlStyle}" />
+                      Style="{Binding Path=NodeModel, Converter={StaticResource NodeModelToPortStyleConverter}}" />
 
         <!--  OUTPUT PORTS  -->
         <ItemsControl Name="outputPortControl"
@@ -418,7 +418,7 @@
                       HorizontalContentAlignment="Stretch"
                       Canvas.ZIndex="4"
                       ItemsSource="{Binding Path=OutPorts}"
-                      Style="{StaticResource InOutPortControlStyle}" />
+                      Style="{Binding Path=NodeModel, Converter={StaticResource NodeModelToPortStyleConverter}}" />
 
         <Grid Name="centralGrid"
               Grid.Row="2"


### PR DESCRIPTION
### Purpose

It was identified that Measure/Arrange override methods in InOutPortPanel consumed a lot of cycles when loading a graph, it was noted that the custom solution was implemented specifically for CBN nodes to align incremental ports ([PR](https://github.com/DynamoDS/Dynamo/pull/5123)).
It was being triggered recursively for each port on each node irrespective of it's type. As a resolution in this PR the target style is made conditional, so we will use the InOutPortPanel based style only for CodeBlock nodes.

Results:

~83000 ms -> ~70000 ms (~16% faster)

(After left - Before right)
![Screenshot 2025-04-30 at 6 03 31 PM](https://github.com/user-attachments/assets/73883b83-e525-4493-948a-7f8f1b1e0b9c)


Profiled with 1024PointsByCoordinate nodes graph and tested with Manekin as well

(Still testing with more nodes)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Use Panel based port size calculation only for CodeBlockNodes

### Reviewers

