### PR TITLE
DYN-8778 - alert user to login

### DIFF
--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -876,13 +876,13 @@ This package likely contains an assembly that is blocked. You will need to load 
     <value>Loading Node Library...</value>
   </data>
   <data name="AutocompleteNoRecommendationsTitle" xml:space="preserve">
-    <value>No recommendations</value>
+    <value>No suggestions available</value>
   </data>
   <data name="AutocompleteLowConfidenceTitle" xml:space="preserve">
     <value>Low confidence</value>
   </data>
   <data name="AutocompleteNoRecommendationsMessage" xml:space="preserve">
-    <value>There are no recommendations yet. You can try switching to node type match autocomplete.</value>
+    <value>The model is continuously improving - check back soon</value>
   </data>
   <data name="AutocompleteLowConfidenceMessage" xml:space="preserve">
     <value>No confident suggestions available. The model is continuously improving - check back soon.</value>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -879,13 +879,13 @@ This package likely contains an assembly that is blocked. You will need to load 
     <value>Loading Node Library...</value>
   </data>
   <data name="AutocompleteNoRecommendationsTitle" xml:space="preserve">
-    <value>No recommendations</value>
+    <value>No suggestions available</value>
   </data>
   <data name="AutocompleteLowConfidenceTitle" xml:space="preserve">
     <value>Low confidence</value>
   </data>
   <data name="AutocompleteNoRecommendationsMessage" xml:space="preserve">
-    <value>There are no recommendations yet. You can try switching to node type match autocomplete.</value>
+    <value>The model is continuously improving - check back soon</value>
   </data>
   <data name="AutocompleteLowConfidenceMessage" xml:space="preserve">
     <value>No confident suggestions available. The model is continuously improving - check back soon.</value>

--- a/src/DynamoCoreWpf/Controls/Docs/en-US/NodeAutocompleteDocumentation.html
+++ b/src/DynamoCoreWpf/Controls/Docs/en-US/NodeAutocompleteDocumentation.html
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
     There are two versions of this HTML file. One that is part of the Dynamo Dictionary
     codebase and one that is part of the Dynamo codebase, used for displaying additional
     error information in the Dynamo side panel.
@@ -66,12 +66,11 @@
         color: #bbbbbb;
     }
 
-        .button:hover {
-            border-color: #656565;
-            background-color: #373737;
-            opacity: 1.0;
-        }
-
+    .button:hover {
+        border-color: #656565;
+        background-color: #373737;
+        opacity: 1.0;
+    }
     .questionmark:after {
         content: '?';
         display: inline-block;
@@ -87,7 +86,6 @@
         border: 1px solid;
         text-decoration: none;
     }
