### PR TITLE
Remove unused code for Port cursor

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -870,22 +870,6 @@ namespace Dynamo.Views
                     ViewModel.CurrentCursor = CursorLibrary.GetCursor(CursorSet.ArcSelect);
             }
 
-            if (ViewModel.IsInIdleState)
-            {
-                // Find the dependency object directly under the mouse 
-                // cursor, then see if it represents a port. If it does,
-                // then determine its type, we would like to show the 
-                // "ArcRemoving" cursor when the mouse is over an out port.
-                Point mouse = e.GetPosition((UIElement)sender);
-                var dependencyObject = ElementUnderMouseCursor(mouse);
-                PortViewModel pvm = PortFromHitTestResult(dependencyObject);
-
-                if (null != pvm && (pvm.PortType == PortType.Input))
-                    this.Cursor = CursorLibrary.GetCursor(CursorSet.ArcSelect);
-                else
-                    this.Cursor = null;
-            }
-
             // If selection is going to be dragged and ctrl is pressed.
             if (ViewModel.IsDragging && Keyboard.Modifiers == ModifierKeys.Control)
             {
@@ -1036,35 +1020,6 @@ namespace Dynamo.Views
         {
             workBench = sender as DragCanvas;
             workBench.owningWorkspace = this;
-        }
-
-        private PortViewModel PortFromHitTestResult(DependencyObject depObject)
-        {
-            Grid grid = depObject as Grid;
-            if (null != grid)
-                return grid.DataContext as PortViewModel;
-
-            return null;
-        }
-
-        private DependencyObject ElementUnderMouseCursor(Point mouseCursor)
-        {
-            hitResultsList.Clear();
-            VisualTreeHelper.HitTest(this, null, DirectHitTestCallback,
-                new PointHitTestParameters(mouseCursor));
-
-            return ((hitResultsList.Count > 0) ? hitResultsList[0] : null);
-        }
-
-        private HitTestResultBehavior DirectHitTestCallback(HitTestResult result)
-        {
-            if (null != result && (null != result.VisualHit))
-            {
-                hitResultsList.Add(result.VisualHit);
-                return HitTestResultBehavior.Stop;
-            }
-
-            return HitTestResultBehavior.Continue;
         }
 
         private void OnWorkspaceDrop(object sender, DragEventArgs e)


### PR DESCRIPTION
### Purpose

Based on the Reope PR: https://github.com/DynamoDS/Dynamo/pull/15825
See original PR's description for a detailed summary.

TLDR; Removing some code from MouseMove event which used to trigger when mouse hover over the input port, at which point the cursor should have been changed to `CursorSet.ArcSelect`. But this have not been working since Notes were introduced (May 2023). IMO it is better to go away with it and gain some performance instead.

I tried to quantify the gain but it is hard, I tried to capture the amount of processing time spent inside the code while simply hovering over a huge graph, for a difference in CPU usage you can look at the screenshots on the original PR.
(I did see minor gains when selecting nodes in the workspace after this fix)

![DynamoSandbox_OfomJLQ10S](https://github.com/user-attachments/assets/b97c5a17-e0b5-4f48-9976-37436743e468)


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

Remove unused code for Port cursor

### Reviewers


