### PR TITLE
DYN-8893: Connectors between collapsed groups to remain visible

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -390,8 +390,7 @@ namespace Dynamo.ViewModels
 
             //reduce ZIndex if one of associated nodes is collapsed
             bool oneNodeInCollapsedGroup = OneConnectingNodeInCollapsedGroup(firstNode, lastNode);
-            bool bothNodesInCollapsedGroup = ConnectingNodesBothInCollapsedGroup(firstNode, lastNode);
-            if (oneNodeInCollapsedGroup && !bothNodesInCollapsedGroup)
+            if (oneNodeInCollapsedGroup)
             {
                 var lowestIndex = new int[] { this.Nodevm.ZIndex, this.NodeEnd.ZIndex }
                 .OrderBy(x => x)
@@ -410,11 +409,6 @@ namespace Dynamo.ViewModels
         {
             if (firstNode == null || lastNode == null) return false;
             return firstNode.IsNodeInCollapsedGroup || lastNode.IsNodeInCollapsedGroup;
-        }
-        private bool ConnectingNodesBothInCollapsedGroup(NodeViewModel firstNode, NodeViewModel lastNode)
-        {
-            if (firstNode == null || lastNode == null) return false;
-            return firstNode.IsNodeInCollapsedGroup && lastNode.IsNodeInCollapsedGroup;
         }
 
         /// <summary>
@@ -1514,7 +1508,11 @@ namespace Dynamo.ViewModels
         /// </summary>
         private void SetCollapsedByNodeViewModel()
         {
-            if (Nodevm?.IsCollapsed == true && NodeEnd?.IsCollapsed == true)
+            // Check if the connector is between two proxy ports. 
+            // Connectors between proxy ports should not be collapsed.
+            bool bothEndsAreProxyPorts = ConnectorModel.Start.IsProxyPort && ConnectorModel.End.IsProxyPort;
+
+            if (Nodevm?.IsCollapsed == true && NodeEnd?.IsCollapsed == true && !bothEndsAreProxyPorts)
             {
                 IsCollapsed = true;
             }


### PR DESCRIPTION
### Purpose

PR in response to this [Slack thread](https://autodesk.slack.com/archives/C08AMP1A7AB/p1752512417624679) and related to [DYN-8893](https://jira.autodesk.com/browse/DYN-8893).

Updates to ConnectorViewModel.cs make sure  that connectors between two collapsed groups remain visible and render correctly under their  proxy ports.
- Updated SetCollapsedByNodeViewModel() to explicitly check if both the start and end ports are proxy ports. If so, the connector is no longer collapsed in this case.
- Removed the unused ConnectingNodesBothInCollapsedGroup() method from SetZIndex() as it was redundant. Even when a connector links nodes inside two collapsed groups, its ZIndex still needs to be 1 to ensure it does not render on top of the proxy ports.

Before:

![DYN-ConnectorsBetweenCollapsedGroups_Before](https://github.com/user-attachments/assets/f7984496-95f6-4cb2-820e-f789a96abcd7)

After:

![DYN-ConnectorsBetweenCollapsedGroups_After](https://github.com/user-attachments/assets/50119b1c-df03-4fc7-862a-074a71f8da3f)


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

Updates to make sure  that connectors between two collapsed groups remain visible and render correctly under their  proxy ports.

### Reviewers

@DynamoDS/eidos
@jasonstratton

### FYIs

@dnenov
@achintyabhat
@zeusongit 
