### PR TITLE
[DYN-8893] - Double click on group to add cbn

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -336,16 +336,16 @@ namespace Dynamo.Nodes
                 return;
 
             var clickPosition = e.GetPosition(workspace.WorkspaceElements);
-            var model = ViewModel.AnnotationModel;
+            var annotationModel = ViewModel.AnnotationModel;
 
             // Define the area below the text block where nodes reside
-            var annoRectArea = new Rect(model.X, model.Y + model.TextBlockHeight, model.Width, model.ModelAreaHeight);
+            var annoRectArea = new Rect(annotationModel.X, annotationModel.Y + annotationModel.TextBlockHeight, annotationModel.Width, annotationModel.ModelAreaHeight);
 
             // Only create CBN if click is in model area (not in the title/text area)
             if (!annoRectArea.Contains(clickPosition))
                 return;
 
-            workspace.ViewModel?.HandleAnnotationDoubleClick(clickPosition, model);
+            workspace.ViewModel?.HandleAnnotationDoubleClick(clickPosition, annotationModel);
             e.Handled = true;
         }
 

--- a/test/DynamoCoreWpfTests/AnnotationViewTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewTests.cs
@@ -154,5 +154,34 @@ namespace DynamoCoreWpfTests
             var finalNodeCount = group1.Nodes.Count();
             Assert.AreEqual(3, finalNodeCount, $"Expected the group to contain 3 nodes after adding the connector pin, but found {finalNodeCount}.");
         }
+
+        [Test]
+        public void DoubleClickOnGroupAddsCodeBlockNode()
+        {
+            // Arrange
+            Open(@"core\annotationViewModelTests\groupsTestFile.dyn");
+
+            var groupGuid = new Guid("8324afb7-2d77-4a75-aa5e-f10e59964c2b");
+
+            // Act
+            var ws = this.Model.CurrentWorkspace;
+            var group1 = ws.Annotations.FirstOrDefault(annotation => annotation.GUID == groupGuid);
+
+            // Verify the initial node count in the group
+            var initialNodeCount = group1.Nodes.Count();
+            Assert.AreEqual(2, initialNodeCount, "Expected group to have 2 nodes initially");
+
+            var workspaceView = View.WorkspaceTabs.ChildrenOfType<WorkspaceView>().First();
+            var workspaceViewModel = workspaceView.ViewModel;
+
+            // This is the click position within the group's model area.
+            var clickPosition = new Point(group1.X + 1, group1.Y + group1.TextBlockHeight + 1);
+
+            // Act: Simulate double-click
+            workspaceViewModel.HandleAnnotationDoubleClick(clickPosition, group1);
+
+            // Assert
+            Assert.AreEqual(3, group1.Nodes.Count(), "Expected group to have 3 nodes after double click.");
+        }
     }
 }


### PR DESCRIPTION
### Purpose

Small PR related to [DYN-8893](https://jira.autodesk.com/browse/DYN-8893) and this [tread](https://autodesk.slack.com/archives/C08AMP1A7AB/p1752512417624679).

This PR restores the changes to AnnotationView.xaml.cs that allow double-clicking on a group to add a CodeBlockNode to it. These changes were previously submitted in #16334 but are not present in the current master branch.

![DYN-8893-New](https://github.com/user-attachments/assets/e2d6d95b-7b5c-4e67-8a1a-325da9c4cc56)


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

Double-clicking on a group adds a code block node to it.

### Reviewers

@DynamoDS/eidos
@jasonstratton
@zeusongit 

### FYIs

@dnenov
@achintyabhat
