### PR TITLE
DYN-8615 OpenXML Excel Exception

### DIFF
--- a/src/Libraries/DSOfficeUtilities/OpenXmlHelper.cs
+++ b/src/Libraries/DSOfficeUtilities/OpenXmlHelper.cs
@@ -256,6 +256,10 @@ namespace DSOffice
             foreach (var row in sheetData.Elements<Row>())
             {
                 var lastCell = row.LastChild as Cell;
+
+                //When we have an empty row sometimes the Row.LastChild is null, so this validation will avoid the "Object reference not set to an instance of an object" error.
+                if (lastCell == null) continue;
+
                 var current = GetColumnIndex(lastCell.CellReference);
                 if (current > result)
                 {


### PR DESCRIPTION
### Purpose

Fixing problem with the Data.OpenXMLImportExcel node sending the exception  "Object reference not set to an instance of an object.".
Probably this error is based in how the excel spreadsheet was created (by some reason is counting empty rows as if they contains data but if you copy the info to a new excel sheet it works as expected) but basically the problem is that when the spreadsheet contains empty rows sometimes the Row.LastChild is null so the  "Object reference not set to an instance of an object." exception is generated when trying to check any property inside the Cell instance. For fixing this problem I just added a validation that will skip the empty row if Row.LastChild is null.


### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing problem with the Data.OpenXMLImportExcel node sending the exception  "Object reference not set to an instance of an object.".

### Reviewers

@zeusongit @DynamoDS/eidos 

### FYIs

@achintyabhat 
