### PR TITLE
Revert "DYN-8801 UpdateLayout Performance (#16279)"

### DIFF
--- a/src/DynamoCore/Graph/ModelBase.cs
+++ b/src/DynamoCore/Graph/ModelBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Xml;
 using Dynamo.Core;
@@ -71,18 +71,13 @@ namespace Dynamo.Graph
         /// </summary>
         public event EventHandler<CancelEventArgs> DeletionStarted;
 
-        internal static readonly double DefaultHeight = 100;
-        internal static readonly double DefaultWidth = 100;
-
         private Guid guid;
         private bool isSelected;
         private bool belongsToGroup;
         private double x;
         private double y;
-        private double height = DefaultHeight;
-        private double width = DefaultWidth;
-        private double heightBorder = DefaultHeight;
-        private double widthBorder = DefaultWidth;
+        private double height = 100;
+        private double width = 100;
 
         /// <summary>
         /// X coordinate of center point.
@@ -169,6 +164,7 @@ namespace Dynamo.Graph
         /// <summary>
         /// The height of the object.
         /// </summary>
+        [JsonIgnore]
         public virtual double Height
         {
             get { return height; }
@@ -182,6 +178,7 @@ namespace Dynamo.Graph
         /// <summary>
         /// The width of the object.
         /// </summary>
+        [JsonIgnore]
         public virtual double Width
         {
             get { return width; }
@@ -189,36 +186,6 @@ namespace Dynamo.Graph
             {
                 width = value;
                 //RaisePropertyChanged("Width");
-            }
-        }
-
-        /// <summary>Add commentMore actions
-        /// The width of the object.
-        /// </summary>
-        public virtual double WidthBorder
-        {
-            get { return widthBorder; }
-            set
-            {
-                if (value > 0)
-                {
-                    widthBorder = value;
-                }
-            }
-        }
-
-        /// <summary>
-        /// The height of the object.
-        /// </summary>
-        public virtual double HeightBorder
-        {
-            get { return heightBorder; }
-            set
-            {
-                if (value > 0)
-                {
-                    heightBorder = value;
-                }
             }
         }
 

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -90,10 +90,6 @@ namespace Dynamo.Graph.Workspaces
         public string Name;
         public double X;
         public double Y;
-        public double Width = ModelBase.DefaultWidth;
-        public double Height = ModelBase.DefaultWidth;
-        public double WidthBorder;
-        public double HeightBorder;
         public bool ShowGeometry;
         public bool Excluded;
         public bool IsSetAsInput;
@@ -2499,10 +2495,6 @@ namespace Dynamo.Graph.Workspaces
                         nodeModel.X = nodeViewInfo.X + offsetX;
                         nodeModel.Y = nodeViewInfo.Y + offsetY;
                     }
-                    nodeModel.Width = nodeViewInfo.Width;
-                    nodeModel.Height = nodeViewInfo.Height;
-                    nodeModel.WidthBorder = nodeViewInfo.WidthBorder;
-                    nodeModel.HeightBorder = nodeViewInfo.HeightBorder;
                     nodeModel.IsFrozen = nodeViewInfo.Excluded;
                     nodeModel.IsSetAsInput = nodeViewInfo.IsSetAsInput;
                     nodeModel.IsSetAsOutput = nodeViewInfo.IsSetAsOutput;

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -1312,10 +1312,6 @@ Dynamo.Graph.Workspaces.ExtraNodeViewInfo.ShowGeometry -> bool
 Dynamo.Graph.Workspaces.ExtraNodeViewInfo.UserDescription -> string
 Dynamo.Graph.Workspaces.ExtraNodeViewInfo.X -> double
 Dynamo.Graph.Workspaces.ExtraNodeViewInfo.Y -> double
-Dynamo.Graph.Workspaces.ExtraNodeViewInfo.Width -> double
-Dynamo.Graph.Workspaces.ExtraNodeViewInfo.Height -> double
-Dynamo.Graph.Workspaces.ExtraNodeViewInfo.WidthBorder -> double
-Dynamo.Graph.Workspaces.ExtraNodeViewInfo.HeightBorder -> double
 Dynamo.Graph.Workspaces.ExtraNoteViewInfo
 Dynamo.Graph.Workspaces.ExtraNoteViewInfo.ExtraNoteViewInfo() -> void
 Dynamo.Graph.Workspaces.ExtraNoteViewInfo.Id -> string
@@ -3064,10 +3060,6 @@ virtual Dynamo.Graph.ModelBase.ShouldSerializeY() -> bool
 virtual Dynamo.Graph.ModelBase.UpdateValueCore(Dynamo.Graph.UpdateValueParams updateValueParams) -> bool
 virtual Dynamo.Graph.ModelBase.Width.get -> double
 virtual Dynamo.Graph.ModelBase.Width.set -> void
