### PR TITLE
DYN-9033: Make IsObsolete attribute message take precedence over Obsolete attribute message

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -1288,6 +1288,7 @@ namespace ProtoFFI
     public class FFIMethodAttributes : ProtoCore.AST.AssociativeAST.MethodAttributes
     {
         private List<Attribute> attributes;
+        private bool hasIsObsoleteAttribute;
         /// <summary>
         /// FFI method attributes.
         /// </summary>
@@ -1409,6 +1410,7 @@ namespace ProtoFFI
                 else if (attr is IsObsoleteAttribute)
                 {
                     HiddenInLibrary = true;
+                    hasIsObsoleteAttribute = true;
                     ObsoleteMessage = (attr as IsObsoleteAttribute).Message;
                     if (string.IsNullOrEmpty(ObsoleteMessage))
                         ObsoleteMessage = "Obsolete";
@@ -1416,9 +1418,14 @@ namespace ProtoFFI
                 else if (attr is ObsoleteAttribute)
                 {
                     HiddenInLibrary = true;
-                    ObsoleteMessage = (attr as ObsoleteAttribute).Message;
-                    if (string.IsNullOrEmpty(ObsoleteMessage))
-                        ObsoleteMessage = "Obsolete";
+                    // Obsolete message in IsObsoleteAttribute is overridden to support localization
+                    // and therefore should always be preferred over the ObsoleteAttribute message.
+                    if (!hasIsObsoleteAttribute || string.IsNullOrEmpty(ObsoleteMessage))
+                    {
+                        ObsoleteMessage = (attr as ObsoleteAttribute).Message;
+                        if (string.IsNullOrEmpty(ObsoleteMessage))
+                            ObsoleteMessage = "Obsolete";
+                    }
                 }
                 else if (attr is CanUpdatePeriodicallyAttribute)
                 {

--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -1420,6 +1420,8 @@ namespace ProtoFFI
                     HiddenInLibrary = true;
                     // Obsolete message in IsObsoleteAttribute is overridden to support localization
                     // and therefore should always be preferred over the ObsoleteAttribute message.
+                    // The following logic ensures that the ObsoleteAttribute message is only used
+                    // if the IsObsoleteAttribute is not present or its message is empty.
                     if (!hasIsObsoleteAttribute || string.IsNullOrEmpty(ObsoleteMessage))
                     {
                         ObsoleteMessage = (attr as ObsoleteAttribute).Message;


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-9033

`IsObsolete ` attribute message should take precedence over `Obsolete ` attribute message.

When both `IsObsolete` and `Obsolete` attributes are defined on a function (such as for some deprecated LibG functions), the message for whichever attribute was processed last was assigned to the warning message on the node. As `IsObsolete` attribute is a custom attribute in Dynamo that supports localization for its messages, it should take precedence over the message for `Obsolete` attribute, which is non-localized. This PR makes this change so that all deprecated node warnings are localized appropriately.

![image](https://github.com/user-attachments/assets/bb32c907-c315-4801-9985-d710a0ce9bbf)


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

Make `IsObsolete` attribute message take precedence over `Obsolete` attribute message on nodes so that if `IsObsolete` attribute messages are localized, the localized version of the deprecated warning can be displayed for non-ENU locales.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
