### PR TITLE
DYN-9093 Update default backup interval to 5 minutes

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -93,6 +93,11 @@ namespace Dynamo.Configuration
         internal const int DefaultBackupInterval = 300000;
 
         /// <summary>
+        /// The old time interval between backup files. 1 minute.
+        /// </summary>
+        private const int OldDefaultBackupInterval = 60000;
+
+        /// <summary>
         /// Indicates the default render precision, i.e. the maximum number of tessellation divisions
         /// </summary>
         internal const int DefaultRenderPrecision = 128;


### PR DESCRIPTION
### Purpose

Changed the default backup interval from 1 minute (60000ms) to 5 minutes (300000ms). Added logic to migrate existing settings using the old interval to the new default value.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

Changed the default backup interval from 1 minute (60000ms) to 5 minutes (300000ms). Added logic to migrate existing settings using the old interval to the new default value.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
