### PR TITLE
Revert "[DYN-7843] Resize collapsed groups (#16203)" due to performance regression

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -143,11 +143,6 @@ namespace Dynamo.Graph.Workspaces
         public string PinnedNode;
         public double WidthAdjustment;
         public double HeightAdjustment;
-        public double WidthAdjustmentCollapsed;
-        public double HeightAdjustmentCollapsed;
-        public double WidthAdjustmentExpanded;
-        public double HeightAdjustmentExpanded;
-        public bool IsResizedWhileCollapsed;
 
         // TODO, Determine if these are required
         public double Left;
@@ -2712,11 +2707,6 @@ namespace Dynamo.Graph.Workspaces
             annotationModel.GUID = annotationGuidValue;
             annotationModel.HeightAdjustment = annotationViewInfo.HeightAdjustment;
             annotationModel.WidthAdjustment = annotationViewInfo.WidthAdjustment;
-            annotationModel.HeightAdjustmentCollapsed = annotationViewInfo.HeightAdjustmentCollapsed;
-            annotationModel.WidthAdjustmentCollapsed = annotationViewInfo.WidthAdjustmentCollapsed;
-            annotationModel.HeightAdjustmentExpanded = annotationViewInfo.HeightAdjustmentExpanded;
-            annotationModel.WidthAdjustmentExpanded = annotationViewInfo.WidthAdjustmentExpanded;
-            annotationModel.IsResizedWhileCollapsed = annotationViewInfo.IsResizedWhileCollapsed;
             annotationModel.UpdateGroupFrozenStatus();
 
             annotationModel.ModelBaseRequested += annotationModel_GetModelBase;

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -47,7 +47,6 @@ const Dynamo.Engine.LibraryServices.Categories.Constructors = "Create" -> string
 const Dynamo.Engine.LibraryServices.Categories.MemberFunctions = "Actions" -> string
 const Dynamo.Engine.LibraryServices.Categories.Operators = "Operators" -> string
 const Dynamo.Engine.LibraryServices.Categories.Properties = "Query" -> string
-const Dynamo.Graph.Annotations.AnnotationModel.CollapsedContentHeight = 82 -> double
 const Dynamo.Graph.Nodes.BuiltinNodeCategories.ANALYZE_SOLAR = "Analyze.Solar" -> string
 const Dynamo.Graph.Nodes.BuiltinNodeCategories.CORE = "Core" -> string
 const Dynamo.Graph.Nodes.BuiltinNodeCategories.CORE_EVALUATE = "Core.Evaluate" -> string
@@ -703,10 +702,6 @@ Dynamo.Graph.Annotations.AnnotationModel.GroupStyleId.set -> void
 Dynamo.Graph.Annotations.AnnotationModel.HasNestedGroups.get -> bool
 Dynamo.Graph.Annotations.AnnotationModel.HeightAdjustment.get -> double
 Dynamo.Graph.Annotations.AnnotationModel.HeightAdjustment.set -> void
-Dynamo.Graph.Annotations.AnnotationModel.HeightAdjustmentCollapsed.get -> double
-Dynamo.Graph.Annotations.AnnotationModel.HeightAdjustmentCollapsed.set -> void
-Dynamo.Graph.Annotations.AnnotationModel.HeightAdjustmentExpanded.get -> double
-Dynamo.Graph.Annotations.AnnotationModel.HeightAdjustmentExpanded.set -> void
 Dynamo.Graph.Annotations.AnnotationModel.InitialHeight.get -> double
 Dynamo.Graph.Annotations.AnnotationModel.InitialHeight.set -> void
 Dynamo.Graph.Annotations.AnnotationModel.InitialTop.get -> double
@@ -714,15 +709,9 @@ Dynamo.Graph.Annotations.AnnotationModel.InitialTop.set -> void
 Dynamo.Graph.Annotations.AnnotationModel.IsExpanded.get -> bool
 Dynamo.Graph.Annotations.AnnotationModel.IsExpanded.set -> void
 Dynamo.Graph.Annotations.AnnotationModel.IsFrozen.get -> bool
