### PR TITLE
DYN-8602 - Consolidate Undos Added for Cluster

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -238,8 +238,6 @@ namespace Dynamo.Models
                 node.GUID = nodeId;
                 node.IsTransient = isTransient;
             }
-
-           
             return node;
         }
 

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -216,7 +216,7 @@ namespace Dynamo.Models
             return null;
         }
 
-        internal NodeModel CreateNodeFromNameOrType(Guid nodeId, string name)
+        internal NodeModel CreateNodeFromNameOrType(Guid nodeId, string name, bool isTransient = false)
         {
             NodeModel node;
 
@@ -228,6 +228,7 @@ namespace Dynamo.Models
                     ? new DSVarArgFunction(functionItem) as NodeModel
                     : new DSFunction(functionItem);
                 node.GUID = nodeId;
+                node.IsTransient = isTransient;
                 return node;
             }
 
@@ -235,7 +236,10 @@ namespace Dynamo.Models
             if (NodeFactory.CreateNodeFromTypeName(name, out node))
             {
                 node.GUID = nodeId;
+                node.IsTransient = isTransient;
             }
+
+           
             return node;
         }
 

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -216,7 +216,7 @@ namespace Dynamo.Models
             return null;
         }
 
-        private NodeModel CreateNodeFromNameOrType(Guid nodeId, string name)
+        internal NodeModel CreateNodeFromNameOrType(Guid nodeId, string name)
         {
             NodeModel node;
 

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -725,9 +725,10 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             if (transientNodes.Any())
             {
                 dynamoViewModel.Model.ExecuteCommand(new DynamoModel.DeleteModelCommand(transientNodes.Select(x => x.Id), true));
-                /*We can't remove the undo from the undo group at this time, because the elements and their modifications still exist in the cache.
-                With the deletion not in the undo cache, this results in errors if the user hits undo*/
-                //wsViewModel.Model.UndoRecorder.PopFromUndoGroup();
+                //remove the deletion of the elements from the undo stack
+                wsViewModel.Model.UndoRecorder.PopFromUndoGroup();
+                //remove the layout of the elements from the undo stack
+                wsViewModel.Model.UndoRecorder.PopFromUndoGroup();
             }
         }
 

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -20,10 +20,6 @@ using Dynamo.Search.SearchElements;
 using Dynamo.Utilities;
 using Dynamo.Wpf.ViewModels;
 using Greg;
-using J2N.Text;
-using Lucene.Net.Documents;
-using Lucene.Net.QueryParsers.Classic;
-using Lucene.Net.Search;
 using Newtonsoft.Json;
 using ProtoCore.AST.AssociativeAST;
 using ProtoCore.Mirror;
@@ -32,14 +28,9 @@ using RestSharp;
 using Dynamo.Wpf.Utilities;
 using Dynamo.ViewModels;
 using System.Reflection;
-using Dynamo.Controls;
-using Dynamo.Core;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Graph;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using Dynamo.Graph.Annotations;
-using Dynamo.Graph.Notes;
 using Dynamo.Selection;
 
 namespace Dynamo.NodeAutoComplete.ViewModels

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -811,6 +811,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                 var entryPortIndex = clusterResultItem.EntryNodeInPort;
                 if (entryNode.InPorts.Count > entryPortIndex)
                 {
+                    //only connect to the entry node when it does not have connections already.
                     if (!entryNode.InPorts[entryPortIndex].Connectors.Any())
                     {
                         var entryConnector = ConnectorModel.Make(PortViewModel.NodeViewModel.NodeModel, entryNode, 0, entryPortIndex);
@@ -819,7 +820,6 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                             entryConnector.IsHidden = true;
                             var entryConnectorViewModel = workspaceViewModel.Connectors.First(c => c.ConnectorModel.Equals(entryConnector));
                             entryConnectorViewModel.IsConnecting = true;
-
                             createdClusterItems.Add(entryConnector);
                         }
                     }

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -725,9 +725,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             if (transientNodes.Any())
             {
                 dynamoViewModel.Model.ExecuteCommand(new DynamoModel.DeleteModelCommand(transientNodes.Select(x => x.Id), true));
-                /*We can't remove the undo from the undo group at this time, because the elements and their modifications still exist in the cache.
-                With the deletion not in the undo cache, this results in errors if the user hits undo*/
-                //wsViewModel.Model.UndoRecorder.PopFromUndoGroup();
+                wsViewModel.Model.UndoRecorder.PopFromUndoGroup();
             }
         }
 

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -242,12 +242,11 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                 connector.IsConnecting = false;
             }
 