-virtual Dynamo.Graph.ModelBase.WidthBorder.get -> double
-virtual Dynamo.Graph.ModelBase.WidthBorder.set -> void
-virtual Dynamo.Graph.ModelBase.HeightBorder.get -> double
-virtual Dynamo.Graph.ModelBase.HeightBorder.set -> void
 virtual Dynamo.Graph.Nodes.FunctionCallNodeController<T>.AssignIdentifiersForFunctionCall(Dynamo.Graph.Nodes.NodeModel model, ProtoCore.AST.AssociativeAST.AssociativeNode rhs, System.Collections.Generic.List<ProtoCore.AST.AssociativeAST.AssociativeNode> resultAst) -> void
 virtual Dynamo.Graph.Nodes.FunctionCallNodeController<T>.BuildAstForPartialMultiOutput(Dynamo.Graph.Nodes.NodeModel model, ProtoCore.AST.AssociativeAST.AssociativeNode rhs, System.Collections.Generic.List<ProtoCore.AST.AssociativeAST.AssociativeNode> resultAst) -> void
 virtual Dynamo.Graph.Nodes.FunctionCallNodeController<T>.BuildOutputAst(Dynamo.Graph.Nodes.NodeModel model, System.Collections.Generic.List<ProtoCore.AST.AssociativeAST.AssociativeNode> inputAstNodes, System.Collections.Generic.List<ProtoCore.AST.AssociativeAST.AssociativeNode> resultAst) -> void

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -2610,14 +2610,6 @@ Dynamo.ViewModels.NodeViewModel.X.get -> double
 Dynamo.ViewModels.NodeViewModel.X.set -> void
 Dynamo.ViewModels.NodeViewModel.Y.get -> double
 Dynamo.ViewModels.NodeViewModel.Y.set -> void
-Dynamo.ViewModels.NodeViewModel.Width.get -> double
-Dynamo.ViewModels.NodeViewModel.Width.set -> void
-Dynamo.ViewModels.NodeViewModel.Height.get -> double
-Dynamo.ViewModels.NodeViewModel.Height.set -> void
-Dynamo.ViewModels.NodeViewModel.WidthBorder.get -> double
-Dynamo.ViewModels.NodeViewModel.WidthBorder.set -> void
-Dynamo.ViewModels.NodeViewModel.HeightBorder.get -> double
-Dynamo.ViewModels.NodeViewModel.HeightBorder.set -> void
 Dynamo.ViewModels.NodeViewModel.ZIndex.get -> int
 Dynamo.ViewModels.NodeViewModel.ZIndex.set -> void
 Dynamo.ViewModels.NoteEventArgs

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -729,57 +729,6 @@ namespace Dynamo.ViewModels
             }
         }
 
