### PR TITLE
DYN-9104 : reuse node autocomplete bar plus other fixes

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -324,10 +324,9 @@ namespace Dynamo.Models
             get { return currentWorkspace; }
             set
             {
-                if (Equals(value, currentWorkspace)) return;
-                var old = currentWorkspace;
+                if (Equals(value, currentWorkspace)) return;                
+                OnWorkspaceHidden(currentWorkspace);
                 currentWorkspace = value;
-                OnWorkspaceHidden(old);
                 OnPropertyChanged(nameof(CurrentWorkspace));
             }
         }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -324,9 +324,10 @@ namespace Dynamo.Models
             get { return currentWorkspace; }
             set
             {
-                if (Equals(value, currentWorkspace)) return;                
-                OnWorkspaceHidden(currentWorkspace);
+                if (Equals(value, currentWorkspace)) return;
+                var old = currentWorkspace;
                 currentWorkspace = value;
+                OnWorkspaceHidden(old);
                 OnPropertyChanged(nameof(CurrentWorkspace));
             }
         }

--- a/src/NodeAutoCompleteViewExtension/NodeAutoCompleteViewExtension.cs
+++ b/src/NodeAutoCompleteViewExtension/NodeAutoCompleteViewExtension.cs
@@ -167,6 +167,7 @@ namespace Dynamo.NodeAutoComplete
         }
 
         private static NodeAutoCompleteBarViewModel nodeAutoCompleteBarViewModel;
+        private static Guid lastWorkspaceId;
 
         private void OnNodeAutoCompleteBarRequested(Window parentWindow, ViewModelBase viewModelBase)
         {
@@ -177,20 +178,14 @@ namespace Dynamo.NodeAutoComplete
             }
 
             DynamoViewModel dynamoViewModel = portViewModel?.NodeViewModel?.WorkspaceViewModel?.DynamoViewModel;
-            if (nodeAutoCompleteBarViewModel is null || !ReferenceEquals(nodeAutoCompleteBarViewModel.dynamoViewModel, dynamoViewModel))
+            if (nodeAutoCompleteBarViewModel is null || lastWorkspaceId != dynamoViewModel.CurrentSpace.Guid)
             {
                 nodeAutoCompleteBarViewModel = new NodeAutoCompleteBarViewModel(dynamoViewModel);
             }
 
-            var existingPort = nodeAutoCompleteBarViewModel.PortViewModel;
-            if (existingPort != null)
-            {
-                existingPort.Highlight = Visibility.Collapsed;
-            }
+            lastWorkspaceId = dynamoViewModel.CurrentSpace.Guid;
 
-            nodeAutoCompleteBarViewModel.PortViewModel = portViewModel;
-
-            NodeAutoCompleteBarView.PrepareAndShowNodeAutoCompleteBar(parentWindow, nodeAutoCompleteBarViewModel);
+            NodeAutoCompleteBarView.PrepareAndShowNodeAutoCompleteBar(parentWindow, nodeAutoCompleteBarViewModel, portViewModel);
         }
     }
 }

--- a/src/NodeAutoCompleteViewExtension/NodeAutoCompleteViewExtension.cs
+++ b/src/NodeAutoCompleteViewExtension/NodeAutoCompleteViewExtension.cs
@@ -25,7 +25,6 @@ namespace Dynamo.NodeAutoComplete
         private const String extensionName = "Node Auto Complete";
         private ViewLoadedParams viewLoadedParamsReference;
         private NodeAutoCompletePanelViewModel nodeAutoCompleteViewModel;
-        private NodeAutoCompleteBarView nodeAutoCompleteBarView;
 
         internal MenuItem nodeAutocompleteMenuItem;
 
@@ -177,35 +176,21 @@ namespace Dynamo.NodeAutoComplete
                 return;
             }
 
-            if (nodeAutoCompleteBarViewModel is null)
+            DynamoViewModel dynamoViewModel = portViewModel?.NodeViewModel?.WorkspaceViewModel?.DynamoViewModel;
+            if (nodeAutoCompleteBarViewModel is null || !ReferenceEquals(nodeAutoCompleteBarViewModel.dynamoViewModel, dynamoViewModel))
             {
-                DynamoViewModel dynamoViewModel = portViewModel?.NodeViewModel?.WorkspaceViewModel?.DynamoViewModel;
                 nodeAutoCompleteBarViewModel = new NodeAutoCompleteBarViewModel(dynamoViewModel);
             }
 
