### PR TITLE
DYN-8308: Fix temporary connector and Node memory leak

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -1204,25 +1204,32 @@ namespace Dynamo.ViewModels
         /// </summary>
         public override void Dispose()
         {
-            model.PropertyChanged -= HandleConnectorPropertyChanged;
+            if (model != null)
+            {
+                model.PropertyChanged -= HandleConnectorPropertyChanged;
 
-            model.Start.PropertyChanged -= StartPortModel_PropertyChanged;
-            model.End.PropertyChanged -= EndPortModel_PropertyChanged;
+                model.Start.PropertyChanged -= StartPortModel_PropertyChanged;
+                model.End.PropertyChanged -= EndPortModel_PropertyChanged;
 
-            model.Start.Owner.PropertyChanged -= StartOwner_PropertyChanged;
-            model.End.Owner.PropertyChanged -= EndOwner_PropertyChanged;
-            model.ConnectorPinModels.CollectionChanged -= ConnectorPinModelCollectionChanged;
+                model.Start.Owner.PropertyChanged -= StartOwner_PropertyChanged;
+                model.End.Owner.PropertyChanged -= EndOwner_PropertyChanged;
+                model.ConnectorPinModels.CollectionChanged -= ConnectorPinModelCollectionChanged;
+
+                // Nodevm and NodeEnd props are found via model
+                if (Nodevm != null)
+                {
+                    Nodevm.PropertyChanged -= nodeViewModel_PropertyChanged;
+                }
+                if (NodeEnd != null)
+                {
+                    NodeEnd.PropertyChanged -= nodeEndViewModel_PropertyChanged;
+                }
+            }
+
+            workspaceViewModel.PropertyChanged -= WorkspaceViewModel_PropertyChanged;
 
             workspaceViewModel.DynamoViewModel.PropertyChanged -= DynamoViewModel_PropertyChanged;
             workspaceViewModel.DynamoViewModel.Model.PreferenceSettings.PropertyChanged -= DynamoViewModel_PropertyChanged;
-            if (Nodevm != null)
-            {
-                Nodevm.PropertyChanged -= nodeViewModel_PropertyChanged;
-            }
-            if (NodeEnd != null)
-            {
-                NodeEnd.PropertyChanged -= nodeEndViewModel_PropertyChanged;
-            }
 
             if (ConnectorPinViewCollection != null)
             {
@@ -1235,16 +1242,14 @@ namespace Dynamo.ViewModels
                 }
             }
 
-            workspaceViewModel.PropertyChanged -= WorkspaceViewModel_PropertyChanged;
-
             this.PropertyChanged -= ConnectorViewModelPropertyChanged;
             DiscardAllConnectorPinModels();
 
-            if(ConnectorContextMenuViewModel != null)
+            if (ConnectorContextMenuViewModel != null)
             {
                 ConnectorContextMenuViewModel.Dispose();
             }
-            if(ConnectorAnchorViewModel != null)
+            if (ConnectorAnchorViewModel != null)
             {
                 ConnectorAnchorViewModel.Dispose();
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -332,6 +332,7 @@ namespace Dynamo.ViewModels
                     foreach (ConnectorViewModel a in activeConnectors)
                     {
                         this.WorkspaceElements.Remove(a);
+                        a.Dispose();
                     }
                 }
                 this.activeConnectors = null;

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -128,7 +128,6 @@ namespace Dynamo.Controls
             nodeBorder.SizeChanged += OnSizeChanged;
             DataContextChanged += OnDataContextChanged;
 
-
             Panel.SetZIndex(this, 1);
         }
 
@@ -154,6 +153,8 @@ namespace Dynamo.Controls
                 previewControl = null;
             }
             nodeBorder.SizeChanged -= OnSizeChanged;
+            DataContextChanged -= OnDataContextChanged;
+            Loaded -= OnNodeViewLoaded;
         }
 
         #endregion

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -1292,6 +1292,7 @@ namespace Dynamo.Views
         public void Dispose()
         {
             RemoveViewModelsubscriptions(ViewModel);
+            DataContextChanged -= OnWorkspaceViewDataContextChanged;
         }
     }
 }


### PR DESCRIPTION
### Purpose

Based on https://github.com/DynamoDS/Dynamo/pull/15832

It was identified that when working with connectors, the temporary connectors (dotted wires) were not properly disposed, the PR disposes them properly when the wire connection is made.

Also, added a few more unsubscription related to nodes.

Results:

Tested twice with VS Memory Profiler.
Action: Opened Mars graph and closed twice in the same session.

After (Left) : Before (Right)
![Screenshot 2025-05-07 at 7 17 09 PM](https://github.com/user-attachments/assets/7fea493d-0d90-4d6f-bbd0-1651e7f39c94)

![Screenshot 2025-05-07 at 7 20 07 PM](https://github.com/user-attachments/assets/7a169d46-9474-41db-8eac-12ae6d7235b7)

NodeViewModel (Inclusive of all child elements size): 
Before: ~150 MB
After: ~10MB
~93% drop
(The drop was due to node leak fix, as no interaction was done with wires when testing)



### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Fix temporary connector and Node memory leak

### Reviewers

@DynamoDS/eidos 
