### PR TITLE
DYN-7099: notification focus fix

### DIFF
--- a/src/Notifications/View/NotificationUI.xaml
+++ b/src/Notifications/View/NotificationUI.xaml
@@ -1,79 +1,82 @@
-<Popup x:Class="Dynamo.Notifications.View.NotificationUI"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-       xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
-       xmlns:controls="clr-namespace:Dynamo.Controls;assembly=DynamoCoreWpf"
-       xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf" 
-       xmlns:fa="http://schemas.fontawesome.io/icons/" 
-       xmlns:wv2="clr-namespace:Dynamo.Wpf.Utilities;assembly=DynamoCoreWpf"
-       mc:Ignorable="d" 
-       AllowsTransparency="True"
-       StaysOpen="False"
-       Opacity="0.5"
-       Width="340"
-       Height="598">
+<Popup
+    x:Class="Dynamo.Notifications.View.NotificationUI"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:Dynamo.Controls;assembly=DynamoCoreWpf"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:fa="http://schemas.fontawesome.io/icons/"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
+    xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
+    xmlns:wv2="clr-namespace:Dynamo.Wpf.Utilities;assembly=DynamoCoreWpf"
+    Width="340"
+    Height="598"
+    AllowsTransparency="True"
+    Opacity="0.5"
+    Opened="NotificationUI_Opened"
+    StaysOpen="False"
+    mc:Ignorable="d">
     <Popup.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
-            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
-            <controls:PointsToPathConverter x:Key="PointsToPathConverter"/>
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+            <controls:PointsToPathConverter x:Key="PointsToPathConverter" />
         </ResourceDictionary>
     </Popup.Resources>
-    <Canvas Background="Transparent"
-            Name="RootLayout" >
-        <Path x:Name="PopupPathRectangle" 
-              Style="{StaticResource PoupPathRectangleStyle}">
+    <Canvas Name="RootLayout" Background="Transparent">
+        <Path x:Name="PopupPathRectangle" Style="{StaticResource PoupPathRectangleStyle}">
             <Path.Data>
-                <RectangleGeometry x:Name="BackgroundRectangle">
-                </RectangleGeometry>
+                <RectangleGeometry x:Name="BackgroundRectangle" />
             </Path.Data>
-            <!--This effect will show a 4px shadow of 20% of tranparency with a angle of 135 grades-->
+            <!--  This effect will show a 4px shadow of 20% of tranparency with a angle of 135 grades  -->
             <Path.Effect>
-                <DropShadowEffect Opacity="0.2" 
-                                  Color="Black"
-                                  ShadowDepth="4"
-                                  BlurRadius="4"
-                                  Direction="135"/>
+                <DropShadowEffect
+                    BlurRadius="4"
+                    Direction="135"
+                    Opacity="0.2"
+                    ShadowDepth="4"
+                    Color="Black" />
             </Path.Effect>
         </Path>
 
-        <Path x:Name="PopupPathRectangleShadow"   
-              Style="{StaticResource PoupPathRectangleStyle}">
+        <Path x:Name="PopupPathRectangleShadow" Style="{StaticResource PoupPathRectangleStyle}">
             <Path.Data>
-                <RectangleGeometry Rect="{Binding ElementName=BackgroundRectangle, Path=Rect}">
-                </RectangleGeometry>
+                <RectangleGeometry Rect="{Binding ElementName=BackgroundRectangle, Path=Rect}" />
             </Path.Data>
-            <!--This effect will show a 4px shadow of 20% of tranparency with a angle of 315 grades-->
+            <!--  This effect will show a 4px shadow of 20% of tranparency with a angle of 315 grades  -->
             <Path.Effect>
-                <DropShadowEffect Opacity="0.2" 
-                                  Color="Black"
-                                  ShadowDepth="4"
-                                  BlurRadius="4"
-                                  Direction="315"/>
+                <DropShadowEffect
+                    BlurRadius="4"
+                    Direction="315"
+                    Opacity="0.2"
+                    ShadowDepth="4"
+                    Color="Black" />
             </Path.Effect>
         </Path>
 
-        <!--This Path will draw on the Canvas the pointer (a triangle)-->
-        <Path  x:Name="TooltipPointer"
-               Data="{Binding Path=TooltipPointerPoints, Converter={StaticResource PointsToPathConverter}}"
-               Style="{StaticResource PoupPathPointerStyle}">
+        <!--  This Path will draw on the Canvas the pointer (a triangle)  -->
+        <Path
+            x:Name="TooltipPointer"
+            Data="{Binding Path=TooltipPointerPoints, Converter={StaticResource PointsToPathConverter}}"
+            Style="{StaticResource PoupPathPointerStyle}">
             <Path.Effect>