-        /// <summary>
-        ///     Returns or set the Width of the NodeView.
-        /// </summary>
-        [JsonProperty(Order = 9)]
-        public double Width
-        {
-            get { return NodeModel.Width; }
-            set
-            {
-                NodeModel.Width = value;
-            }
-        }
-
-        /// <summary>
-        ///     Returns or set the Height of the NodeView.
-        /// </summary>
-        [JsonProperty(Order = 10)]
-        public double Height
-        {
-            get { return NodeModel.Height; }
-            set
-            {
-                NodeModel.Height = value;
-            }
-        }
-        /// <summary>
-        ///     Returns or set the Width of the Node's border that is added inside the NodeView.
-        /// </summary>
-        [JsonProperty(Order = 11)]
-        public double WidthBorder
-        {
-            get { return NodeModel.WidthBorder; }
-            set
-            {
-                NodeModel.WidthBorder = value;
-            }
-        }
-
-        /// <summary>
-        ///     Returns or set the Height of the Node's border that is added inside the NodeView.
-        /// </summary>
-        [JsonProperty(Order = 12)]
-        public double HeightBorder
-        {
-            get { return NodeModel.HeightBorder; }
-            set
-            {
-                NodeModel.HeightBorder = value;
-            }
-        }
-
         [JsonIgnore]
         public ImageSource ImageSource
         {

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -1161,8 +1161,7 @@ namespace Dynamo.Controls
             Unloaded += OnNodeViewUnloaded;
             nodeBackground.Loaded += NodeViewReady;
 
-            nodeBorder.SizeChanged += OnSizeChangedBorder;
-            this.SizeChanged += OnSizeChangedNodeView;
+            nodeBorder.SizeChanged += OnSizeChanged;
             DataContextChanged += OnDataContextChanged;
 
             Panel.SetZIndex(this, 1);
@@ -1582,8 +1581,7 @@ namespace Dynamo.Controls
             EditableNameBox.LostFocus -= EditableNameBox_OnLostFocus;
             EditableNameBox.KeyDown -= EditableNameBox_KeyDown;
             optionsButton.Click -= DisplayNodeContextMenu;
-            nodeBorder.SizeChanged -= OnSizeChangedBorder;
-            this.SizeChanged -= OnSizeChangedNodeView;
+            nodeBorder.SizeChanged -= OnSizeChanged;
             nodeBackground.Loaded -= NodeViewReady;
 
             if (previewControl != null)
@@ -1605,20 +1603,13 @@ namespace Dynamo.Controls
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="eventArgs"></param>
-        private void OnSizeChangedBorder(object sender, SizeChangedEventArgs e)
+        private void OnSizeChanged(object sender, EventArgs eventArgs)
         {
-            if (ViewModel != null)
-            {
-                ViewModel.WidthBorder = e.NewSize.Width;
-                ViewModel.HeightBorder = e.NewSize.Height;              
-            }
-        }
+            if (ViewModel == null || ViewModel.PreferredSize.HasValue) return;
 
-        private void OnSizeChangedNodeView(object sender, SizeChangedEventArgs e)
-        {
-            if (ViewModel != null)
+            var size = new[] { ActualWidth, nodeBorder.ActualHeight };
+            if (ViewModel.SetModelSizeCommand.CanExecute(size))
             {
-                var size = new[] { e.NewSize.Width, e.NewSize.Height };
                 ViewModel.SetModelSizeCommand.Execute(size);
             }
         }
@@ -1644,21 +1635,6 @@ namespace Dynamo.Controls
             if (null != ViewModel) return;
 
             ViewModel = e.NewValue as NodeViewModel;
-
-            //This code should be only executed when loading a graph, if the node is being added to the workspace manually then the Width and Height should be auto-calculated.
-            //The default Width and Height values for nodes is 100 so only should be executed on graph loading if both values are 100
-            if (ViewModel.Width > NodeModel.DefaultWidth && ViewModel.Height > NodeModel.DefaultHeight)
-            {
-                Width = ViewModel.Width;
-                Height = ViewModel.Height;
-            }
-
-            if (ViewModel.WidthBorder > NodeModel.DefaultWidth && ViewModel.HeightBorder > NodeModel.DefaultHeight)
-            {
-                nodeBorder.Width = ViewModel.WidthBorder;
-                nodeBorder.Height = ViewModel.HeightBorder;
-            }
-
 
             //Set NodeIcon
             if (ViewModel.ImageSource == null)
@@ -1695,7 +1671,7 @@ namespace Dynamo.Controls
             nodeBorder.Height = size.Height;
             nodeBorder.RenderSize = size;
         }
-
+    
         private void SetCustomNodeVisuals()
         {
             customNodeBorder0 = new Border()

--- a/test/DynamoCoreWpf3Tests/SerializationTests.cs
+++ b/test/DynamoCoreWpf3Tests/SerializationTests.cs
@@ -412,7 +412,7 @@ namespace DynamoCoreWpfTests
             var workSpaceJobject = JObject.Parse(ViewModel.CurrentSpaceViewModel.ToJson());
             JObject nodeViewModelJobject = JObject.Parse(workSpaceJobject["NodeViews"][0].ToString());
 
-            Assert.AreEqual(12, nodeViewModelJobject.Properties().Count(), "The number of Serialized properties is not the expected");
+            Assert.AreEqual(8, nodeViewModelJobject.Properties().Count(), "The number of Serialized properties is not the expected");
 
             bool explicitOrder =
                 nodeViewModelJobject.Properties().ElementAt(0).Name == GetJsonPropertydName<NodeViewModel>(nameof(NodeViewModel.Id)) &&
@@ -422,12 +422,7 @@ namespace DynamoCoreWpfTests
                 nodeViewModelJobject.Properties().ElementAt(4).Name == GetJsonPropertydName<NodeViewModel>(nameof(NodeViewModel.IsFrozenExplicitly)) &&
                 nodeViewModelJobject.Properties().ElementAt(5).Name == GetJsonPropertydName<NodeViewModel>(nameof(NodeViewModel.IsVisible)) &&
                 nodeViewModelJobject.Properties().ElementAt(6).Name == GetJsonPropertydName<NodeViewModel>(nameof(NodeViewModel.X)) &&
-                nodeViewModelJobject.Properties().ElementAt(7).Name == GetJsonPropertydName<NodeViewModel>(nameof(NodeViewModel.Y)) &&
-                nodeViewModelJobject.Properties().ElementAt(8).Name == GetJsonPropertydName<NodeViewModel>(nameof(NodeViewModel.Width)) &&
-                nodeViewModelJobject.Properties().ElementAt(9).Name == GetJsonPropertydName<NodeViewModel>(nameof(NodeViewModel.Height)) &&
-                nodeViewModelJobject.Properties().ElementAt(10).Name == GetJsonPropertydName<NodeViewModel>(nameof(NodeViewModel.WidthBorder)) &&
-                nodeViewModelJobject.Properties().ElementAt(11).Name == GetJsonPropertydName<NodeViewModel>(nameof(NodeViewModel.HeightBorder));
-
+                nodeViewModelJobject.Properties().ElementAt(7).Name == GetJsonPropertydName<NodeViewModel>(nameof(NodeViewModel.Y));
 
             Assert.IsTrue(explicitOrder, "The order of the properties is not the expected");
         }

