### PR TITLE
[DYN-8655] Custom selections node loses contents on Copy

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/CustomSelection.cs
+++ b/src/Libraries/CoreNodeModels/Input/CustomSelection.cs
@@ -182,8 +182,14 @@ namespace CoreNodeModels.Input
                         Items.Add(new DynamoDropDownItem(name, value));
                     }
                 }
-                // Restore default selection to the first item
-                if (Items.Count > 0)
+                // Restore the selected index from the attribute
+                var attrib = nodeElement.Attributes["index"];
+                if (attrib != null && Items.Count > 0)
+                {
+                    var indexStr = attrib.Value;
+                    SelectedIndex = ParseSelectedIndex(indexStr, Items);
+                }
+                else
                 {
                     SelectedIndex = 0;
                 }

--- a/src/Libraries/CoreNodeModels/Input/CustomSelection.cs
+++ b/src/Libraries/CoreNodeModels/Input/CustomSelection.cs
@@ -147,5 +147,47 @@ namespace CoreNodeModels.Input
         {
             serializedItems = Items.ToList();
         }
+
+        protected override void SerializeCore(XmlElement nodeElement, SaveContext context)
+        {
+            base.SerializeCore(nodeElement, context);
+
+            if (context == SaveContext.Copy)
+            {
+                var doc = nodeElement.OwnerDocument;
+
+                foreach (var item in Items)
+                {
+                    var itemElement = doc.CreateElement("CustomItem");
+                    itemElement.SetAttribute("Name", item.Name);
+                    itemElement.SetAttribute("Value", item.Item?.ToString() ?? string.Empty);
+                    nodeElement.AppendChild(itemElement);
+                }
+            }
+        }
+
+        protected override void DeserializeCore(XmlElement nodeElement, SaveContext context)
+        {
+            base.DeserializeCore(nodeElement, context);
+
+            if (context == SaveContext.Copy)
+            {
+                Items.Clear();
+                foreach (XmlNode child in nodeElement.ChildNodes)
+                {
+                    if (child is XmlElement itemElement && itemElement.Name == "CustomItem")
+                    {
+                        var name = itemElement.GetAttribute("Name");
+                        var value = itemElement.GetAttribute("Value");
+                        Items.Add(new DynamoDropDownItem(name, value));
+                    }
+                }
+                // Restore default selection to the first item
+                if (Items.Count > 0)
+                {
+                    SelectedIndex = 0;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
### Purpose

This PR aims to address [DYN-8655](https://jira.autodesk.com/browse/DYN-8655).

I've added custom serialization and deserialization logic to `CustomSelection` to carry over both the dropdown items and the selected index during copy/paste. Now, both the content and the selected item are carried over when the node is copied.

![DYN-8655](https://github.com/user-attachments/assets/0d4ba8cf-d762-4af8-b1f0-a599d2ab20eb)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

The Custom Selection node now carries over both the content and the selected item when copied.

### Reviewers

@DynamoDS/eidos
@jasonstratton  

### FYIs
@achintyabhat 
@dnenov 
@Amoursol