-Dynamo.Graph.Annotations.AnnotationModel.IsResizedWhileCollapsed.get -> bool
-Dynamo.Graph.Annotations.AnnotationModel.IsResizedWhileCollapsed.set -> void
 Dynamo.Graph.Annotations.AnnotationModel.IsVisible.get -> bool
 Dynamo.Graph.Annotations.AnnotationModel.loadFromXML.get -> bool
 Dynamo.Graph.Annotations.AnnotationModel.loadFromXML.set -> void
-Dynamo.Graph.Annotations.AnnotationModel.MinCollapsedPortAreaHeight.get -> double
-Dynamo.Graph.Annotations.AnnotationModel.MinCollapsedPortAreaHeight.set -> void
-Dynamo.Graph.Annotations.AnnotationModel.MinWidthOnCollapsed.get -> double
-Dynamo.Graph.Annotations.AnnotationModel.MinWidthOnCollapsed.set -> void
 Dynamo.Graph.Annotations.AnnotationModel.ModelAreaHeight.get -> double
 Dynamo.Graph.Annotations.AnnotationModel.ModelAreaHeight.set -> void
 Dynamo.Graph.Annotations.AnnotationModel.ModelBaseRequested -> System.Func<System.Guid, Dynamo.Graph.ModelBase>
@@ -738,10 +727,6 @@ Dynamo.Graph.Annotations.AnnotationModel.TextMaxWidth.get -> double
 Dynamo.Graph.Annotations.AnnotationModel.TextMaxWidth.set -> void
 Dynamo.Graph.Annotations.AnnotationModel.WidthAdjustment.get -> double
 Dynamo.Graph.Annotations.AnnotationModel.WidthAdjustment.set -> void
-Dynamo.Graph.Annotations.AnnotationModel.WidthAdjustmentCollapsed.get -> double
-Dynamo.Graph.Annotations.AnnotationModel.WidthAdjustmentCollapsed.set -> void
-Dynamo.Graph.Annotations.AnnotationModel.WidthAdjustmentExpanded.get -> double
-Dynamo.Graph.Annotations.AnnotationModel.WidthAdjustmentExpanded.set -> void
 Dynamo.Graph.ConnectorPinModel
 Dynamo.Graph.ConnectorPinModel.ConnectorId.get -> System.Guid
 Dynamo.Graph.ConnectorPinModel.ConnectorId.set -> void
@@ -1299,13 +1284,10 @@ Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.GroupStyleId -> System.Guid
 Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.HasNestedGroups -> bool
 Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.Height -> double
 Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.HeightAdjustment -> double
-Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.HeightAdjustmentCollapsed -> double
-Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.HeightAdjustmentExpanded -> double
 Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.Id -> string
 Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.InitialHeight -> double
 Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.InitialTop -> double
 Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.IsExpanded -> bool
-Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.IsResizedWhileCollapsed -> bool
 Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.Left -> double
 Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.Nodes -> System.Collections.Generic.IEnumerable<string>
 Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.PinnedNode -> string
@@ -1314,8 +1296,6 @@ Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.Title -> string
 Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.Top -> double
 Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.Width -> double
 Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.WidthAdjustment -> double
-Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.WidthAdjustmentCollapsed -> double
-Dynamo.Graph.Workspaces.ExtraAnnotationViewInfo.WidthAdjustmentExpanded -> double
 Dynamo.Graph.Workspaces.ExtraConnectorPinInfo
 Dynamo.Graph.Workspaces.ExtraConnectorPinInfo.ConnectorGuid -> string
 Dynamo.Graph.Workspaces.ExtraConnectorPinInfo.ExtraConnectorPinInfo() -> void

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -3897,32 +3897,21 @@ namespace Dynamo.Controls
 
     /// <summary>
     /// Returns a dark or light color depending on the contrast ration of the color with the background color
-    /// If the control is a Thumb (passed via the converter parameter), the dark color is slightly different
-    /// Contrast ratio should be larger than 4.5:1
+    /// Contrast ration should be larger than 4.5:1
     /// Contrast calculation algorithm from https://stackoverflow.com/questions/70187918/adapt-given-color-pairs-to-adhere-to-w3c-accessibility-standard-for-epubs/70192373#70192373
