### PR TITLE
[DYN-8893] Group context menu bug fix

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -59,6 +59,7 @@ namespace Dynamo.Nodes
         private Grid outputPortsGrid;
         private Grid groupContent;
         private Border nodeCountBorder;
+        private InCanvasSearchControl searchBar;
         
         private Thumb mainGroupThumb;
         private StackPanel groupPopupPanel;
@@ -740,6 +741,8 @@ namespace Dynamo.Nodes
         {
             if (e.Key == Key.O && Keyboard.Modifiers == System.Windows.Input.ModifierKeys.None)
             {
+                if (searchBar != null && searchBar.IsKeyboardFocusWithin) return;
+
                 OnUngroupAnnotation(this, new RoutedEventArgs());
                 e.Handled = true;
                 GroupContextMenuPopup.IsOpen = false;
@@ -1854,7 +1857,7 @@ namespace Dynamo.Nodes
 
         private UIElement CreateSearchBox()
         {
-            var searchBar = new InCanvasSearchControl
+            searchBar = new InCanvasSearchControl
             {
                 DataContext = ViewModel.WorkspaceViewModel.InCanvasSearchViewModel,
                 Width = 230
@@ -2449,7 +2452,7 @@ namespace Dynamo.Nodes
 
             // Add ContentPresenter
             var contentPresenterFactory = new FrameworkElementFactory(typeof(ContentPresenter));
-            contentPresenterFactory.SetValue(Grid.ColumnSpanProperty, 3);
+            contentPresenterFactory.SetValue(Grid.ColumnSpanProperty, 4);
             contentPresenterFactory.SetValue(FrameworkElement.MarginProperty, new Thickness(4));
             contentPresenterFactory.SetValue(ContentPresenter.ContentSourceProperty, "Header");
             contentPresenterFactory.SetValue(ContentPresenter.RecognizesAccessKeyProperty, true);


### PR DESCRIPTION
### Purpose

Small PR for [DYN-8893](https://jira.autodesk.com/browse/DYN-8893).

- The "o" hotkey for ungrouping is now disabled when the group context menu search bar is focused.
- Removed extra right margin that was causing group names to be cut off in some cases. 

![DYN-8893-SearchBar bug fix](https://github.com/user-attachments/assets/afb40812-c520-4c90-a579-d4152a7fad1f)


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

- The "o" hotkey for ungrouping is now disabled when the group context menu search bar is focused.
- Removed extra right margin that was causing group names to be cut off in some cases. 

### Reviewers

@DynamoDS/eidos
@jasonstratton.
@zeusongit 

### FYIs

@dnenov
@achintyabhat
