### PR TITLE
DYN-8535 : improvements to existing dna

### DIFF
--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
@@ -14,8 +14,7 @@
              ShowInTaskbar="False"
              ResizeMode="NoResize"
              Width="280"
-             Height="350"
-             IsVisibleChanged="OnNodeAutoCompleteSearchControlVisibilityChanged">
+             Height="350">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -99,7 +98,7 @@
                         <Image Width="14"
                                    Height="14"
                                    Margin="0,5,10,5"
-                                   MouseDown="CloseAutocompletionWindow"
+                                   MouseDown="CloseAutoCompleteWindow"
                                    HorizontalAlignment="Right"
                                    VerticalAlignment="Center"
                                    Grid.Column="2">

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -45,6 +45,7 @@ namespace Dynamo.ViewModels
         private bool displayLowConfidence;
         private const string nodeAutocompleteMLEndpoint = "MLNodeAutocomplete";
         private const string nodeClusterAutocompleteMLEndpoint = "MLNodeClusterAutocomplete";
+        internal bool IsOpen { get; set; }
 
         // Lucene search utility to perform indexing operations just for NodeAutocomplete.
         internal LuceneSearchUtility LuceneUtility
@@ -621,12 +622,14 @@ namespace Dynamo.ViewModels
 
         internal void OnNodeAutoCompleteWindowOpened()
         {
+            IsOpen = true;
             dynamoViewModel.CurrentSpaceViewModel.Model.NodeRemoved += NodeViewModel_Removed;
             PortViewModel.Highlight = System.Windows.Visibility.Visible;
         }
 
         internal void OnNodeAutoCompleteWindowClosed()
         {
+            IsOpen = false;
             dynamoViewModel.CurrentSpaceViewModel.Model.NodeRemoved -= NodeViewModel_Removed;
             PortViewModel.Highlight = System.Windows.Visibility.Collapsed;
         }

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -45,7 +45,6 @@ namespace Dynamo.ViewModels
         private bool displayLowConfidence;
         private const string nodeAutocompleteMLEndpoint = "MLNodeAutocomplete";
         private const string nodeClusterAutocompleteMLEndpoint = "MLNodeClusterAutocomplete";
-        internal bool IsOpen { get; set; }
 
         // Lucene search utility to perform indexing operations just for NodeAutocomplete.
         internal LuceneSearchUtility LuceneUtility
@@ -457,8 +456,10 @@ namespace Dynamo.ViewModels
                 if (authProvider is IOAuth2AuthProvider oauth2AuthProvider && authProvider is IOAuth2AccessTokenProvider tokenprovider)
                 {
                     var uri = DynamoUtilities.PathHelper.GetServiceBackendAddress(this, nodeAutocompleteMLEndpoint);
-                    var client = new RestClient(uri);
+                    var options = new RestClientOptions(uri) { Timeout = new TimeSpan(0, 0, 7) };;
+                    var client = new RestClient(options);
                     var request = new RestRequest(string.Empty,Method.Post);
+
                     var tkn = tokenprovider?.GetAccessToken();
                     if (string.IsNullOrEmpty(tkn))
                     {
@@ -542,8 +543,7 @@ namespace Dynamo.ViewModels
         internal void PopulateAutoCompleteCandidates()
         {
             if (PortViewModel == null) return;
-
-            dynamoViewModel.CurrentSpaceViewModel.Model.NodeRemoved += NodeViewModel_Removed;
+            
             ResetAutoCompleteSearchViewState();
 
             if (IsDisplayingMLRecommendation)
@@ -619,9 +619,16 @@ namespace Dynamo.ViewModels
             }
         }
 
+        internal void OnNodeAutoCompleteWindowOpened()
+        {
+            dynamoViewModel.CurrentSpaceViewModel.Model.NodeRemoved += NodeViewModel_Removed;
+            PortViewModel.Highlight = System.Windows.Visibility.Visible;
+        }
+
         internal void OnNodeAutoCompleteWindowClosed()
         {
             dynamoViewModel.CurrentSpaceViewModel.Model.NodeRemoved -= NodeViewModel_Removed;
+            PortViewModel.Highlight = System.Windows.Visibility.Collapsed;
         }
 
         internal void NodeViewModel_Removed(NodeModel node)

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -457,7 +457,7 @@ namespace Dynamo.ViewModels
                 if (authProvider is IOAuth2AuthProvider oauth2AuthProvider && authProvider is IOAuth2AccessTokenProvider tokenprovider)
                 {
                     var uri = DynamoUtilities.PathHelper.GetServiceBackendAddress(this, nodeAutocompleteMLEndpoint);
-                    var options = new RestClientOptions(uri) { Timeout = new TimeSpan(0, 0, 7) };;
+                    var options = new RestClientOptions(uri) { Timeout = new TimeSpan(0, 0, 7) };
                     var client = new RestClient(options);
                     var request = new RestRequest(string.Empty,Method.Post);
 

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -189,8 +189,7 @@ namespace Dynamo.Views
         }
 
         private void ShowNodeAutoCompleteControl()
-        {
-            if (ViewModel.NodeAutoCompleteSearchViewModel.IsOpen) return;
+        {            
             if (ViewModel.NodeAutoCompleteSearchViewModel.PortViewModel == null) return;
             // if the MLRecommendation is default but user not accepting TOU, display notification
             if (ViewModel.NodeAutoCompleteSearchViewModel.IsDisplayingMLRecommendation && !ViewModel.NodeAutoCompleteSearchViewModel.IsMLAutocompleteTOUApproved)
@@ -199,11 +198,7 @@ namespace Dynamo.Views
                 return;
             }
 
-            //TODO : Reuse this window?
-            var nodeAutoCompleteBarWindow = new NodeAutoCompleteSearchControl(Window.GetWindow(this), ViewModel.NodeAutoCompleteSearchViewModel);
-            nodeAutoCompleteBarWindow.Show();
-
-            ViewModel.NodeAutoCompleteSearchViewModel.PortViewModel.SetupNodeAutoCompleteWindowPlacement(nodeAutoCompleteBarWindow);
+            NodeAutoCompleteSearchControl.PrepareAndShowNodeAutoCompleteSearch(Window.GetWindow(this), ViewModel.NodeAutoCompleteSearchViewModel);
         }
 
         private void ShowNodeAutoCompleteBar(PortViewModel viewModel)


### PR DESCRIPTION
### Purpose
Improve existing node auto complete. We can also integrate these improvements into the new flyout as we see fit.
- reuse the window (as much as possible)
- add a time limit to ml service request 
- improve handling of event subscription/un-subscription so that we don't continue to pile up event subscriptions
- handle multiple workspaces - you can have multiple tabs as custom nodes

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

N/A

### Reviewers
@DynamoDS/synapse 

### FYI
@QilongTang 
