### PR TITLE
[DYN-8893] Improvements to group behavior

### DIFF
--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -3184,7 +3184,6 @@ Dynamo.ViewModels.WorkspaceViewModel.GetSelectionMaxY() -> double
 Dynamo.ViewModels.WorkspaceViewModel.GetSelectionMinX() -> double
 Dynamo.ViewModels.WorkspaceViewModel.GetSelectionMinY() -> double
 Dynamo.ViewModels.WorkspaceViewModel.GraphAutoLayoutCommand.get -> Dynamo.UI.Commands.DelegateCommand
-Dynamo.ViewModels.WorkspaceViewModel.HandleAnnotationDoubleClick(System.Windows.Point position, Dynamo.Graph.Annotations.AnnotationModel annotation) -> void
 Dynamo.ViewModels.WorkspaceViewModel.HasSelection.get -> bool
 Dynamo.ViewModels.WorkspaceViewModel.HasUnsavedChanges.get -> bool
 Dynamo.ViewModels.WorkspaceViewModel.HasUnsavedChanges.set -> void

--- a/src/DynamoCoreWpf/Utilities/WpfUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/WpfUtilities.cs
@@ -111,5 +111,18 @@ namespace Dynamo.Utilities
             await ds.BeginInvoke(callback);
         }
 
+        /// <summary>
+        /// Recursively searches up the visual tree from the specified child to find the first parent of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of parent to search for.</typeparam>
+        /// <param name="child">The starting element in the visual tree.</param>
+        /// <returns>The first parent of type <typeparamref name="T"/> if found; otherwise, <c>null</c>.</returns>
+        public static T FindParent<T>(DependencyObject child) where T : DependencyObject
+        {
+            var parent = VisualTreeHelper.GetParent(child);
+            if (parent == null) return null;
+            return parent is T typedParent ? typedParent : FindParent<T>(parent);
+        }
+
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1229,7 +1229,7 @@ namespace Dynamo.ViewModels
         /// Handles double-clicks on annotation groups by creating a CBN at the click position
         /// and adding it to the group if the position intersects with the group's region.
         /// </summary>
-        public void HandleAnnotationDoubleClick(Point position, AnnotationModel annotation)
+        internal void HandleAnnotationDoubleClick(Point position, AnnotationModel annotation)
         {
             if (DynamoViewModel?.Model == null) return;
 

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -302,7 +302,7 @@ namespace Dynamo.Nodes
             if (Keyboard.Modifiers == ModifierKeys.Shift || Keyboard.Modifiers == ModifierKeys.Control)
                 return;
 
-            var workspace = FindParent<WorkspaceView>(this);
+            var workspace = WpfUtilities.FindParent<WorkspaceView>(this);
             if (workspace == null)
                 return;
 
@@ -2904,13 +2904,6 @@ namespace Dynamo.Nodes
             }
 
             return (maxWidth, totalHeight);
-        }
-
-        private T FindParent<T>(DependencyObject child) where T : DependencyObject
-        {
-            var parent = VisualTreeHelper.GetParent(child);
-            if (parent == null) return null;
-            return parent is T typedParent ? typedParent : FindParent<T>(parent);
         }
     }
 }


### PR DESCRIPTION
### Purpose

This PR aims to address [DYN-8893](https://jira.autodesk.com/browse/DYN-8893).

- Double-clicking on empty space within a group now creates a code block node inside that group.
- Fixed an issue where if two groups overlap, selecting the upper groups adds it to the other.

Adding the search bar to the group context menu will be handled in a separate PR.

Before:

![DYN-8893-Old](https://github.com/user-attachments/assets/7783763a-d772-42e3-9ff5-8e2481988020)


After:

![DYN-8893-New](https://github.com/user-attachments/assets/45918be9-6cae-4494-849f-ea0b2d122f6b)


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

Improvements to group behavior:
- Double-clicking on empty space within a group now creates a code block node inside that group.
- Fixed an issue where if two groups overlap, selecting the upper groups adds it to the other.

### Reviewers

@DynamoDS/eidos
@jasonstratton

### FYIs

@achintyabhat
@dnenov