-                <DropShadowEffect Opacity="0.2" 
-                                  Color="Black"
-                                  ShadowDepth="4"
-                                  BlurRadius="4"
-                                  Direction="{Binding Path=ShadowTooltipDirection}"/>
+                <DropShadowEffect
+                    BlurRadius="4"
+                    Direction="{Binding Path=ShadowTooltipDirection}"
+                    Opacity="0.2"
+                    ShadowDepth="4"
+                    Color="Black" />
             </Path.Effect>
         </Path>
 
-        <Grid  x:Name="mainPopupGrid" Background="White"                
-               Width="{Binding PopupRectangleWidth}">
-            <wv2:DynamoWebView2 Name="webView" ></wv2:DynamoWebView2>
+        <Grid
+            x:Name="mainPopupGrid"
+            Width="{Binding PopupRectangleWidth}"
+            Background="White">
+            <wv2:DynamoWebView2 Name="webView" />
         </Grid>
     </Canvas>
 </Popup>

--- a/src/Notifications/View/NotificationUI.xaml.cs
+++ b/src/Notifications/View/NotificationUI.xaml.cs
@@ -82,15 +82,25 @@ namespace Dynamo.Notifications.View
             if (Application.Current?.MainWindow == null)
                 return;
 
-            ReleaseCapture();
-            SetForegroundWindow(new WindowInteropHelper(Application.Current.MainWindow).Handle);
+            if (!ReleaseCapture())
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+                Console.WriteLine($"ReleaseCapture failed with error code: {errorCode}");
+            }
+
+            if (!SetForegroundWindow(new WindowInteropHelper(Application.Current.MainWindow).Handle))
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+                Console.WriteLine($"SetForegroundWindow failed with error code: {errorCode}");
+            }   
         }
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool ReleaseCapture();
+
+        [DllImport("user32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool SetForegroundWindow(IntPtr hWnd);
-
-        [DllImport("user32.dll")]
-        private static extern bool ReleaseCapture();
     }
 }

--- a/src/Notifications/View/NotificationUI.xaml.cs
+++ b/src/Notifications/View/NotificationUI.xaml.cs
@@ -78,15 +78,15 @@ namespace Dynamo.Notifications.View
             if (Application.Current?.MainWindow is Window main && main.IsLoaded)
             {
                 // If we're already on the UI thread, just call the focus method directly.
-                if (Dispatcher.CheckAccess())
-                {
-                    ForceMainWindowFocus();
-                }
-                else
-                {
-                    // Otherwise, invoke the call synchronously on the UI thread.
-                    Dispatcher.Invoke(ForceMainWindowFocus);
-                }
+                //if (Dispatcher.CheckAccess())
+                //{
+                //    ForceMainWindowFocus();
+                //}
+                //else
+                //{
+                //    // Otherwise, invoke the call synchronously on the UI thread.
+                //    Dispatcher.Invoke(ForceMainWindowFocus);
+                //}
             }
         }
 

--- a/src/Notifications/View/NotificationUI.xaml.cs
+++ b/src/Notifications/View/NotificationUI.xaml.cs
@@ -73,10 +73,21 @@ namespace Dynamo.Notifications.View
         // with the main window (e.g., close button, click handling).
         private void NotificationUI_Opened(object sender, EventArgs e)
         {
-            Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, () =>
+            // Ensure the application and main window are available and fully loaded.
+            // This prevents trying to set focus on a window that is not ready or is shutting down.
+            if (Application.Current?.MainWindow is Window main && main.IsLoaded)
             {
-                ForceMainWindowFocus();
-            });
+                // If we're already on the UI thread, just call the focus method directly.
+                if (Dispatcher.CheckAccess())
+                {
+                    ForceMainWindowFocus();
+                }
+                else
+                {
+                    // Otherwise, invoke the call synchronously on the UI thread.
+                    Dispatcher.Invoke(ForceMainWindowFocus);
+                }
+            }
         }
 
         private void ForceMainWindowFocus()

--- a/src/Notifications/View/NotificationUI.xaml.cs
+++ b/src/Notifications/View/NotificationUI.xaml.cs
@@ -75,19 +75,20 @@ namespace Dynamo.Notifications.View
         {
             // Ensure the application and main window are available and fully loaded.
             // This prevents trying to set focus on a window that is not ready or is shutting down.
-            if (Application.Current?.MainWindow is Window main && main.IsLoaded)
-            {
-                // If we're already on the UI thread, just call the focus method directly.
-                //if (Dispatcher.CheckAccess())
-                //{
-                //    ForceMainWindowFocus();
-                //}
-                //else
-                //{
-                //    // Otherwise, invoke the call synchronously on the UI thread.
-                //    Dispatcher.Invoke(ForceMainWindowFocus);
-                //}
-            }
+            ForceMainWindowFocus();
+            //if (Application.Current?.MainWindow is Window main && main.IsLoaded)
+            //{
+            //    // If we're already on the UI thread, just call the focus method directly.
+            //    if (Dispatcher.CheckAccess())
+            //    {
+            //        ForceMainWindowFocus();
+            //    }
+            //    else
+            //    {
+            //        // Otherwise, invoke the call synchronously on the UI thread.
+            //        Dispatcher.Invoke(ForceMainWindowFocus);
+            //    }
+            //}
         }
 
         private void ForceMainWindowFocus()

