### PR TITLE
[DYN-9082] All Python Engines should be loaded correctly in D4R

### DIFF
--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -23,7 +23,7 @@ namespace Dynamo.PackageManager
         //TODO should we add a new handler specifically for packages? this is the package manager afterall so maybe not.
         private event Func<string, PackageInfo, IEnumerable<CustomNodeInfo>> RequestLoadCustomNodeDirectoryHandler;
         private Action<IEnumerable<Assembly>> LoadPackagesHandler;
-       
+
         public event Func<string, IExtension> RequestLoadExtension;
         public event Action<IExtension> RequestAddExtension;
         public event Action<ILogMessage> MessageLogged;
@@ -148,6 +148,13 @@ namespace Dynamo.PackageManager
             PackageLoader.PackagesLoaded += LoadPackagesHandler;
             PackageLoader.RequestLoadNodeLibrary += RequestLoadNodeLibraryHandler;
             PackageLoader.RequestLoadCustomNodeDirectory += RequestLoadCustomNodeDirectoryHandler;
+
+            if (PythonServices.PythonEngineManager.Instance.AvailableEngines.Count == 0)
+            {
+                PythonServices.PythonEngineManager.Instance.LoadDefaultPythonEngine(AppDomain.CurrentDomain.GetAssemblies().
+                                                                                    FirstOrDefault(a => a != null && a.GetName().Name == PythonServices.PythonEngineManager.CPythonAssemblyName));
+            }
+
             PythonServices.PythonEngineManager.Instance.AvailableEngines.CollectionChanged += PythonEngineAdded;
                 
             var dirBuilder = new PackageDirectoryBuilder(
@@ -236,6 +243,7 @@ namespace Dynamo.PackageManager
 
         public void Shutdown()
         {
+            PythonServices.PythonEngineManager.Instance.AvailableEngines.Clear();
             PythonServices.PythonEngineManager.Instance.AvailableEngines.CollectionChanged -= PythonEngineAdded;
             //this.Dispose();
         }

--- a/src/NodeServices/PythonServices.cs
+++ b/src/NodeServices/PythonServices.cs
@@ -192,7 +192,7 @@ namespace Dynamo.PythonServices
             AppDomain.CurrentDomain.AssemblyLoad += new AssemblyLoadEventHandler((object sender, AssemblyLoadEventArgs args) => LoadDefaultPythonEngine(args.LoadedAssembly));
         }
 
-        private void LoadDefaultPythonEngine(Assembly a)
+        internal void LoadDefaultPythonEngine(Assembly a)
         {
             if (a == null ||
                 a.GetName().Name != CPythonAssemblyName)


### PR DESCRIPTION
### Purpose

When Dynamo is closed and reopened in D4R, the AvailableEngines collection under PythonEngineManager is not changed so the PythonEngineAdded is never triggered when Dynamo is reopened. This has caused this bug https://jira.autodesk.com/browse/DYN-9082.

So now, when Dynamo is closed, we clear the AvailableEngines collection and add the default python engine back when it s started back. The rest of the python engines, if any, will be loaded from the packages extension.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes
[DYN-9082] All Python Engines should be loaded correctly in D4R

### Reviewers
@DynamoDS/eidos 

