### PR TITLE
DYN-9028: force recalculate formula fields

### DIFF
--- a/src/Libraries/DSOfficeUtilities/OpenXmlHelper.cs
+++ b/src/Libraries/DSOfficeUtilities/OpenXmlHelper.cs
@@ -245,6 +245,17 @@ namespace DSOffice
 
                     currentRowIndex++;
                 }
+
+                // Force re-calculation of formulas on opening the Excel file
+                var workbook = document.WorkbookPart.Workbook;
+                var calcProps = workbook.Elements<CalculationProperties>().FirstOrDefault();
+                if (calcProps == null)
+                {
+                    calcProps = new CalculationProperties();
+                    workbook.AppendChild(calcProps);
+                }
+                calcProps.FullCalculationOnLoad = true;
+
                 return true;
             }
         }

--- a/src/Libraries/DSOfficeUtilities/OpenXmlHelper.cs
+++ b/src/Libraries/DSOfficeUtilities/OpenXmlHelper.cs
@@ -370,7 +370,9 @@ namespace DSOffice
                             {
                                 if (numberFormatId != 0)
                                 {
-                                    var numberingFormat = (NumberingFormat)stylesheet.NumberingFormats.ElementAt(numberFormatId);
+                                    var numberingFormat = (NumberingFormat)stylesheet.NumberingFormats?.ElementAt(numberFormatId);
+                                    if (numberingFormat == null) return value.ToString();
+
                                     var formatted = value.ToString(numberingFormat.FormatCode);
                                     return formatted;
                                 }


### PR DESCRIPTION
### Purpose

This PR follows the issue discussed here: https://jira.autodesk.com/browse/DYN-9028 - Formulas breaking (not recomputing) after exporting new data using OpenXML node to an existing Excel with Formula

> **Note:**
> Formulas will be correctly evaluated when the user opens the file in Excel. [However, OpenXML, and as a consequence Dynamo, does not have capacity to evaluate formulas. ](https://github.com/dotnet/Open-XML-SDK/issues/519). Dynamo cannot directly consume the results of the formula-driven fields, unless they have been pre-cached by Excel. 

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

- requests full calculation when opening the excel file after writing it with Dynamo OpenXML
- small bug fix when `stylesheet.NumberingFormats` is `null`
- no testing, as OpenXML won't let us evaluate the formula results

### Reviewers

@jasonstratton 
@zeusongit 
@achintyabhat 

### FYIs

@reddyashish 