-            NodeAutoCompleteUtilities.PostAutoLayoutNodes(node.WorkspaceViewModel.Model, node.NodeModel, transientNodes.Select(x => x.NodeModel), true, true, false, null);
+            //NodeAutoCompleteUtilities.PostAutoLayoutNodes(node.WorkspaceViewModel.Model, node.NodeModel, transientNodes.Select(x => x.NodeModel), true, true, false, null);
 
-            (node.WorkspaceViewModel.Model as HomeWorkspaceModel)?.MarkNodesAsModifiedAndRequestRun(transientNodes.Select(x => x.NodeModel));
+            //(node.WorkspaceViewModel.Model as HomeWorkspaceModel)?.MarkNodesAsModifiedAndRequestRun(transientNodes.Select(x => x.NodeModel));
 
             ToggleUndoRedoLocked(false);
-
             DynamoModel.RecordUndoModels(node.WorkspaceViewModel.Model, createdClusterItems);
         }
 
@@ -739,6 +738,8 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             if (transientNodes.Any())
             {
                 dynamoViewModel.Model.ExecuteCommand(new DynamoModel.DeleteModelCommand(transientNodes.Select(x => x.Id), true));
+
+                wsViewModel.Model.UndoRecorder.PopFromUndoGroup();
             }
         }
 
@@ -836,41 +837,54 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                     }
                 }
             }
-
-            // Perform auto-layout for the newly added nodes
-            NodeAutoCompleteUtilities.PostAutoLayoutNodes(
-                workspaceViewModel.DynamoViewModel.CurrentSpace,
-                PortViewModel.NodeViewModel.NodeModel,
-                createdNodes.Values,
-                false,
-                false,
-                false,
-                () =>
-                {
-                    // Finalize visibility of nodes and connectors
-                    foreach (var node in createdNodes.Values)
-                    {
-                        workspaceViewModel.Nodes.FirstOrDefault(n => n.NodeModel.GUID.Equals(node.GUID)).IsHidden = false;
-                        foreach (var connector in node.AllConnectors)
-                        {
-                            connector.IsHidden = !PreferenceSettings.Instance.ShowConnector;
-                        }
-                    }
-                });
-
-            // Group the newly created nodes
-            AnnotationModel annotationModel = new AnnotationModel(createdNodes.Values, new List<NoteModel>())
-                {
-                    AnnotationText = clusterResultItem.Title,
-                    AnnotationDescriptionText = clusterResultItem.Description
-                };
-            workspaceModel.AddAnnotation(annotationModel);
-            if (annotationModel != null)
-            {
-                annotationModel.Background = "#D5BCF7";
-                createdClusterItems.Add(annotationModel);
-            }
             