--- a/test/core/dummy_node/2080_JSONTESTCRASH undo_redo.dyn
+++ b/test/core/dummy_node/2080_JSONTESTCRASH undo_redo.dyn
@@ -1,5 +1,5 @@
 {
-  "Uuid": "5ddc6800-cca5-493e-8a33-f6450038ca11",
+  "Uuid": "edd9e95c-26a5-4ec2-bd1b-ca2a80bc827b",
   "IsCustomNode": false,
   "Description": "",
   "Name": "2080_JSONTESTCRASH undo_redo",
@@ -13,11 +13,11 @@
       "ConcreteType": "Dynamo.Graph.Nodes.UNKNOWNTYPE, DynamoCore",
       "NodeType": "CodeBlockNode",
       "Code": "4;",
-      "Id": "875b287444604b9d976d8d0473692552",
+      "Id": "158f8f25ddb746c88323ae262e87611e",
       "Inputs": [],
       "Outputs": [
         {
-          "Id": "8079554f4ddf46c49480b1bd4b3d45e4",
+          "Id": "cddfa508b4a246fd94f79792d303cbf5",
           "Name": "",
           "Description": "Value of expression at line 1",
           "UsingDefaultValue": false,
@@ -31,26 +31,18 @@
     },
     {
       "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
-      "Height": 127.0,
-      "Width": 154.0,
-      "WidthBorder": 156.0,
-      "HeightBorder": 117.0,
-      "Id": "4371809e0640406a9c99d62e2bba0826",
+      "Id": "6cbd0760736f4235a03b38fb359e9957",
       "NodeType": "CodeBlockNode",
       "Inputs": [],
       "Outputs": [
         {
-          "Id": "2766199ea67e45cb8741617b209eb292",
+          "Id": "8234ec6cc018433da0605ddfb17cdc2b",
           "Name": "",
           "Description": "Value of expression at line 1",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
-          "KeepListStructure": false,
-          "Height": 16.345,
-          "Width": 100.0,
-          "WidthBorder": 100.0,
-          "HeightBorder": 100.0
+          "KeepListStructure": false
         }
       ],
       "Replication": "Disabled",
@@ -71,7 +63,7 @@
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "3.6.0.6885",
+      "Version": "2.19.0.4737",
       "RunType": "Automatic",
       "RunPeriod": "1000"
     },
@@ -90,32 +82,24 @@
     "ConnectorPins": [],
     "NodeViews": [
       {
-        "Id": "875b287444604b9d976d8d0473692552",
+        "Id": "158f8f25ddb746c88323ae262e87611e",
         "Name": "Code Block",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
         "ShowGeometry": true,
         "X": 179.8,
-        "Y": 160.39999999999992,
-        "Width": 154.0,
-        "Height": 167.0,
-        "WidthBorder": 156.0,
-        "HeightBorder": 161.0
+        "Y": 160.39999999999992
       },
       {
-        "Id": "4371809e0640406a9c99d62e2bba0826",
+        "Id": "6cbd0760736f4235a03b38fb359e9957",
         "Name": "Code Block",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
         "ShowGeometry": true,
         "X": 76.8,
-        "Y": 162.4,
-        "Width": 154.0,
-        "Height": 127.0,
-        "WidthBorder": 156.0,
-        "HeightBorder": 117.0
+        "Y": 162.4
       }
     ],
     "Annotations": [],


### PR DESCRIPTION
### Purpose

This reverts commit 39e17d814ea304ba937a46384b8efc568cc8f831.
The main changes for the DYN-8801 UpdateLayout Performance PR are tsetting the size for the NodeView and also for NodeBorder (when the graph is loaded).
By doing this the number of calls to Measure() and Arrange() were drastically reduced but the problem is that is setting a fixed size for those controls is producing rendering issues so in the cases reported like when showing a warning (increase the height) or add large text in String node ( increase Width), the displayed node is wrong,

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

This reverts commit 39e17d814ea304ba937a46384b8efc568cc8f831.

### Reviewers

@QilongTang @reddyashish 

### FYIs

