### PR TITLE
DYN-9170 : close node autocomplete when certain commands are started

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -24,6 +24,8 @@ namespace Dynamo.Models
         internal event RecordableCommandHandler CommandStarting;
         internal event RecordableCommandHandler CommandCompleted;
 
+        static internal event Action RequestHideNodeAutoCompleteBar;
+
         /// <summary>
         /// Executes specified command
         /// </summary>
@@ -88,6 +90,8 @@ namespace Dynamo.Models
 
         private void CreateNodeImpl(CreateNodeCommand command)
         {
+            RequestHideNodeAutoCompleteBar?.Invoke();
+
             var node = GetNodeFromCommand(command);
             if (node == null)
             {
@@ -324,6 +328,8 @@ namespace Dynamo.Models
 
         private void MakeConnectionImpl(MakeConnectionCommand command)
         {
+            RequestHideNodeAutoCompleteBar?.Invoke();
+
             Guid nodeId = command.ModelGuid;
 
             switch (command.ConnectionMode)
@@ -573,6 +579,8 @@ namespace Dynamo.Models
 
         private void DeleteModelImpl(DeleteModelCommand command)
         {
+            RequestHideNodeAutoCompleteBar?.Invoke();
+
             var modelsToDelete = new List<ModelBase>();
             if (command.ModelGuid == Guid.Empty)
             {

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -145,10 +145,13 @@ namespace Dynamo.UI.Controls
         //Hide the window and unsubscribe from model events.
         //Note that the window is not destroyed, it is just hidden so that it can be reused.
         internal void OnHideNodeAutoCompleteSearch()
-        {            
-            ViewModel.ParentNodeRemoved -= OnParentNodeRemoved;
-            ViewModel.OnNodeAutoCompleteWindowClosed();
-            Hide();
+        {
+            if (IsVisible) //when window is already hidden it means unsubscribe was already performed
+            {
+                ViewModel.ParentNodeRemoved -= OnParentNodeRemoved;
+                ViewModel.OnNodeAutoCompleteWindowClosed();
+                Hide();
+            }
         }
 
         internal void OnShowNodeAutoCompleteSearch()

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -67,7 +67,7 @@ namespace Dynamo.Views
         private Point inCanvasSearchPosition;
         private List<DependencyObject> hitResultsList = new List<DependencyObject>();
 
-        static internal event Action<Window, ViewModelBase> RequesNodeAutoCompleteBar;
+        static internal event Action<Window, ViewModelBase> RequestShowNodeAutoCompleteBar;
         private double currentRenderScale = -1;
 
         public WorkspaceViewModel ViewModel
@@ -210,7 +210,7 @@ namespace Dynamo.Views
 
         private void ShowNodeAutoCompleteBar(PortViewModel viewModel)
         {
-            RequesNodeAutoCompleteBar?.Invoke(Window.GetWindow(this), viewModel);
+            RequestShowNodeAutoCompleteBar?.Invoke(Window.GetWindow(this), viewModel);
         }
 
         private void ShowHidePortContextMenu(ShowHideFlags flag, PortViewModel portViewModel)

--- a/src/NodeAutoCompleteViewExtension/NodeAutoCompleteViewExtension.cs
+++ b/src/NodeAutoCompleteViewExtension/NodeAutoCompleteViewExtension.cs
@@ -80,7 +80,7 @@ namespace Dynamo.NodeAutoComplete
 
         public override void Shutdown()
         {
-            WorkspaceView.RequesNodeAutoCompleteBar -= OnNodeAutoCompleteBarRequested;
+            WorkspaceView.RequestShowNodeAutoCompleteBar -= OnShowNodeAutoCompleteBarRequested;
         }
 
         public override void Startup(ViewStartupParams viewStartupParams)
@@ -147,7 +147,7 @@ namespace Dynamo.NodeAutoComplete
 #endif
             }
 
-            WorkspaceView.RequesNodeAutoCompleteBar += OnNodeAutoCompleteBarRequested;
+            WorkspaceView.RequestShowNodeAutoCompleteBar += OnShowNodeAutoCompleteBarRequested;
 
         }
 
@@ -169,7 +169,7 @@ namespace Dynamo.NodeAutoComplete
         private static NodeAutoCompleteBarViewModel nodeAutoCompleteBarViewModel;
         private static Guid lastWorkspaceId;
 
-        private void OnNodeAutoCompleteBarRequested(Window parentWindow, ViewModelBase viewModelBase)
+        private void OnShowNodeAutoCompleteBarRequested(Window parentWindow, ViewModelBase viewModelBase)
         {
             PortViewModel portViewModel = viewModelBase as PortViewModel;
             if (parentWindow is null || portViewModel is null)

--- a/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml.cs
+++ b/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml.cs
@@ -9,6 +9,7 @@ using Dynamo.Logging;
 using Dynamo.Models;
 using Dynamo.NodeAutoComplete.ViewModels;
 using Dynamo.ViewModels;
+using Dynamo.Views;
 
 namespace Dynamo.NodeAutoComplete.Views
 {
@@ -146,6 +147,7 @@ namespace Dynamo.NodeAutoComplete.Views
             ViewModel.ParentNodeRemoved += OnParentNodeRemoved;
             ViewModel.RefocusSearchBox += OnRefocusSearchbox;
             Owner.LocationChanged += OwnerMoved;
+            DynamoModel.RequestHideNodeAutoCompleteBar += OnHideNodeAutoCompleteBarAction;
             if (ViewModel.PortViewModel != null)
             {
                 ViewModel.PortViewModel.PortModel.Owner.PropertyChanged += Owner_PropertyChanged;
@@ -159,6 +161,7 @@ namespace Dynamo.NodeAutoComplete.Views
             ViewModel.ParentNodeRemoved -= OnParentNodeRemoved;
             ViewModel.RefocusSearchBox -= OnRefocusSearchbox;
             Owner.LocationChanged -= OwnerMoved;
+            DynamoModel.RequestHideNodeAutoCompleteBar -= OnHideNodeAutoCompleteBarAction;
             if (ViewModel.PortViewModel != null)
             {
                 ViewModel.PortViewModel.PortModel.Owner.PropertyChanged -= Owner_PropertyChanged;
@@ -176,6 +179,11 @@ namespace Dynamo.NodeAutoComplete.Views
                     Dispatcher.BeginInvoke(UpdatePosition, DispatcherPriority.Loaded);
                     break;
             }
+        }
+
+        private void OnHideNodeAutoCompleteBarAction()
+        {
+            OnHideNodeAutoCompleteBar();
         }
 
         //Hide the window and unsubscribe from model events.


### PR DESCRIPTION
### Purpose
We want to close the node autocomplete bar if it is visible when other commands are invoked.
Currently we do this if the user wants to create a node, connect a node or delete node(s).
Moving forward we can add other commands as well.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes
Hide autocomplete marker on far zoom out

### Reviewers
@DynamoDS/synapse 