--- a/src/Notifications/View/NotificationUI.xaml.cs
+++ b/src/Notifications/View/NotificationUI.xaml.cs
@@ -74,21 +74,7 @@ namespace Dynamo.Notifications.View
         private void NotificationUI_Opened(object sender, EventArgs e)
         {
             // Ensure the application and main window are available and fully loaded.
-            // This prevents trying to set focus on a window that is not ready or is shutting down.
             ForceMainWindowFocus();
-            //if (Application.Current?.MainWindow is Window main && main.IsLoaded)
-            //{
-            //    // If we're already on the UI thread, just call the focus method directly.
-            //    if (Dispatcher.CheckAccess())
-            //    {
-            //        ForceMainWindowFocus();
-            //    }
-            //    else
-            //    {
-            //        // Otherwise, invoke the call synchronously on the UI thread.
-            //        Dispatcher.Invoke(ForceMainWindowFocus);
-            //    }
-            //}
         }
 
         private void ForceMainWindowFocus()

--- a/src/Notifications/View/NotificationUI.xaml.cs
+++ b/src/Notifications/View/NotificationUI.xaml.cs
@@ -79,6 +79,9 @@ namespace Dynamo.Notifications.View
 
         private void ForceMainWindowFocus()
         {
+            if (Application.Current?.MainWindow == null)
+                return;
+
             ReleaseCapture();
             SetForegroundWindow(new WindowInteropHelper(Application.Current.MainWindow).Handle);
         }

--- a/src/Notifications/View/NotificationUI.xaml.cs
+++ b/src/Notifications/View/NotificationUI.xaml.cs
@@ -1,6 +1,10 @@
+using System;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls.Primitives;
+using System.Windows.Interop;
+using System.Windows.Threading;
 
 namespace Dynamo.Notifications.View
 {
@@ -40,6 +44,8 @@ namespace Dynamo.Notifications.View
             mainPopupGrid.Width = notificationsUIViewModel.PopupRectangleWidth;
             mainPopupGrid.Height = notificationsUIViewModel.PopupRectangleHeight;
             mainPopupGrid.Margin = new Thickness(notificationsUIViewModel.PopupBordersOffSet, notificationsUIViewModel.PopupBordersOffSet, 0, 0);
+
+
         }
 
         internal void UpdatePopupLocation()
@@ -60,5 +66,30 @@ namespace Dynamo.Notifications.View
 
             this.Height = notificationsUIViewModel.PopupRectangleHeight + notificationsUIViewModel.PopupBordersOffSet + 10;
         }
+
+        // Wait until the Popup is opened to set focus back to the main window.
+        // This is necessary because Popup opens asynchronously, and WebView2 (HWND-based)
+        // can steal focus. We explicitly reclaim native focus to ensure correct interaction
+        // with the main window (e.g., close button, click handling).
+        private void NotificationUI_Opened(object sender, EventArgs e)
+        {
+            Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, () =>
+            {
+                ForceMainWindowFocus();
+            });
+        }
+
+        private void ForceMainWindowFocus()
+        {
+            ReleaseCapture();
+            SetForegroundWindow(new WindowInteropHelper(Application.Current.MainWindow).Handle);
+        }
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+        [DllImport("user32.dll")]
+        private static extern bool ReleaseCapture();
     }
 }


### PR DESCRIPTION
### Purpose

Addresses an issue where the notification popup window was not getting focus correctly after activation. This would lead to the user not being able to close the Dynamo window unless they hit the close 'X' button multiple times. Furthermore, the webView2-hosted component would not correctly capture the mouseover 'hover' interactions. This PR fixes that.

Captured in this jira ticket: [Dynamo does not close when click on X with notification open](https://jira.autodesk.com/browse/DYN-7099)

### Before
![DynamoSandbox_EuxyXPPPQV](https://github.com/user-attachments/assets/e33bf1ed-71ce-4542-92e2-cb99ef66ca96)

### After
![DynamoSandbox_TLTMO8TU02](https://github.com/user-attachments/assets/76493575-9b2d-4b15-a51f-9ec312f9ee5a)

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

- Fix the notification popup window to allow Dynamo window to be closed correctly (without having to hit 'X' multiple times)
- small auto-formatting changes
- Testing not added as no new logic is introduced, just window focus handling

### Reviewers

@zeusongit 
@reddyashish 

### FYIs

@jasonstratton 
@achintyabhat 
