### PR TITLE
DYN-9191: RecentFiles bug fix

### DIFF
--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -419,7 +419,11 @@ namespace Dynamo.UI.Controls
             }
             else if (e.Action == NotifyCollectionChangedAction.Remove)
             {
-                recentFiles.RemoveRange(e.OldStartingIndex, recentFiles.Count - e.OldStartingIndex);
+                var removedItemsCount = e.OldItems?.Count ?? 0;
+                if (recentFiles.Count > e.OldStartingIndex && recentFiles.Count >= removedItemsCount)
+                {
+                    recentFiles.RemoveRange(e.OldStartingIndex, removedItemsCount);
+                }
             }
             else
             {

--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -424,6 +424,10 @@ namespace Dynamo.UI.Controls
                 {
                     recentFiles.RemoveRange(e.OldStartingIndex, removedItemsCount);
                 }
+                else
+                {
+                    RefreshRecentFileList(sender as IEnumerable<string>, true);
+                }
             }
             else
             {


### PR DESCRIPTION
### Purpose

When changing recent files cache, in case when max recent files has been reached, removing the last item from the collection would throw an error, if invalid paths exist.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

Adds logic to refresh the recent file list when removed items are not contiguous, ensuring the UI stays in sync with the underlying data.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
