### PR TITLE
DYN-8845: Handle fetching feature flags with type cast error

### DIFF
--- a/src/DynamoUtilities/DynamoFeatureFlagsManager.cs
+++ b/src/DynamoUtilities/DynamoFeatureFlagsManager.cs
@@ -115,7 +115,20 @@ namespace DynamoUtilities
             }
             if (AllFlagsCache.TryGetValue(featureFlagKey, out var flagVal))
             {
-                return (T)flagVal;
+                try
+                {
+                    if (typeof(T) == typeof(double) && flagVal is int intValue)
+                    {
+                        flagVal = Convert.ToDouble(intValue);
+                    }
+                    return (T)flagVal;
+                }
+                catch (InvalidCastException e)
+                {
+                    RaiseMessageLogged(
+                        $"failed to cast feature flag value for {featureFlagKey} to {typeof(T)}, ex: {e.Message}, returning default value: {defaultval}");
+                    return defaultval;
+                }
             }
             else
             {


### PR DESCRIPTION
### Purpose

- Error while type casting feature flag should return the default value.
- Added a special case for FF of type `double`, since setting a value 0.0 is not supported by launch darkly, if any integer is encountered when fetching a FF that is supposed to be a `double` type, it will be explicitly casted to a `double`.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
