### PR TITLE
DYN-8888 : optimize graph execution for dna

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -474,7 +474,7 @@ namespace Dynamo.Graph.Workspaces
         {
             base.NodeModified(node);
 
-            if (!silenceNodeModifications)
+            if (!silenceNodeModifications && !node.IsTransient)
             {
                 RequestRun();
             }

--- a/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
@@ -752,7 +752,7 @@ namespace Dynamo.Graph.Workspaces
                         node.Y = n.Y + n.NotesHeight + offsetY;
                     }
                     node.ReportPosition();
-                    workspace.HasUnsavedChanges = true;
+                    //workspace.HasUnsavedChanges = true;
 
                     double noteOffset = -n.NotesHeight;
                     foreach (NoteModel note in n.LinkedNotes)

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1633,12 +1633,12 @@ namespace Dynamo.Graph.Workspaces
 
             AddNode(node);
 
-            HasUnsavedChanges = true;
-
-            if (node is CodeBlockNodeModel cbn
-                && string.IsNullOrEmpty(cbn.Code)) return;
-
-            RequestRun();
+            if (!node.IsTransient)
+            {
+                HasUnsavedChanges = true;
+                if (node is CodeBlockNodeModel cbn && string.IsNullOrEmpty(cbn.Code)) return;
+                RequestRun();
+            }
         }
 
         protected virtual void RegisterNode(NodeModel node)
@@ -1670,6 +1670,11 @@ namespace Dynamo.Graph.Workspaces
         /// </summary>
         protected virtual void NodeModified(NodeModel node)
         {
+            if (node.IsTransient)
+            {
+                return;
+            }
+
             HasUnsavedChanges = true;
         }
 
@@ -1689,7 +1694,10 @@ namespace Dynamo.Graph.Workspaces
             OnNodeRemoved(model);
             // Force this change to address the edge case that user deleting the right edge
             // node and do not see unsaved changes, e.g. the watch node at end of the graph
-            HasUnsavedChanges = true;
+            if (!model.IsTransient)
+            {
+                HasUnsavedChanges = true;
+            }
 
             if (dispose)
             {

--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -320,11 +320,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
 
             NodeAutoCompleteUtilities.PostAutoLayoutNodes(node.WorkspaceViewModel.Model, node.NodeModel, transientNodes.Select(x => x.NodeModel), true, true, PortViewModel.PortType, null);
 
-            if (PortViewModel.PortType == PortType.Input)
-            {
-                node.NodeModel.MarkNodeAsModified();
-            }
-
+            node.WorkspaceViewModel.Model.HasUnsavedChanges = true;
             (node.WorkspaceViewModel.Model as HomeWorkspaceModel)?.MarkNodesAsModifiedAndRequestRun(transientNodes.Select(x => x.NodeModel));
 
             //add the new items to the undo recorder (this ensures the elements are valid at this point in time before any other manipulation occurs)


### PR DESCRIPTION
### Purpose
Avoid marking the graph with unsaved changes while in transient state.
Avoid requesting a graph run while in transient state.
The graph will be marked with unsaved changes only when confirming a cluster ( or a single node ) and a single run will be performed in both automatic and manual mode.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Reviewers
@DynamoDS/synapse 
