### PR TITLE
[DYN-8997] Tooltips for code block outports

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -1026,19 +1026,21 @@ namespace Dynamo.Graph.Nodes
             // Clear out all the output port models
             OutPorts.RemoveAll((p) => true);
 
+            int maxLength = Configurations.CBNMaxPortNameLength;
+
             foreach (var def in allDefs)
             {
+                // Try to retrieve the output metadata (label and tooltip) for this output variable.
+                // If not found, fallback to empty strings to avoid null issues.
                 if (!outportMetadata.TryGetValue(def.Key, out var metadata))
                 {
-                    metadata = ("", "");
+                    metadata = (string.Empty, string.Empty);
                 }
 
                 var label = metadata.Label;
                 var tooltip = $"{string.Format(Resources.CodeBlockTempIdentifierOutputLabel, def.Value)} : {metadata.Tooltip}";
-
-                // Trim long labels
-                int maxLength = Configurations.CBNMaxPortNameLength;
-                if (label.Length > Configurations.CBNMaxPortNameLength) label = label.Remove(maxLength - 3) + "...";
+                if (label.Length > maxLength)
+                    label = label.Remove(maxLength - 3) + "...";
 
                 OutPorts.Add(new PortModel(PortType.Output, this, new PortData(label, tooltip)
                 {
@@ -1047,7 +1049,6 @@ namespace Dynamo.Graph.Nodes
                 }));
             }
         }
-
 
         /// <summary>
         ///     Deletes all the connections and saves their data (the start and end port)

--- a/src/DynamoCore/Graph/Nodes/CodeBlockUtils.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockUtils.cs
@@ -308,11 +308,15 @@ namespace Dynamo.Graph.Nodes
                 case IdentifierNode idNode:
                     return idNode.Value;
                 case IdentifierListNode:
-                    return "[identifier list]";
+                    if (ProtoCore.Utils.CoreUtils.TryGetPropertyName(node.ToString(), out string _))
+                        return "[property]";
+                    return "[function]";
                 case FunctionCallNode:
                     return "[function]";
                 case InlineConditionalNode:
                     return "[conditional]";
+                case LanguageBlockNode:
+                    return "[language block]";
                 default:
                     return "[unknown]";
             }

--- a/src/DynamoCore/Graph/Nodes/CodeBlockUtils.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockUtils.cs
@@ -270,28 +270,13 @@ namespace Dynamo.Graph.Nodes
         /// <summary>
         /// Extracts cleaned individual code expressions as tooltip strings from a full code block.
         /// </summary>
-        internal static List<string> GetCleanedCodeExpressionsForTooltips(string code)
+        internal static string GetTooltipForNode(AssociativeNode node)
         {
-            if (string.IsNullOrWhiteSpace(code))
-                return new List<string>();
+            if (node == null)
+                return string.Empty;
 
-            // Filter out full-line comments and remove inline comments
-            var cleanedCode = string.Join(" ",
-                code.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-                    .Where(line => !line.TrimStart().StartsWith("//"))
-                    .Select(line =>
-                    {
-                        var idx = line.IndexOf("//");
-                        return idx >= 0 ? line.Substring(0, idx) : line;
-                    }));
-
-            // Split by semicolon and return trimmed expressions
-            return cleanedCode
-                .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(expr => expr.Trim())
-                .Where(expr => !string.IsNullOrEmpty(expr))
-                .Select(expr => expr + ";")
-                .ToList();
+            var codeGen = new ProtoCore.CodeGenDS(new[] { node });
+            return codeGen.GenerateCode();
         }
 
         /// <summary>

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -2113,10 +2113,15 @@ var06 = g;
             string openPath = Path.Combine(TestDirectory, @"core\cbn\OutputPortLabels.dyn");
             RunModel(openPath);
 
+            var intLineContent = "1";
+            var imperativeBlockContent = "[Imperative]\n{\nreturn = 5;\n\n}\n";
+            var stringLiteralContent = "foo";
+
             var cbn = GetModel().Workspaces.First().Nodes.First() as CodeBlockNodeModel;
-            Assert.AreEqual(string.Format(Resources.CodeBlockTempIdentifierOutputLabel, 1), cbn.OutPorts.First().ToolTip); 
-            Assert.AreEqual(string.Format(Resources.CodeBlockTempIdentifierOutputLabel, 2), cbn.OutPorts.ElementAt(1).ToolTip); 
-            Assert.AreEqual(string.Format(Resources.CodeBlockTempIdentifierOutputLabel, 4), cbn.OutPorts.ElementAt(2).ToolTip); 
+
+            Assert.AreEqual($"{string.Format(Resources.CodeBlockTempIdentifierOutputLabel, 1)} : {intLineContent}", cbn.OutPorts[0].ToolTip);
+            Assert.AreEqual($"{string.Format(Resources.CodeBlockTempIdentifierOutputLabel, 2)} : {imperativeBlockContent}", cbn.OutPorts[1].ToolTip);
+            Assert.AreEqual($"{string.Format(Resources.CodeBlockTempIdentifierOutputLabel, 4)} : \"{stringLiteralContent}\"", cbn.OutPorts[2].ToolTip);
         }
     }
 


### PR DESCRIPTION
### Purpose

Small PR related to [DYN-8997](https://jira.autodesk.com/browse/DYN-8997).

Shows the line statement in the outport tooltip.

@aparajit-pratap , would this proposal be acceptable if we want to update the tooltips?

<img width="982" height="255" alt="Screenshot 2025-07-14 074932" src="https://github.com/user-attachments/assets/0d0d2d32-ae7e-4a1f-8c8e-b1bf97d5d711" />

<img width="609" height="446" alt="Screenshot 2025-07-14 075025" src="https://github.com/user-attachments/assets/3073dbf8-973b-48c4-8d70-8da4178bdd09" />


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

Shows the line statement in the outport tooltip.

### Reviewers

@DynamoDS/eidos
@jasonstratton.

### FYIs

@dnenov 
@achintyabhat 