-    ///
-    /// Expected values for controlType:
-    /// - "Thumb" : applies alternate dark color for thumb controls
-    /// - null    : applies default dark color for annotation text and description
     /// </summary>
     public class TextForegroundSaturationColorConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var controlType = parameter as string;
-
             var lightColor = (System.Windows.Media.Color)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["WhiteColor"];
-            var darkColorText = (System.Windows.Media.Color)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["DarkerGrey"];
-            var darkColorThumb = (System.Windows.Media.Color)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["MidGrey"];
+            var darkColor = (System.Windows.Media.Color)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["DarkerGrey"];
 
             var backgroundColor = (System.Windows.Media.Color)value;
 
-            var contrastRatio = GetContrastRatio(darkColorText, backgroundColor);
+            var contrastRatio = GetContrastRatio(darkColor, backgroundColor);
 
-            if (contrastRatio < 4.5)
-                return new SolidColorBrush(lightColor);
-            else
-                return controlType == "Thumb" ? new SolidColorBrush(darkColorThumb) : new SolidColorBrush(darkColorText);
+            return contrastRatio < 4.5 ? new SolidColorBrush(lightColor) : new SolidColorBrush(darkColor);
         }
 
         public object ConvertBack(object value, Type targetType, object parameter,

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -702,15 +702,9 @@ namespace Dynamo.ViewModels
             // owner
             newPortViewModels = CreateProxyInPorts(originalInPorts);
 
-            // Set the minimum required vertical space to fit the input ports when collapsed
-            if (newPortViewModels == null)
-            {
-                annotationModel.MinCollapsedPortAreaHeight = 0;
-                return;
-            }
-
-            annotationModel.MinCollapsedPortAreaHeight = newPortViewModels.Sum(p => p.Height);
+            if (newPortViewModels == null) return;
             InPorts.AddRange(newPortViewModels);
+            return;
         }
 
         /// <summary>
@@ -723,7 +717,7 @@ namespace Dynamo.ViewModels
             List<PortViewModel> newPortViewModels;
 
             // we need to store the original ports here
-            // as we need these later for when we
+            // as we need thoese later for when we
             // need to collapse the groups content
             if (this.AnnotationModel.HasNestedGroups)
             {
@@ -741,19 +735,13 @@ namespace Dynamo.ViewModels
 
             // Create proxies of the ports so we can
             // visually add them to the group but they
-            // should still reference their NodeModel owner
+            // should still reference their NodeModel
+            // owner
             newPortViewModels = CreateProxyOutPorts(originalOutPorts);
 
-            // If no view models were created, we leave the existing height as is
-            if (newPortViewModels == null)
-                return;
-
-            // Update the collapsed port area height to be the greater of the existing value
-            // and the height needed to render all output ports
-            var outportsHeight = newPortViewModels.Sum(p => p.Height);
-            annotationModel.MinCollapsedPortAreaHeight = Math.Max(annotationModel.MinCollapsedPortAreaHeight, outportsHeight);
-
+            if (newPortViewModels == null) return;
             OutPorts.AddRange(newPortViewModels);
+            return;
         }
 
         internal IEnumerable<PortModel> GetGroupInPorts(IEnumerable<NodeModel> ownerNodes = null)
@@ -988,11 +976,8 @@ namespace Dynamo.ViewModels
             }
         }
 
-        private void RedrawConnectors(bool isCollapsedCheck = false)
+        private void RedrawConnectors()
         {
-            if (isCollapsedCheck && IsExpanded && !annotationModel.IsResizedWhileCollapsed)
-                return;
-
             var allNodes = this.Nodes
                 .OfType<AnnotationModel>()
                 .SelectMany(x => x.Nodes.OfType<NodeModel>())
@@ -1083,7 +1068,6 @@ namespace Dynamo.ViewModels
 
             if (annotationModel.IsExpanded)
             {
-                ToggleSizeAdjustmentsForCollapse(false);
                 this.ShowGroupContents();
             }
             else
@@ -1091,9 +1075,6 @@ namespace Dynamo.ViewModels
                 this.SetGroupInputPorts();
                 this.SetGroupOutPorts();
                 this.CollapseGroupContents(true);
-                ToggleSizeAdjustmentsForCollapse(true);
-
-                RaisePropertyChanged(nameof(Height));
                 RaisePropertyChanged(nameof(NodeContentCount));
             }
             WorkspaceViewModel.HasUnsavedChanges = true;
