### PR TITLE
Dyn-9003 - Update `AutocompleteLowConfidenceMessage`

### DIFF
--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -89,7 +89,7 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to All recommendations are below the specified confidence level. You can try them or adjust the confidence settings in Preferences..
+        ///   Looks up a localized string similar to No confident suggestions available. The model is continuously improving - check back soon.
         /// </summary>
         public static string AutocompleteLowConfidenceMessage {
             get {

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -885,7 +885,7 @@ This package likely contains an assembly that is blocked. You will need to load 
     <value>There are no recommendations yet. You can try switching to node type match autocomplete.</value>
   </data>
   <data name="AutocompleteLowConfidenceMessage" xml:space="preserve">
-    <value>All recommendations are below the specified confidence level. You can try them or adjust the confidence settings in Preferences.</value>
+    <value>No confident suggestions available. The model is continuously improving - check back soon.</value>
   </data>
   <data name="AutocompleteLowConfidenceTooltip" xml:space="preserve">
     <value>Show Recommendations that are below the confidence level.</value>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -888,7 +888,7 @@ This package likely contains an assembly that is blocked. You will need to load 
     <value>There are no recommendations yet. You can try switching to node type match autocomplete.</value>
   </data>
   <data name="AutocompleteLowConfidenceMessage" xml:space="preserve">
-    <value>All recommendations are below the specified confidence level. You can try them or adjust the confidence settings in Preferences.</value>
+    <value>No confident suggestions available. The model is continuously improving - check back soon.</value>
   </data>
   <data name="AutocompleteLowConfidenceTooltip" xml:space="preserve">
     <value>Show Recommendations that are below the confidence level.</value>


### PR DESCRIPTION
### Purpose

Updates the user-facing message for low-confidence autocomplete suggestions to be more user-friendly and encouraging.

Refines the text of AutocompleteLowConfidenceMessage in both default and en-US resource files.
Streamlines messaging to remove references to preference adjustments.

![image](https://github.com/user-attachments/assets/5dec51f4-5d7c-456c-a950-41f14886755a)


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

N/A

### Reviewers

@DynamoDS/synapse 

### FYIs

@achintyabhat @emru-y 
