### PR TITLE
DYN-8658:allowed newline support

### DIFF
--- a/src/GraphMetadataViewExtension/GraphMetadataView.xaml
+++ b/src/GraphMetadataViewExtension/GraphMetadataView.xaml
@@ -144,7 +144,8 @@
             <HeaderedContentControl Header="{x:Static properties:Resources.GraphMetaData_Description}">
                 <TextBox Text="{Binding GraphDescription, Mode=TwoWay, FallbackValue='Graph Description'}"
                          Style="{StaticResource TextBoxStyle}"
-                         TextWrapping="WrapWithOverflow" />
+                         TextWrapping="WrapWithOverflow"
+                         AcceptsReturn="True" />
             </HeaderedContentControl>
 
             <HeaderedContentControl Header="{x:Static properties:Resources.GraphMetaData_Image}">


### PR DESCRIPTION
### Purpose

Allow newline support for the Graph Properties Description field. As per https://jira.autodesk.com/browse/DYN-8658

![image](https://github.com/user-attachments/assets/b330709b-b327-4505-a3a7-78c23c6730e3)


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

- allowed new line support for Graph Properties Description field

### Reviewers

@zeusongit 
@reddyashish 

### FYIs

@achintyabhat 