-            if (nodeAutoCompleteBarViewModel.PortViewModel != null)
+            var existingPort = nodeAutoCompleteBarViewModel.PortViewModel;
+            if (existingPort != null)
             {
-                nodeAutoCompleteBarViewModel.PortViewModel.Highlight = Visibility.Collapsed;
+                existingPort.Highlight = Visibility.Collapsed;
             }
 
             nodeAutoCompleteBarViewModel.PortViewModel = portViewModel;
-            portViewModel.Highlight = Visibility.Visible;
 
-            if (nodeAutoCompleteBarViewModel.IsOpen)
-            {
-                if (nodeAutoCompleteBarView == null)
-                {
-                    nodeAutoCompleteBarView = new NodeAutoCompleteBarView(parentWindow, nodeAutoCompleteBarViewModel);
-                    nodeAutoCompleteBarView.Show();
-                }
-                nodeAutoCompleteBarView.ReloadDataContext(nodeAutoCompleteBarViewModel);
-                portViewModel.SetupNodeAutoCompleteClusterWindowPlacement(nodeAutoCompleteBarView);
-                return;
-            }
-
-            nodeAutoCompleteBarView = new NodeAutoCompleteBarView(parentWindow, nodeAutoCompleteBarViewModel);
-            nodeAutoCompleteBarView.Show();
-            portViewModel.SetupNodeAutoCompleteClusterWindowPlacement(nodeAutoCompleteBarView);
+            NodeAutoCompleteBarView.PrepareAndShowNodeAutoCompleteBar(parentWindow, nodeAutoCompleteBarViewModel);
         }
     }
 }

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -188,10 +188,20 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             }
             set
             {
-                if (isOpen == value) return;
+                if (isOpen == value)
+                {
+                    return;
+                }
+
                 isOpen = value;
-                if (isOpen) SubscribeWindowEvents();
-                else UnsubscribeWindowEvents();
+                if (isOpen)
+                {
+                    SubscribeWindowEvents();
+                }
+                else
+                {
+                    UnsubscribeWindowEvents();
+                }
             }
         }
 

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -791,8 +791,8 @@ namespace Dynamo.NodeAutoComplete.ViewModels
         // Delete all transient nodes in the workspace
         internal void DeleteTransientNodes()
         {
-            var node = PortViewModel.NodeViewModel;
-            var wsViewModel = node.WorkspaceViewModel;
+            var node = PortViewModel?.NodeViewModel;
+            var wsViewModel = node?.WorkspaceViewModel;
 
             var transientNodes = wsViewModel.Nodes.Where(x => x.IsTransient).ToList();
             var transientConnectors = wsViewModel.Connectors.Where(c => c.IsTransient).ToList();

--- a/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml.cs
+++ b/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml.cs
@@ -201,14 +201,12 @@ namespace Dynamo.NodeAutoComplete.Views
                 Dispatcher.BeginInvoke(new Action(() =>
                 {
                     ViewModel.DeleteTransientNodes();
-                    ViewModel.ToggleUndoRedoLocked(false);
                     ViewModel.PortViewModel = null;
                 }), DispatcherPriority.Loaded);
             }
             else
             {
                 ViewModel.DeleteTransientNodes();
-                ViewModel.ToggleUndoRedoLocked(false);
                 ViewModel.PortViewModel = null;
             }
         }

