### PR TITLE
DYN-8896 Fixes

### DIFF
--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -467,10 +467,10 @@ Dynamo.Controls.NodeView
 Dynamo.Controls.NodeView.ContentGrid.get -> System.Windows.Controls.Grid
 Dynamo.Controls.NodeView.grid -> System.Windows.Controls.Grid
 Dynamo.Controls.NodeView.InitializeComponent() -> void
-Dynamo.Controls.NodeView.inputGrid.get -> System.Windows.Controls.Grid
+Dynamo.Controls.NodeView.inputGrid -> System.Windows.Controls.Grid
 Dynamo.Controls.NodeView.MainContextMenu -> System.Windows.Controls.ContextMenu
 Dynamo.Controls.NodeView.NodeView() -> void
-Dynamo.Controls.NodeView.PresentationGrid.get -> System.Windows.Controls.Grid
+Dynamo.Controls.NodeView.PresentationGrid -> System.Windows.Controls.Grid
 Dynamo.Controls.NodeView.SetToolTipDelegate
 Dynamo.Controls.NodeView.topControl -> Dynamo.Controls.NodeView
 Dynamo.Controls.NodeView.TopControl.get -> Dynamo.Controls.NodeView
@@ -5817,7 +5817,9 @@ static readonly Dynamo.UI.FrozenResources.PreviewIconPinnedBrush -> System.Windo
 static readonly Dynamo.UI.FrozenResources.WarningFrameFill -> System.Windows.Media.SolidColorBrush
 static readonly Dynamo.UI.FrozenResources.WarningFrameStrokeColor -> System.Windows.Media.SolidColorBrush
 static readonly Dynamo.UI.FrozenResources.WarningTextForeground -> System.Windows.Media.SolidColorBrush
+static readonly Dynamo.ViewModels.PortViewModel.PortBackgroundColorDefault -> System.Windows.Media.SolidColorBrush
 static readonly Dynamo.ViewModels.PortViewModel.PortBackgroundColorPreviewOff -> System.Windows.Media.SolidColorBrush
+static readonly Dynamo.ViewModels.PortViewModel.PortBorderBrushColorDefault -> System.Windows.Media.SolidColorBrush
 static readonly Dynamo.Wpf.UI.GuidedTour.CustomRichTextBox.CustomTextProperty -> System.Windows.DependencyProperty
 static readonly Dynamo.Wpf.UI.MouseBehaviour.MouseXProperty -> System.Windows.DependencyProperty
 static readonly Dynamo.Wpf.UI.MouseBehaviour.MouseYProperty -> System.Windows.DependencyProperty

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -31,8 +31,8 @@ namespace Dynamo.ViewModels
         private const double autocompletePopupSpacing = 2.5;
         private const double proxyPortContextMenuOffset = 20;
         protected static readonly SolidColorBrush PortBackgroundColorPreviewOff = new SolidColorBrush(Color.FromRgb(102, 102, 102));
-        internal static readonly SolidColorBrush PortBackgroundColorDefault = new SolidColorBrush(Color.FromRgb(60, 60, 60));
-        internal static readonly SolidColorBrush PortBorderBrushColorDefault = new SolidColorBrush(Color.FromRgb(161, 161, 161));
+        public static readonly SolidColorBrush PortBackgroundColorDefault = new SolidColorBrush(Color.FromRgb(60, 60, 60));
+        public static readonly SolidColorBrush PortBorderBrushColorDefault = new SolidColorBrush(Color.FromRgb(161, 161, 161));
         private SolidColorBrush portBorderBrushColor = PortBorderBrushColorDefault;
         private SolidColorBrush portBackgroundColor = PortBackgroundColorDefault;
         private Visibility highlight = Visibility.Collapsed;

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -61,32 +61,10 @@ namespace Dynamo.Controls
             get { return inputGrid; }
         }
 
-        private Grid _inputGrid = null;
-
         //Todo add message to mark this as deprecated or ContentGrid?  Currently only one item references ContentGrid.  Most use inputGrid