+            // Finalize visibility of nodes and connectors
+            foreach (var node in createdNodes.Values)
+            {
+                workspaceViewModel.Nodes.FirstOrDefault(n => n.NodeModel.GUID.Equals(node.GUID)).IsHidden = false;
+                foreach (var connector in node.AllConnectors)
+                {
+                    connector.IsHidden = !PreferenceSettings.Instance.ShowConnector;
+                }
+            }
+        
+
+            //// Perform auto-layout for the newly added nodes
+            //NodeAutoCompleteUtilities.PostAutoLayoutNodes(
+            //    workspaceViewModel.DynamoViewModel.CurrentSpace,
+            //    PortViewModel.NodeViewModel.NodeModel,
+            //    createdNodes.Values,
+            //    false,
+            //    false,
+            //    false,
+            //    () =>
+            //    {
+            //        // Finalize visibility of nodes and connectors
+            //        foreach (var node in createdNodes.Values)
+            //        {
+            //            workspaceViewModel.Nodes.FirstOrDefault(n => n.NodeModel.GUID.Equals(node.GUID)).IsHidden = false;
+            //            foreach (var connector in node.AllConnectors)
+            //            {
+            //                connector.IsHidden = !PreferenceSettings.Instance.ShowConnector;
+            //            }
+            //        }
+            //    });
+
+
+
+            //// Group the newly created nodes
+            //AnnotationModel annotationModel = new AnnotationModel(createdNodes.Values, new List<NoteModel>())
+            //    {
+            //        AnnotationText = clusterResultItem.Title,
+            //        AnnotationDescriptionText = clusterResultItem.Description
+            //    };
+            //workspaceModel.AddAnnotation(annotationModel);
+            //if (annotationModel != null)
+            //{
+            //    annotationModel.Background = "#D5BCF7";
+            //    createdClusterItems.Add(annotationModel);
+            //}
+
             // Unlock undo/redo
             ToggleUndoRedoLocked(false);
 

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -189,7 +189,9 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             }
             set
             {
-                if(selectedIndex != value && value >= 0)
+                /*don't try to add a node if the index is out of range or a selection is not made yet (-1)
+                an index of -1 occurs when using the switch to change between modes.*/
+                if (selectedIndex != value && value >= 0 && selectedIndex != -1)
                 {
                     ReAddNode(value);
                 }
@@ -938,11 +940,10 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                     // this runs synchronously on the UI thread, so the UI can't disappear during execution
                     DropdownResults = comboboxResults;
                     SelectedIndex = 0;
-                    if (QualifiedResults.Any())
-                    {
-                        var ClusterResultItem = QualifiedResults.First();
-                        AddCluster(ClusterResultItem);
-                    }
+
+                    var ClusterResultItem = QualifiedResults.First();
+                    AddCluster(ClusterResultItem);
+                    
                 });
             });
             //Tracking Analytics when raising Node Autocomplete with the Recommended Nodes option selected (Machine Learning)

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -740,7 +740,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             if (clusterResultItem == null || clusterResultItem.Topology == null)
                 return;
 
