### PR TITLE
DYN-8646: Add explicit input port types to Curve Mapper node for object type node autocomplete 

### DIFF
--- a/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
+++ b/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
@@ -18,6 +18,7 @@ namespace CoreNodeModels
     [NodeCategory("Math.Graph.Create")]
     [NodeDescription("CurveMapperDescription", typeof(Properties.Resources))]
     [NodeSearchTags("CurveMapperSearchTags", typeof(Properties.Resources))]
+    [InPortTypes("double", "double", "double", "double", "int")]
     public class CurveMapperNodeModel : NodeModel
     {
         private double minLimitX = 0;


### PR DESCRIPTION
### Purpose

Add explicit input port types to Curve Mapper node for object type node autocomplete.

Adding the input port types explicitly in the `InPortType` class attribute for `NodeModel` nodes is necessary for node-type autocomplete to work as expected for `NodeModel` nodes. This fixes the specific issue highlighted by @jnealb in DYN-8646.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Add explicit input port types to Curve Mapper node for object type node autocomplete 

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