-        public Grid inputGrid
-        {
-            get
-            {
-                if (_inputGrid == null)
-                {
-                    _inputGrid = new Grid()
-                    {
-                        Name = "inputGrid",
-                        MinHeight = Configuration.Configurations.PortHeightInPixels,
-                        VerticalAlignment = VerticalAlignment.Stretch,
-                        HorizontalAlignment = HorizontalAlignment.Stretch,
-                    };
 
-                    Canvas.SetZIndex(_inputGrid, 5);
-                    _inputGrid.SetBinding(Grid.IsEnabledProperty, new Binding("IsInteractionEnabled"));
-
-                    centralGrid.Children.Add(_inputGrid);
-                }
-
-                return _inputGrid;
-            }
-        }
+        [Obsolete("This method is deprecated and will be removed in a future version of Dynamo, use the ContentGrid")]
+        public Grid inputGrid = null;
 
         public NodeViewModel ViewModel
         {
@@ -157,7 +135,7 @@ namespace Dynamo.Controls
         internal Border customNodeBorder0; //for testing
         internal Grid zoomGlyphsGrid; //for testing
         internal Rectangle nodeColorOverlayZoomOut; //for testing
-
+        internal Grid centralGrid = null;
 
         //View items referenced outside of NodeView internal to DynamoCoreWPF previously from xaml but now loaded on demand.
         private Canvas _expansionBay;
@@ -186,64 +164,10 @@ namespace Dynamo.Controls
             }
         }
 
-        private Grid _centralGrid;
-        internal Grid centralGrid
-        {
-            get
-            {
-                if(_centralGrid == null)
-                {
-                    _centralGrid = new Grid()
-                    {
-                        Name = "centralGrid",
-                        Margin = new Thickness(6, 6, 6, 3),
-                        VerticalAlignment = VerticalAlignment.Top
-                    };
-
-                    _centralGrid.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
-                    _centralGrid.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) });
-                    _centralGrid.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) });
-                    Grid.SetRow(_centralGrid, 2);
-                    Grid.SetColumn(_centralGrid, 1);
-                    Canvas.SetZIndex(_centralGrid, 4);
-
-                    grid.Children.Add(_centralGrid);
-                }
-
-                return _centralGrid;
-            }
-        }
-
         //View items referenced outside of NodeView as previously from xaml outside of DynamoCoreWPF
         public ContextMenu MainContextMenu = new ContextMenu();
         public Grid grid;
-
-        private Grid _presentationGrid = null;
-        public Grid PresentationGrid
-        {
-            get
-            {
-                if(_presentationGrid == null)
-                {
-                    _presentationGrid = new Grid()
-                    {
-                        Name = "PresentationGrid",
-                        Margin = new Thickness(6, 6, 6, -3),
-                        HorizontalAlignment = HorizontalAlignment.Left,
-                        VerticalAlignment = VerticalAlignment.Bottom,
-                        Visibility = Visibility.Collapsed
-                    };
-
-                    Grid.SetRow(_presentationGrid, 2);
-                    Grid.SetColumn(_presentationGrid, 1);
-                    Canvas.SetZIndex(_presentationGrid, 3);
-
-                    grid.Children.Add(_presentationGrid);
-                }
-
-                return _presentationGrid;
-            }
-        }
+        public Grid PresentationGrid = null;
 
         //Static resources mostly from DynamoModern themes but some from DynamoColorsAndBrushes.xaml
 
@@ -1138,6 +1062,48 @@ namespace Dynamo.Controls
                 UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
             });
 
+
+            PresentationGrid = new Grid()
+            {
+                Name = "PresentationGrid",
+                Margin = new Thickness(6, 6, 6, -3),
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Bottom,
+                Visibility = Visibility.Collapsed
+            };
+
+            Grid.SetRow(PresentationGrid, 2);
+            Grid.SetColumn(PresentationGrid, 1);
+            Canvas.SetZIndex(PresentationGrid, 3);
+
+            centralGrid = new Grid()
+            {
+                Name = "centralGrid",
+                Margin = new Thickness(6, 6, 6, 3),
+                VerticalAlignment = VerticalAlignment.Top
+            };
+
+            centralGrid.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+            centralGrid.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) });
+            centralGrid.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) });
+            Grid.SetRow(centralGrid, 2);
+            Grid.SetColumn(centralGrid, 1);
+            Canvas.SetZIndex(centralGrid, 4);
+
+            inputGrid = new Grid()
+            {
+                Name = "inputGrid",
+                MinHeight = Configuration.Configurations.PortHeightInPixels,
+                VerticalAlignment = VerticalAlignment.Stretch,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+            };
+
+            Canvas.SetZIndex(inputGrid, 5);
+            inputGrid.SetBinding(Grid.IsEnabledProperty, new Binding("IsInteractionEnabled"));
+
+            centralGrid.Children.Add(inputGrid);
+
+
             //TODO DebugAST Canvas.  Do we need this?
 
             grid.Children.Add(nodeBackground);