-            List<ModelBase> createdClusterItems = [];
+            List<ModelBase> createdClusterItems = new List<ModelBase>();
 
             var workspaceViewModel = PortViewModel.NodeViewModel.WorkspaceViewModel;
             var workspaceModel = workspaceViewModel.Model;

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -725,7 +725,9 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             if (transientNodes.Any())
             {
                 dynamoViewModel.Model.ExecuteCommand(new DynamoModel.DeleteModelCommand(transientNodes.Select(x => x.Id), true));
-                wsViewModel.Model.UndoRecorder.PopFromUndoGroup();
+                /*We can't remove the undo from the undo group at this time, because the elements and their modifications still exist in the cache.
+                With the deletion not in the undo cache, this results in errors if the user hits undo*/
+                //wsViewModel.Model.UndoRecorder.PopFromUndoGroup();
             }
         }
 

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -736,9 +736,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             var transientNodes = wsViewModel.Nodes.Where(x => x.IsTransient).ToList();
             if (transientNodes.Any())
             {
-                
                 dynamoViewModel.Model.ExecuteCommand(new DynamoModel.DeleteModelCommand(transientNodes.Select(x => x.Id), true));
-
                 /*We can't remove the undo from the undo group at this time, because the elements and their modifications still exist in the cache.
                 With the deletion not in the undo cache, this results in errors if the user hits undo*/
                 //wsViewModel.Model.UndoRecorder.PopFromUndoGroup();
@@ -778,7 +776,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                 foreach (var nodeItem in nodeStack)
                 {
                     var typeInfo = new NodeModelTypeId(nodeItem.Type.Id);
-                    var newNode = dynamoModel.CreateNodeFromNameOrType(Guid.NewGuid(), typeInfo.FullName);
+                    var newNode = dynamoModel.CreateNodeFromNameOrType(Guid.NewGuid(), typeInfo.FullName, true);
                     if (newNode != null)
                     {
                         newNode.X = offset; // Adjust X position
@@ -788,7 +786,6 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                         createdClusterItems.Add(newNode);
 
                         var newNodeViewModel = workspaceViewModel.Nodes.Last();
-                        newNodeViewModel.IsTransient = true; // Mark as transient
                         newNodeViewModel.IsHidden = true; // Hide the node initially
                     }
                 }

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -844,7 +844,11 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                     // Finalize visibility of nodes and connectors
                     foreach (var node in createdNodes.Values)
                     {
-                        workspaceViewModel.Nodes.FirstOrDefault(n => n.NodeModel.GUID.Equals(node.GUID)).IsHidden = false;
+                        var matchingNode = workspaceViewModel.Nodes.FirstOrDefault(n => n.NodeModel.GUID.Equals(node.GUID));
+                        if (matchingNode != null)
+                        {
+                            matchingNode.IsHidden = false;
+                        }
                         foreach (var connector in node.AllConnectors)
                         {
                             connector.IsHidden = !PreferenceSettings.Instance.ShowConnector;

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -189,7 +189,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             }
             set
             {
-                if(selectedIndex != value && value >= 0 && selectedIndex != -1)
+                if(selectedIndex != value && value >= 0)
                 {
                     ReAddNode(value);
                 }

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -847,7 +847,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                     connector.IsHidden = !PreferenceSettings.Instance.ShowConnector;
                 }
             }
-        
+
 
             //// Perform auto-layout for the newly added nodes
             //NodeAutoCompleteUtilities.PostAutoLayoutNodes(
@@ -873,17 +873,17 @@ namespace Dynamo.NodeAutoComplete.ViewModels
 
 
             //// Group the newly created nodes
-            //AnnotationModel annotationModel = new AnnotationModel(createdNodes.Values, new List<NoteModel>())
-            //    {
-            //        AnnotationText = clusterResultItem.Title,
-            //        AnnotationDescriptionText = clusterResultItem.Description
-            //    };
-            //workspaceModel.AddAnnotation(annotationModel);
-            //if (annotationModel != null)
-            //{
-            //    annotationModel.Background = "#D5BCF7";
-            //    createdClusterItems.Add(annotationModel);
-            //}
+            AnnotationModel annotationModel = new AnnotationModel(createdNodes.Values, new List<NoteModel>())
+            {
+                AnnotationText = clusterResultItem.Title,
+                AnnotationDescriptionText = clusterResultItem.Description
+            };
+            workspaceModel.AddAnnotation(annotationModel);
+            if (annotationModel != null)
+            {
+                annotationModel.Background = "#D5BCF7";
+                //createdClusterItems.Add(annotationModel);
+            }
 
             // Unlock undo/redo
             ToggleUndoRedoLocked(false);

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -32,7 +32,6 @@ using RestSharp;
 using Dynamo.Wpf.Utilities;
 using Dynamo.ViewModels;
 using System.Reflection;
-using System.Windows.Media;
 using Dynamo.Controls;
 using Dynamo.Core;
 using Dynamo.Graph.Workspaces;
@@ -42,8 +41,6 @@ using System.Windows.Media.Imaging;
 using Dynamo.Graph.Annotations;
 using Dynamo.Graph.Notes;
 using Dynamo.Selection;
-using System.IO.Packaging;
-using System.Windows.Threading;
 
 namespace Dynamo.NodeAutoComplete.ViewModels
 {


### PR DESCRIPTION
### Purpose
This PR aims to consolidate the undos being added to the undo recorder by switching to creating NodeModel elements and ConnectorModels. This allows us to add the creation as one undo.

#### Known Issue:
For iterating between solutions, the transient nodes are deleted. This means there is a delete added to the undo stack at this time and the user can _technically_ undo back through the cycled options. See GIFbelow for details. The plan is to fix this in an upcoming PR, but the errors being added to the log were something we wanted to fix.

![20250508-nodeClusterDelete](https://github.com/user-attachments/assets/42480f50-7f33-4a94-89cd-aea14e7c1ffc)


#### Errors added to undo stack:
The following errors occur because the transient nodes have commands added to the undo stack if users interact with them. This is the same thing that happens if we disallow the undo during the deletion mentioned above.

![20250508-nodeClusterError](https://github.com/user-attachments/assets/48392354-7a36-45b6-8dff-f2d8d1eded8e)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes
N/A

### Reviewers
@DynamoDS/synapse 

### FYIs
@Amoursol @QilongTang 
