### PR TITLE
DYN-5555-Update-Sign-In Tooltip Style

### DIFF
--- a/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml.cs
@@ -101,8 +101,16 @@ namespace Dynamo.UI.Controls
                 };
 
                 // Retrieve the style from resources
-                var style = (Style)FindResource("GenericToolTipLight");
-                toolTip.Style = style;
+                var style = (Style)TryFindResource("GenericToolTipLight");
+                if (style != null)
+                {
+                    toolTip.Style = style;
+                }
+                else
+                {
+                    // Optionally log a warning or handle the missing resource gracefully
+                    System.Diagnostics.Debug.WriteLine("Warning: 'GenericToolTipLight' resource not found.");
+                }
 
                 // Assign the styled tooltip to the Login Button
                 LoginButton.ToolTip = toolTip;


### PR DESCRIPTION

### Purpose

Fixing problem about the Tooltip Style after the Sign Out button is pressed in Dynamo
When signed in Dynamo if you press the Sign Out button was just setting the Tooltip text but the style was null, so with this fix I'm setting the Style in code behind after Sign Out button was pressed. When Signed in no tooltip text is appearing so no need to update the content.


### Declarations

Check these if you believe they are true

- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

Fixing problem about the Tooltip Style after the Sign Out button is pressed in Dynamo

### Reviewers

@reddyashish @zeusongit 

### FYIs

@avidit 