@@ -1154,6 +1120,8 @@ namespace Dynamo.Controls
             grid.Children.Add(zoomGlyphsGrid);
             grid.Children.Add(nodeHoveringStateBorder);
             grid.Children.Add(warningBar);
+            grid.Children.Add(PresentationGrid);
+            grid.Children.Add(centralGrid);
 
             this.Content = grid;
 

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -173,6 +173,7 @@ namespace Dynamo.Controls
 
         //Brushes
         private static SolidColorBrush _primaryCharcoal100 = SharedDictionaryManager.DynamoColorsAndBrushesDictionary["PrimaryCharcoal100Brush"] as SolidColorBrush;
+        private static SolidColorBrush _primaryCharcoal200 = SharedDictionaryManager.DynamoColorsAndBrushesDictionary["PrimaryCharcoal200Brush"] as SolidColorBrush;
         private static SolidColorBrush _blue300 = SharedDictionaryManager.DynamoColorsAndBrushesDictionary["Blue300Brush"] as SolidColorBrush;
         private static SolidColorBrush _darkBlue200 = SharedDictionaryManager.DynamoColorsAndBrushesDictionary["DarkBlue200Brush"] as SolidColorBrush;
         private static SolidColorBrush _nodeDismissedWarningsGlyphForeground = SharedDictionaryManager.DynamoColorsAndBrushesDictionary["NodeDismissedWarningsGlyphForeground"] as SolidColorBrush;
@@ -230,6 +231,7 @@ namespace Dynamo.Controls
             _nodeButtonDots.Freeze();
             _defaultNodeIcon.Freeze();
             _primaryCharcoal100.Freeze();
+            _primaryCharcoal200.Freeze();
             _blue300.Freeze();
             _nodeDismissedWarningsGlyphBackground.Freeze();
             _nodeDismissedWarningsGlyphForeground.Freeze();
@@ -395,7 +397,8 @@ namespace Dynamo.Controls
                 VerticalAlignment = VerticalAlignment.Center,
                 FontSize = 16,
                 FontWeight = FontWeights.Medium,
-                Foreground = _primaryCharcoal100,
+                Foreground = _primaryCharcoal200,
+                Background = null,
                 IsHitTestVisible = false,
                 TextAlignment = TextAlignment.Center,
                 FontFamily = _artifactElementReg,
@@ -416,14 +419,15 @@ namespace Dynamo.Controls
                 VerticalAlignment = VerticalAlignment.Center,
                 FontSize = 16,
                 FontWeight = FontWeights.Medium,
-                Foreground = _primaryCharcoal100,
+                Foreground = _primaryCharcoal200,
                 SelectionBrush = _blue300,
                 SelectionOpacity = 0.2,
                 IsHitTestVisible = true,
                 BorderThickness = new Thickness(0),
                 TextAlignment = TextAlignment.Center,
                 Visibility = Visibility.Collapsed,
-                FontFamily = _artifactElementReg
+                FontFamily = _artifactElementReg,
+                Background = null
             };
 
             EditableNameBox.LostFocus += EditableNameBox_OnLostFocus;


### PR DESCRIPTION
### Purpose

This PR addresses two issues with https://github.com/DynamoDS/Dynamo/pull/16188.

1. Breaking API changes where fields were changed to getters.  The `inputGrid` and `PresentationGrid` are now returned to fields.
2. Breaking API Changes where protected was changed to internal.  The `PortBackgroundColorDefault` and `PortBorderBrushColorDefault` are now adjusted to public.
3. Fix the highlight color for the node name change.  The `NameBlock` and `EditableNameBox` require the Background brush to be set to null.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

No Applicable

### Reviewers

@reddyashish @mjkkirschner

### FYIs

@jnealb @QilongTang 