-
     @media screen and (max-width: 600px) {
         table {
             width: 100%;
@@ -209,7 +207,7 @@
         or generalized, such as Geometry.Explode, which takes in any collection of geometry types and works on all of them..<br /><br />
 
         Nodes are sorted in this order:<br />
-
+            
         <ol>
             <li>Nodes closest to the type (have the smallest type distance) that match the input/output port type.</li>
             <li>Nodes that are further away from the type (have a greater type distance)</li>

--- a/src/DynamoCoreWpf/Controls/Docs/en-US/NodeAutocompleteDocumentation.html
+++ b/src/DynamoCoreWpf/Controls/Docs/en-US/NodeAutocompleteDocumentation.html
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
     There are two versions of this HTML file. One that is part of the Dynamo Dictionary
     codebase and one that is part of the Dynamo codebase, used for displaying additional
     error information in the Dynamo side panel.
@@ -66,11 +66,12 @@
         color: #bbbbbb;
     }
 
-    .button:hover {
-        border-color: #656565;
-        background-color: #373737;
-        opacity: 1.0;
-    }
+        .button:hover {
+            border-color: #656565;
+            background-color: #373737;
+            opacity: 1.0;
+        }
+
     .questionmark:after {
         content: '?';
         display: inline-block;
@@ -86,6 +87,7 @@
         border: 1px solid;
         text-decoration: none;
     }
+
     @media screen and (max-width: 600px) {
         table {
             width: 100%;
@@ -207,7 +209,7 @@
         or generalized, such as Geometry.Explode, which takes in any collection of geometry types and works on all of them..<br /><br />
 
         Nodes are sorted in this order:<br />
-            
+
         <ol>
             <li>Nodes closest to the type (have the smallest type distance) that match the input/output port type.</li>
             <li>Nodes that are further away from the type (have a greater type distance)</li>

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -169,24 +169,6 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No suggestions available.
-        /// </summary>
-        public static string AutocompleteNoSuggestions {
-            get {
-                return ResourceManager.GetString("AutocompleteNoSuggestions", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The model is continuously improving - check back soon.
-        /// </summary>
-        public static string AutocompletePlaceholder {
-            get {
-                return ResourceManager.GetString("AutocompletePlaceholder", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Autodesk A360.
         /// </summary>
         public static string Autodesk360SignInButtonTitleToolTip {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -4176,12 +4176,6 @@ To make this file into a new template, save it to a different folder, then move 
     <value>Node Icon Data is dumped to \"{0}\".</value>
     <comment>Debug menu | Dump all node icons</comment>
   </data>
-  <data name="AutocompletePlaceholder" xml:space="preserve">
-    <value>The model is continuously improving - check back soon</value>
-  </data>
-  <data name="AutocompleteNoSuggestions" xml:space="preserve">
-    <value>No suggestions available</value>
-  </data>
   <data name="GroupOptionalInportsText" xml:space="preserve">
     <value>Optional</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -4160,12 +4160,6 @@ To make this file into a new template, save it to a different folder, then move 
     <value>Node Icon Data is dumped to \"{0}\".</value>
     <comment>Debug menu | Dump all node icons</comment>
   </data>
-  <data name="AutocompletePlaceholder" xml:space="preserve">
-    <value>The model is continuously improving - check back soon</value>
-  </data>
-  <data name="AutocompleteNoSuggestions" xml:space="preserve">
-    <value>No suggestions available</value>
-  </data>
   <data name="GroupOptionalInportsText" xml:space="preserve">
     <value>Optional</value>
   </data>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -4549,8 +4549,6 @@ static Dynamo.Wpf.Properties.Resources.AddFileToPackageDialogTitle.get -> string
 static Dynamo.Wpf.Properties.Resources.AddStyleButton.get -> string
 static Dynamo.Wpf.Properties.Resources.AddToLibraryButton.get -> string
 static Dynamo.Wpf.Properties.Resources.AgreeToMLAutocompleteTOUText.get -> string
-static Dynamo.Wpf.Properties.Resources.AutocompleteNoSuggestions.get -> string
-static Dynamo.Wpf.Properties.Resources.AutocompletePlaceholder.get -> string
 static Dynamo.Wpf.Properties.Resources.Autodesk360SignInButtonTitleToolTip.get -> string
 static Dynamo.Wpf.Properties.Resources.AutodeskSignIn.get -> string
 static Dynamo.Wpf.Properties.Resources.Automatic.get -> string

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -151,8 +151,11 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                 RaisePropertyChanged(nameof(HasPrevious));
                 RaisePropertyChanged(nameof(HasNext));
                 RaisePropertyChanged(nameof(FilteredView));
+                RaisePropertyChanged(nameof(HasUnfilteredResults));
             }
         }
+
+        public bool HasUnfilteredResults => DropdownResults != null && DropdownResults.Any();
 
         /// <summary>
         /// Return the filter associated currently with dropdown results.
@@ -562,19 +565,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             MLNodeAutoCompletionResponse MLresults = null;
 
             // Get results from the ML API.
-            try
-            {
-                MLresults = GetGenericAutocompleteResult<MLNodeAutoCompletionResponse>(nodeAutocompleteMLEndpoint);
-            }
-            catch (Exception ex)
-            {
-                dynamoViewModel.Model.Logger.Log("Unable to fetch ML Node autocomplete results: " + ex.Message);
-                DisplayAutocompleteMLStaticPage = true;
-                AutocompleteMLTitle = Resources.LoginNeededTitle;
-                AutocompleteMLMessage = Resources.LoginNeededMessage;
-                Analytics.TrackEvent(Actions.View, Categories.NodeAutoCompleteOperations, "UnabletoFetch");
-                return new List<SingleResultItem>();
-            }
+            MLresults = GetGenericAutocompleteResult<MLNodeAutoCompletionResponse>(nodeAutocompleteMLEndpoint);
 
             // no results
             if (MLresults == null || MLresults.Results.Count() == 0)
@@ -1013,19 +1004,33 @@ namespace Dynamo.NodeAutoComplete.ViewModels
                 List<SingleResultItem> fullSingleResults = null;
                 MLNodeClusterAutoCompletionResponse fullResults = null;
 
-                if (IsSingleAutocomplete || !IsDisplayingMLRecommendation)
+                try
                 {
-                    fullSingleResults = GetSingleAutocompleteResults().ToList();
-                    fullResults = new MLNodeClusterAutoCompletionResponse
+                    if (IsSingleAutocomplete || !IsDisplayingMLRecommendation)
                     {
-                        Version = "0.0",
-                        NumberOfResults = fullSingleResults.Count,
-                        Results = fullSingleResults,
-                    };
+                        fullSingleResults = GetSingleAutocompleteResults().ToList();
+                        fullResults = new MLNodeClusterAutoCompletionResponse
+                        {
+                            Version = "0.0",
+                            NumberOfResults = fullSingleResults.Count,
+                            Results = fullSingleResults,
+                        };
+                    }
+                    else
+                    {
+                        fullResults = GetGenericAutocompleteResult<MLNodeClusterAutoCompletionResponse>(nodeClusterAutocompleteMLEndpoint);
+                    }
                 }
-                else
+                catch (Exception ex)
                 {
-                    fullResults = GetGenericAutocompleteResult<MLNodeClusterAutoCompletionResponse>(nodeClusterAutocompleteMLEndpoint);
+                    dynamoViewModel.Model.Logger.Log("Unable to fetch ML Node autocomplete results: " + ex.Message);
+                    DisplayAutocompleteMLStaticPage = true;
+                    AutocompleteMLTitle = Resources.LoginNeededTitle;
+                    AutocompleteMLMessage = Resources.LoginNeededMessage;
+                    Analytics.TrackEvent(Actions.View, Categories.NodeAutoCompleteOperations, "UnabletoFetch");
+                    DropdownResults = new List<DNADropdownViewModel>();
+                    IsDropDownOpen = true;
+                    return;
                 }
 
                 dynamoViewModel.UIDispatcher.BeginInvoke(() =>

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -405,6 +405,14 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             }
         }
 
+        internal bool IsUserAuthenticated
+        {
+            get
+            {
+                return dynamoViewModel?.Model?.AuthenticationManager?.IsLoggedIn() == true || !IsDisplayingMLRecommendation;
+            }
+        }
+
         internal event Action<NodeModel> ParentNodeRemoved;
         internal event Action RefocusSearchBox;
 
@@ -426,6 +434,11 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             DefaultResults = dynamoViewModel.DefaultAutocompleteCandidates.Values;
             ServiceVersion = string.Empty;
             localAutoCompleteService = new LocalAutoCompleteService(dynamoViewModel);
+            
+            if (dynamoViewModel?.Model?.AuthenticationManager != null)
+            {
+                RaisePropertyChanged(nameof(IsUserAuthenticated));
+            }
         }
 
         /// <summary>

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -408,14 +408,6 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             }
         }
 
-        internal bool IsUserAuthenticated
-        {
-            get
-            {
-                return dynamoViewModel?.Model?.AuthenticationManager?.IsLoggedIn() == true || !IsDisplayingMLRecommendation;
-            }
-        }
-
         internal event Action<NodeModel> ParentNodeRemoved;
         internal event Action RefocusSearchBox;
 
@@ -437,11 +429,6 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             DefaultResults = dynamoViewModel.DefaultAutocompleteCandidates.Values;
             ServiceVersion = string.Empty;
             localAutoCompleteService = new LocalAutoCompleteService(dynamoViewModel);
-            
-            if (dynamoViewModel?.Model?.AuthenticationManager != null)
-            {
-                RaisePropertyChanged(nameof(IsUserAuthenticated));
-            }
         }
 
         /// <summary>

--- a/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml
+++ b/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml
@@ -137,7 +137,6 @@
                                            TextAlignment="Center"
                                            Visibility="Visible"
                                            Margin="6"/>
-                                        <!-- Login Needed Placeholders -->
                                         <TextBlock x:Name="LoginNeededMessagePlaceholder"
                                            FontSize="12"
                                            Text="{Binding AutocompleteMLMessage}"

--- a/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml
+++ b/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml
@@ -116,7 +116,7 @@
                                         BorderThickness="0,6,0,0" />
                                         <ContentControl x:Name="SearchSlot"
                                     Content="{TemplateBinding Tag}"
-                                    Visibility="{Binding Content, RelativeSource={RelativeSource Self}, Converter={StaticResource NullToVisibiltyConverter}}"
+                                    Visibility="{Binding HasUnfilteredResults, Converter={StaticResource BooleanToVisibilityConverter}}"
                                     Margin="0,6,0,0"
                                     VerticalAlignment="Top"/>
                                         <TextBlock x:Name="MessagePlaceholder"
@@ -141,14 +141,12 @@
                                 <Trigger Property="HasItems" Value="false">
                                     <Setter TargetName="DropDownBorder" Property="MinHeight" Value="70" />
                                     <Setter Property="ScrollViewer.Visibility" Value="Collapsed" />
-                                    <Setter TargetName="SearchSlot" Property="Visibility" Value="Collapsed" />
                                     <Setter TargetName="ContentSite" Property="Visibility" Value="Collapsed"/>
                                     <Setter TargetName="TitlePlaceholder" Property="Visibility" Value="Collapsed"/>
                                     <Setter TargetName="MessagePlaceholder" Property="Visibility" Value="Collapsed"/>
                                 </Trigger>
                                 <Trigger Property="HasItems" Value="true">
                                     <Setter Property="ScrollViewer.Visibility" Value="Visible" />
-                                    <Setter TargetName="SearchSlot" Property="Visibility" Value="Visible" />
                                     <Setter TargetName="ContentSite" Property="Visibility" Value="Visible"/>
                                     <Setter TargetName="TitlePlaceholder" Property="Visibility" Value="Collapsed"/>
                                     <Setter TargetName="MessagePlaceholder" Property="Visibility" Value="Collapsed"/>
@@ -156,7 +154,6 @@
                                 <DataTrigger Binding="{Binding DisplayAutocompleteMLStaticPage}" Value="True">
                                     <Setter TargetName="TitlePlaceholder" Property="Visibility" Value="Visible"/>
                                     <Setter TargetName="MessagePlaceholder" Property="Visibility" Value="Visible"/>
-                                    <Setter TargetName="SearchSlot" Property="Visibility" Value="Collapsed"/>
                                     <Setter TargetName="ContentSite" Property="Visibility" Value="Collapsed"/>
                                 </DataTrigger>
                                 <Trigger Property="IsGrouping" Value="true">

--- a/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml
+++ b/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml
@@ -129,7 +129,7 @@
                                            TextWrapping="Wrap"
                                            TextAlignment="Center"
                                            Visibility="Collapsed"
-                                           Margin="6,0,0,0"/>
+                                           Margin="4"/>
                                         <ScrollViewer Margin="0,36,0,0" SnapsToDevicePixels="True">
                                             <StackPanel KeyboardNavigation.DirectionalNavigation="Contained"
                                                 IsItemsHost="True" />

--- a/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml
+++ b/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml
@@ -80,14 +80,7 @@
                                           ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
                                           ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
                                           IsHitTestVisible="False" />
-                                <TextBlock x:Name="BoxPlaceholder"
-                                 Text="{x:Static resxother:Resources.AutocompleteNoSuggestions}"
-                                 Foreground="LightGray"
-                                 VerticalAlignment="Center"
-                                 FontSize="12"
-                                 Margin="6,0,0,0"
-                                 Visibility="Collapsed"/>
-                                <TextBlock x:Name="LoginNeededTitlePlaceholder"
+                                <TextBlock x:Name="TitlePlaceholder"
                                            Text="{Binding AutocompleteMLTitle}"
                                            Foreground="LightGray"
                                            VerticalAlignment="Center"
@@ -126,18 +119,7 @@
                                     Visibility="{Binding Content, RelativeSource={RelativeSource Self}, Converter={StaticResource NullToVisibiltyConverter}}"
                                     Margin="0,6,0,0"
                                     VerticalAlignment="Top"/>
-                                        <TextBlock x:Name="NoItemsPlaceholder"
-                                           FontSize="12"
-                                           Text="{x:Static resxother:Resources.AutocompletePlaceholder}"
-                                           Foreground="LightGray"
-                                           HorizontalAlignment="Center"
-                                           VerticalAlignment="Center"
-                                           MaxWidth="{TemplateBinding ActualWidth}"
-                                           TextWrapping="Wrap"
-                                           TextAlignment="Center"
-                                           Visibility="Visible"
-                                           Margin="6"/>
-                                        <TextBlock x:Name="LoginNeededMessagePlaceholder"
+                                        <TextBlock x:Name="MessagePlaceholder"
                                            FontSize="12"
                                            Text="{Binding AutocompleteMLMessage}"
                                            Foreground="LightGray"
@@ -159,27 +141,21 @@
                                 <Trigger Property="HasItems" Value="false">
                                     <Setter TargetName="DropDownBorder" Property="MinHeight" Value="70" />
                                     <Setter Property="ScrollViewer.Visibility" Value="Collapsed" />
-                                    <Setter TargetName="NoItemsPlaceholder" Property="Visibility" Value="Visible" />
                                     <Setter TargetName="SearchSlot" Property="Visibility" Value="Collapsed" />
-                                    <Setter TargetName="BoxPlaceholder" Property="Visibility" Value="Visible"/>
                                     <Setter TargetName="ContentSite" Property="Visibility" Value="Collapsed"/>
-                                    <Setter TargetName="LoginNeededTitlePlaceholder" Property="Visibility" Value="Collapsed"/>
-                                    <Setter TargetName="LoginNeededMessagePlaceholder" Property="Visibility" Value="Collapsed"/>
+                                    <Setter TargetName="TitlePlaceholder" Property="Visibility" Value="Collapsed"/>
+                                    <Setter TargetName="MessagePlaceholder" Property="Visibility" Value="Collapsed"/>
                                 </Trigger>
                                 <Trigger Property="HasItems" Value="true">
                                     <Setter Property="ScrollViewer.Visibility" Value="Visible" />
-                                    <Setter TargetName="NoItemsPlaceholder" Property="Visibility" Value="Collapsed" />
                                     <Setter TargetName="SearchSlot" Property="Visibility" Value="Visible" />
-                                    <Setter TargetName="BoxPlaceholder" Property="Visibility" Value="Collapsed"/>
                                     <Setter TargetName="ContentSite" Property="Visibility" Value="Visible"/>
-                                    <Setter TargetName="LoginNeededTitlePlaceholder" Property="Visibility" Value="Collapsed"/>
-                                    <Setter TargetName="LoginNeededMessagePlaceholder" Property="Visibility" Value="Collapsed"/>
+                                    <Setter TargetName="TitlePlaceholder" Property="Visibility" Value="Collapsed"/>
+                                    <Setter TargetName="MessagePlaceholder" Property="Visibility" Value="Collapsed"/>
                                 </Trigger>
                                 <DataTrigger Binding="{Binding DisplayAutocompleteMLStaticPage}" Value="True">
-                                    <Setter TargetName="LoginNeededTitlePlaceholder" Property="Visibility" Value="Visible"/>
-                                    <Setter TargetName="LoginNeededMessagePlaceholder" Property="Visibility" Value="Visible"/>
-                                    <Setter TargetName="NoItemsPlaceholder" Property="Visibility" Value="Collapsed"/>
-                                    <Setter TargetName="BoxPlaceholder" Property="Visibility" Value="Collapsed"/>
+                                    <Setter TargetName="TitlePlaceholder" Property="Visibility" Value="Visible"/>
+                                    <Setter TargetName="MessagePlaceholder" Property="Visibility" Value="Visible"/>
                                     <Setter TargetName="SearchSlot" Property="Visibility" Value="Collapsed"/>
                                     <Setter TargetName="ContentSite" Property="Visibility" Value="Collapsed"/>
                                 </DataTrigger>

--- a/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml
+++ b/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml
@@ -7,6 +7,7 @@
              xmlns:local="clr-namespace:Dynamo.PackageManager.UI;assembly=DynamoCoreWpf"
              xmlns:dynconverters="clr-namespace:Dynamo.Controls;assembly=DynamoCoreWpf"
              xmlns:resxother="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
+             xmlns:properties="clr-namespace:Dynamo.Properties;assembly=DynamoCore"
              mc:Ignorable="d"
              WindowStyle="None"
              AllowsTransparency="True"
@@ -86,6 +87,13 @@
                                  FontSize="12"
                                  Margin="6,0,0,0"
                                  Visibility="Collapsed"/>
+                                <TextBlock x:Name="LoginNeededTitlePlaceholder"
+                                           Text="{Binding AutocompleteMLTitle}"
+                                           Foreground="LightGray"
+                                           VerticalAlignment="Center"
+                                           FontSize="12"
+                                           Margin="6,0,0,0"
+                                           Visibility="Collapsed"/>
                                 <TextBox x:Name="PART_EditableTextBox"
                                  Margin="3,3,23,3"
                                  Padding="10"
@@ -129,6 +137,18 @@
                                            TextAlignment="Center"
                                            Visibility="Visible"
                                            Margin="6"/>
+                                        <!-- Login Needed Placeholders -->
+                                        <TextBlock x:Name="LoginNeededMessagePlaceholder"
+                                           FontSize="12"
+                                           Text="{Binding AutocompleteMLMessage}"
+                                           Foreground="LightGray"
+                                           HorizontalAlignment="Center"
+                                           VerticalAlignment="Center"
+                                           MaxWidth="{TemplateBinding ActualWidth}"
+                                           TextWrapping="Wrap"
+                                           TextAlignment="Center"
+                                           Visibility="Collapsed"
+                                           Margin="6,48,6,6"/>
                                         <ScrollViewer Margin="0,36,0,0" SnapsToDevicePixels="True">
                                             <StackPanel KeyboardNavigation.DirectionalNavigation="Contained"
                                                 IsItemsHost="True" />
@@ -144,6 +164,8 @@
                                     <Setter TargetName="SearchSlot" Property="Visibility" Value="Collapsed" />
                                     <Setter TargetName="BoxPlaceholder" Property="Visibility" Value="Visible"/>
                                     <Setter TargetName="ContentSite" Property="Visibility" Value="Collapsed"/>
+                                    <Setter TargetName="LoginNeededTitlePlaceholder" Property="Visibility" Value="Collapsed"/>
+                                    <Setter TargetName="LoginNeededMessagePlaceholder" Property="Visibility" Value="Collapsed"/>
                                 </Trigger>
                                 <Trigger Property="HasItems" Value="true">
                                     <Setter Property="ScrollViewer.Visibility" Value="Visible" />
@@ -151,7 +173,17 @@
                                     <Setter TargetName="SearchSlot" Property="Visibility" Value="Visible" />
                                     <Setter TargetName="BoxPlaceholder" Property="Visibility" Value="Collapsed"/>
                                     <Setter TargetName="ContentSite" Property="Visibility" Value="Visible"/>
+                                    <Setter TargetName="LoginNeededTitlePlaceholder" Property="Visibility" Value="Collapsed"/>
+                                    <Setter TargetName="LoginNeededMessagePlaceholder" Property="Visibility" Value="Collapsed"/>
                                 </Trigger>
+                                <DataTrigger Binding="{Binding DisplayAutocompleteMLStaticPage}" Value="True">
+                                    <Setter TargetName="LoginNeededTitlePlaceholder" Property="Visibility" Value="Visible"/>
+                                    <Setter TargetName="LoginNeededMessagePlaceholder" Property="Visibility" Value="Visible"/>
+                                    <Setter TargetName="NoItemsPlaceholder" Property="Visibility" Value="Collapsed"/>
+                                    <Setter TargetName="BoxPlaceholder" Property="Visibility" Value="Collapsed"/>
+                                    <Setter TargetName="SearchSlot" Property="Visibility" Value="Collapsed"/>
+                                    <Setter TargetName="ContentSite" Property="Visibility" Value="Collapsed"/>
+                                </DataTrigger>
                                 <Trigger Property="IsGrouping" Value="true">
                                     <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
                                 </Trigger>

--- a/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml
+++ b/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml
@@ -129,7 +129,7 @@
                                            TextWrapping="Wrap"
                                            TextAlignment="Center"
                                            Visibility="Collapsed"
-                                           Margin="6,48,6,6"/>
+                                           Margin="6,0,0,0"/>
                                         <ScrollViewer Margin="0,36,0,0" SnapsToDevicePixels="True">
                                             <StackPanel KeyboardNavigation.DirectionalNavigation="Contained"
                                                 IsItemsHost="True" />


### PR DESCRIPTION
### Purpose

This PR replaces hardcoded “no suggestions” placeholders with dynamic ML-based titles and messages, introduces a user authentication flag for controlling placeholder visibility, and cleans up obsolete resources and minor documentation whitespace.

- Swap out BoxPlaceholder/NoItemsPlaceholder for TitlePlaceholder/MessagePlaceholder with bindings and a DataTrigger for DisplayAutocompleteMLStaticPage
- Add IsUserAuthenticated property in the ViewModel to gate ML content based on login state
- Remove old resource entries and update core resource strings for consistency
- Clean up trailing blanks in the Node Autocomplete documentation HTML
<img width="726" height="410" alt="image" src="https://github.com/user-attachments/assets/a7f5765d-acad-4312-b611-b9c9548f4a26" />


<img width="760" height="647" alt="image" src="https://github.com/user-attachments/assets/b43c5199-4aca-4b47-85e9-460f65652231" />



### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers

@DynamoDS/synapse 

### FYIs

@Jingyi-Wen 