@@ -1101,35 +1082,6 @@ namespace Dynamo.ViewModels
             RaisePropertyChanged(nameof(IsExpanded));
             RedrawConnectors();
             ReportNodesPosition();
-        }
-
-        /// <summary>
-        /// Switches the width and height adjustment values when toggling
-        /// between collapsed and expanded group states.
-        /// </summary>
-        private void ToggleSizeAdjustmentsForCollapse(bool isCollapsing)
-        {
-            if (isCollapsing)
-            {
-                annotationModel.WidthAdjustmentExpanded = annotationModel.WidthAdjustment;
-                annotationModel.HeightAdjustmentExpanded = annotationModel.HeightAdjustment;
-
-                // Reset to collapsed value so first resize ignores expanded height adjustment
-                annotationModel.HeightAdjustment = annotationModel.HeightAdjustmentCollapsed;
-
-                if (annotationModel.IsResizedWhileCollapsed)
-                {
-                    annotationModel.WidthAdjustment = annotationModel.WidthAdjustmentCollapsed;
-                }
-            }
-            else
-            {
-                annotationModel.WidthAdjustmentCollapsed = annotationModel.WidthAdjustment;
-                annotationModel.HeightAdjustmentCollapsed = annotationModel.HeightAdjustment;
-
-                annotationModel.WidthAdjustment = annotationModel.WidthAdjustmentExpanded;
-                annotationModel.HeightAdjustment = annotationModel.HeightAdjustmentExpanded;
-            }
         }
 
         private void UpdateFontSize(object parameter)
@@ -1247,7 +1199,6 @@ namespace Dynamo.ViewModels
                     RaisePropertyChanged("Width");
                     RaisePropertyChanged(nameof(ModelAreaRect));
                     UpdateAllGroupedGroups();
-                    RedrawConnectors(false);
                     break;
                 case "Height":
                     RaisePropertyChanged("Height");

--- a/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
@@ -127,20 +127,10 @@ namespace Dynamo.Wpf.ViewModels.Core.Converters
             writer.WriteValue(anno.AnnotationDescriptionText);
             writer.WritePropertyName(nameof(ExtraAnnotationViewInfo.IsExpanded));
             writer.WriteValue(anno.IsExpanded);
-            writer.WritePropertyName(nameof(ExtraAnnotationViewInfo.IsResizedWhileCollapsed));
-            writer.WriteValue(anno.IsResizedWhileCollapsed);
             writer.WritePropertyName(nameof(ExtraAnnotationViewInfo.WidthAdjustment));
             writer.WriteValue(anno.WidthAdjustment);
             writer.WritePropertyName(nameof(ExtraAnnotationViewInfo.HeightAdjustment));
             writer.WriteValue(anno.HeightAdjustment);
-            writer.WritePropertyName(nameof(ExtraAnnotationViewInfo.WidthAdjustmentCollapsed));
-            writer.WriteValue(anno.WidthAdjustmentCollapsed);
-            writer.WritePropertyName(nameof(ExtraAnnotationViewInfo.HeightAdjustmentCollapsed));
-            writer.WriteValue(anno.HeightAdjustmentCollapsed);
-            writer.WritePropertyName(nameof(ExtraAnnotationViewInfo.WidthAdjustmentExpanded));
-            writer.WriteValue(anno.WidthAdjustmentExpanded);
-            writer.WritePropertyName(nameof(ExtraAnnotationViewInfo.HeightAdjustmentExpanded));
-            writer.WriteValue(anno.HeightAdjustmentExpanded);
             writer.WritePropertyName("Nodes");
             writer.WriteStartArray();
             foreach (var m in anno.Nodes)

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -403,26 +403,6 @@
                 </Setter.Value>
             </Setter>
         </Style>