--- a/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml.cs
+++ b/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml.cs
@@ -96,7 +96,7 @@ namespace Dynamo.NodeAutoComplete.Views
 
         private void UpdatePosition()
         {
-            if ( ViewModel.PortViewModel != null)
+            if (ViewModel.PortViewModel != null)
             {
                 ViewModel.PortViewModel.SetupNodeAutoCompleteClusterWindowPlacement(this);
             }
@@ -182,17 +182,14 @@ namespace Dynamo.NodeAutoComplete.Views
         //Note that the window is not destroyed, it is just hidden so that it can be reused.
         internal void OnHideNodeAutoCompleteBar(bool delayTransientDeletion = false)
         {
-            if (ViewModel != null)
+            ViewModel.IsDropDownOpen = false;
+            ViewModel.IsOpen = false;
+            if (ViewModel.PortViewModel != null)
             {
-                ViewModel.IsOpen = false;                
-                ViewModel.IsDropDownOpen = false;
-                if (ViewModel.PortViewModel != null)
-                {
-                    ViewModel.PortViewModel.Highlight = Visibility.Hidden;
-                }
-                
-                UnsubscribeFromOtherEvents();
+                ViewModel.PortViewModel.Highlight = Visibility.Hidden;
             }
+                
+            UnsubscribeFromOtherEvents();
 
             Hide();
 
@@ -203,15 +200,15 @@ namespace Dynamo.NodeAutoComplete.Views
             {
                 Dispatcher.BeginInvoke(new Action(() =>
                 {
-                    ViewModel?.DeleteTransientNodes();
-                    ViewModel?.ToggleUndoRedoLocked(false);
+                    ViewModel.DeleteTransientNodes();
+                    ViewModel.ToggleUndoRedoLocked(false);
                     ViewModel.PortViewModel = null;
                 }), DispatcherPriority.Loaded);
             }
             else
             {
-                ViewModel?.DeleteTransientNodes();
-                ViewModel?.ToggleUndoRedoLocked(false);
+                ViewModel.DeleteTransientNodes();
+                ViewModel.ToggleUndoRedoLocked(false);
                 ViewModel.PortViewModel = null;
             }
         }
@@ -220,20 +217,17 @@ namespace Dynamo.NodeAutoComplete.Views
         {
             //Analytics.TrackEvent(Actions.Open, Categories.NodeAutoCompleteOperations);
 
-            if (ViewModel != null)
-            {
-                ViewModel.IsOpen = true;
-                ViewModel.PortViewModel.Highlight = Visibility.Visible;
-                ViewModel.PortViewModel.SetupNodeAutoCompleteClusterWindowPlacement(this);
-                SubscribeToOtherEvents();
-            }
+            ViewModel.IsOpen = true;
+            ViewModel.PortViewModel.Highlight = Visibility.Visible;
+            ViewModel.PortViewModel.SetupNodeAutoCompleteClusterWindowPlacement(this);
+            SubscribeToOtherEvents();
 
             Show();
 
             // Call asynchronously to populate data when the window is ready.
             Dispatcher.BeginInvoke(new Action(() =>
             {
-                ViewModel?.PopulateAutoComplete();
+                ViewModel.PopulateAutoComplete();
             }), DispatcherPriority.Loaded);
         }
 

--- a/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml.cs
+++ b/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml.cs
@@ -66,7 +66,6 @@ namespace Dynamo.NodeAutoComplete.Views
             }), DispatcherPriority.ApplicationIdle);
         }
 
-<<<<<<< HEAD
         private void OwnerMoved(object sender, EventArgs e) => UpdatePosition();
 
         private void UpdatePosition()
@@ -82,8 +81,6 @@ namespace Dynamo.NodeAutoComplete.Views
             }
         }
 
-=======
->>>>>>> e126d733ea (remove unused)
         // When triggered, they will result in the autocomplete bar window being destroyed.
         private void SubscribeToAppEvents()
         {
@@ -115,7 +112,6 @@ namespace Dynamo.NodeAutoComplete.Views
             ViewModel.dynamoViewModel.Model.WorkspaceRemoveStarted -= OnWorkspaceRemoved;
         }
 
-<<<<<<< HEAD
         void WorkspaceModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
@@ -128,8 +124,6 @@ namespace Dynamo.NodeAutoComplete.Views
             }
         }
 
-=======
->>>>>>> e126d733ea (remove unused)
         //Hide the window and unsubscribe from model events.
         //Note that the window is not destroyed, it is just hidden so that it can be reused.
         internal void OnHideNodeAutoCompleteBar(bool delayTransientDeletion = false)

--- a/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml.cs
+++ b/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml.cs
@@ -66,6 +66,7 @@ namespace Dynamo.NodeAutoComplete.Views
             }), DispatcherPriority.ApplicationIdle);
         }
 
+<<<<<<< HEAD
         private void OwnerMoved(object sender, EventArgs e) => UpdatePosition();
 
         private void UpdatePosition()
@@ -81,6 +82,8 @@ namespace Dynamo.NodeAutoComplete.Views
             }
         }
 
+=======
+>>>>>>> e126d733ea (remove unused)
         // When triggered, they will result in the autocomplete bar window being destroyed.
         private void SubscribeToAppEvents()
         {
@@ -112,6 +115,7 @@ namespace Dynamo.NodeAutoComplete.Views
             ViewModel.dynamoViewModel.Model.WorkspaceRemoveStarted -= OnWorkspaceRemoved;
         }
 
+<<<<<<< HEAD
         void WorkspaceModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
@@ -124,6 +128,8 @@ namespace Dynamo.NodeAutoComplete.Views
             }
         }
 
+=======
+>>>>>>> e126d733ea (remove unused)
         //Hide the window and unsubscribe from model events.
         //Note that the window is not destroyed, it is just hidden so that it can be reused.
         internal void OnHideNodeAutoCompleteBar(bool delayTransientDeletion = false)


### PR DESCRIPTION
### Purpose
Reuse NodeAutoCompleteBar window.
Handle multiple workspaces scenarios.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

N/A

### Reviewers
@DynamoDS/synapse 
