### PR TITLE
DYN-6515 OpenXML ExportXML Bug Fix

### DIFF
--- a/src/Libraries/DSOfficeUtilities/OpenXmlHelper.cs
+++ b/src/Libraries/DSOfficeUtilities/OpenXmlHelper.cs
@@ -163,17 +163,21 @@ namespace DSOffice
                     }
 
                     Row row;
+                    //This case is when we need to append a new row at the end of the spreadsheet
                     if (rowsIndex >= rows.Count)
                     {
                         // Add a new row to the end
                         row = new Row() { RowIndex = currentRowIndex };
                         sheetData.AppendChild(row);
                     }
+                    //This case is when there are empty rows before or in between the populated rows
                     else if (rows[rowsIndex].RowIndex > currentRowIndex)
                     {
                         // Add a new row before this one
                         row = new Row() { RowIndex = currentRowIndex };
-                        sheetData.InsertBefore(rows[rowsIndex], row);
+
+                        //This is the method definition - InsertBefore(newChild, referenceChild), so we need to pass row as first argument
+                        sheetData.InsertBefore(row, rows[rowsIndex]);
                     }
                     else
                     {
@@ -608,6 +612,14 @@ namespace DSOffice
                 {
                     // The string is not in the table, so we add it
                     sharedStringTable.AppendChild(new SharedStringItem(new Text((string)value)));
+
+                    //Means that the current (row, column) is probably empty so we should start from 0
+                    if (sharedStringTable.Count == null)
+                    {
+                        sharedStringTable.Count = 0;
+                        sharedStringTable.UniqueCount = 0;
+                    }
+
                     index = (int)sharedStringTable.Count.Value;
                     // Yes, you need to update these manually
                     sharedStringTable.Count++;


### PR DESCRIPTION
### Purpose

Fixing some bugs found when using the node Data.OpenXMLExportExcel.
When using the Data.OpenXMLExportExcel node was generating a error saying "Object reference not set to an instance of an object", then in this fix I'm adding code for preventing that error and also fixed the method call to sheetData.InsertBefore due that the arguments were inverted and were producing a node warning message when the spreadsheet used in Data.OpenXMLExportExcel contains empty space in the middle of the populated rows.
### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing some bugs found when using the node Data.OpenXMLExportExcel.

### Reviewers

@reddyashish @zeusongit 

### FYIs

@jnealb 