-
-        <Style x:Key="GroupResizeThumbStyle" TargetType="{x:Type Thumb}">
-            <Setter Property="SnapsToDevicePixels" Value="True" />
-            <Setter Property="Margin" Value="0,0,2.5,2.5" />
-            <Setter Property="Width" Value="10" />
-            <Setter Property="Height" Value="10" />
-            <Setter Property="HorizontalAlignment" Value="Right" />
-            <Setter Property="VerticalAlignment" Value="Bottom" />
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="{x:Type Thumb}">
-                        <Polygon Points="0,8 8,8 8,0"
-                         Fill="{Binding DataContext.Background,
-                                RelativeSource={RelativeSource AncestorType=UserControl},
-                                Converter={StaticResource TextForegroundSaturationColorConverter},
-                                ConverterParameter=Thumb}" />
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
     </UserControl.Resources>
 
     <Grid Name="AnnotationGrid"
@@ -948,10 +928,27 @@
                 </Canvas>
 
                 <Thumb x:Name="ResizeThumb"
-                       Style="{StaticResource GroupResizeThumbStyle}"
+                       Width="10"
+                       Height="10"
+                       HorizontalAlignment="Right"
+                       VerticalAlignment="Bottom"
                        DragDelta="AnnotationRectangleThumb_DragDelta"
                        MouseEnter="Thumb_MouseEnter"
-                       MouseLeave="Thumb_MouseLeave" />
+                       MouseLeave="Thumb_MouseLeave">
+                    <Thumb.Style>
+                        <Style TargetType="{x:Type Thumb}">
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="{x:Type Thumb}">
+                                        <Border BorderThickness="0"
+                                                BorderBrush="Transparent"
+                                                Background="Transparent" />
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </Thumb.Style>
+                </Thumb>
             </Grid>
         </Expander>
         <!--
@@ -966,7 +963,6 @@
         -->
         <Border x:Name="CollapsedAnnotationRectangle"
                 Width="{Binding Width}"
-                Height="{Binding ModelAreaHeight}"
                 Visibility="{Binding ElementName=GroupExpander, Path=IsExpanded, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}"
                 Grid.Row="1">
             <Border.Background>
@@ -980,7 +976,7 @@
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
                 <!--INPUT PORTS-->
@@ -1058,7 +1054,6 @@
                             Background="#EEEEEE"
                             CornerRadius="{Binding Path=ActualHeight, ElementName=NodeCount}"
                             Width="{Binding Path=ActualHeight, ElementName=NodeCount}"
-                            VerticalAlignment="Bottom"
                             Height="32"
                             Margin="10">
                         <TextBlock Text="{Binding NodeContentCount, Mode=OneWay, StringFormat='+{0}'}"
@@ -1067,14 +1062,6 @@
                                    FontSize="14" />
                     </Border>
                 </Grid>
-
-                <Thumb x:Name="ResizeThumbCollapsed"
-                       Grid.Row="1"
-                       Grid.Column="2"
-                       Style="{StaticResource GroupResizeThumbStyle}"
-                       DragDelta="CollapsedAnnotationRectangleThumb_DragDelta"
-                       MouseEnter="Thumb_MouseEnter"
-                       MouseLeave="Thumb_MouseLeave" />
             </Grid>
         </Border>
     </Grid>


### PR DESCRIPTION
### Purpose

This reverts commit e2a8ee60d9031284e49b66718f48e33d04ce4c0a.

The profiling results with this change (adds more than 60s):
![Screenshot 2025-06-11 at 12 54 19 PM](https://github.com/user-attachments/assets/d55c7704-88e1-4062-882f-d46168d16fce)

and without:
![Screenshot 2025-06-11 at 12 55 18 PM](https://github.com/user-attachments/assets/27991f5c-e691-45a9-ac4a-28a2744deee9)


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

na

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
