### PR TITLE
DYN-9011: Use custom node cache on the basis of service mode being false

### DIFF
--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -194,8 +194,7 @@ namespace Dynamo.Applications
             bool cliMode = true,
             string userDataFolder = "",
             string commonDataFolder = "",
-            bool serviceMode = false,
-            bool useCustomNodeCache = false)
+            bool serviceMode = false)
         {
             var normalizedCLILocale = string.IsNullOrEmpty(cliLocale) ? null : cliLocale;
             IPathResolver pathResolver = CreatePathResolver(false, string.Empty, string.Empty, string.Empty);
@@ -215,8 +214,7 @@ namespace Dynamo.Applications
                 noNetworkMode: noNetworkMode,
                 info: analyticsInfo,
                 isServiceMode: serviceMode,
-                cliLocale: normalizedCLILocale,
-                useCustomNodeCache
+                cliLocale: normalizedCLILocale
             );
             model.IsASMLoaded = isASMloaded;
             return model;
@@ -299,22 +297,6 @@ namespace Dynamo.Applications
             return model;
         }
 
-        internal static DynamoModel MakeModel(bool CLImode, string CLIlocale, bool noNetworkMode, bool useCustomNodeCache,
-            string asmPath = "", HostAnalyticsInfo info = new HostAnalyticsInfo())
-        {
-            var model = PrepareModel(
-                cliLocale: CLIlocale,
-                asmPath: asmPath,
-                noNetworkMode: noNetworkMode,
-                analyticsInfo: info,
-                cliMode: CLImode,
-                userDataFolder: "",
-                commonDataFolder: "",
-                serviceMode: false,
-                useCustomNodeCache);
-            return model;
-        }
-
         /// <summary>
         /// It returns an IPathResolver based on the mode and some locations
         /// </summary>
@@ -390,8 +372,7 @@ namespace Dynamo.Applications
             bool noNetworkMode,
             HostAnalyticsInfo info = new HostAnalyticsInfo(),
             bool isServiceMode = false,
-            string cliLocale = null,
-            bool useCustomNodeCache = false)
+            string cliLocale = null)
         {
 
             var config = new DynamoModel.DefaultStartConfiguration
@@ -406,8 +387,7 @@ namespace Dynamo.Applications
                 IsServiceMode = isServiceMode,
                 Preferences = PreferenceSettings.Instance,
                 NoNetworkMode = noNetworkMode,
-                CLILocale = cliLocale,
-                UseCustomNodeCache = useCustomNodeCache,
+                CLILocale = cliLocale
                 //Breaks all Lucene calls. TI enable this would require a lot of refactoring around Lucene usage in Dynamo.
                 //IsHeadless = CLImode
             };

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -599,12 +599,6 @@ namespace Dynamo.Models
             /// </summary>
             public bool CLIMode { get; set; }
             public string CLILocale { get; set; }
-
-            /// <summary>
-            /// If true, a custom node cache stores custom node info objects
-            /// in a dictionary, so they don't have to be reloaded from the DYF.
-            /// </summary>
-            internal bool UseCustomNodeCache { get; set; }
         }
 
         /// <summary>
@@ -644,7 +638,6 @@ namespace Dynamo.Models
         {
             DynamoModel.IsCrashing = false;
 
-            bool useCustomNodeCache = false;
             if (config is DefaultStartConfiguration defaultStartConfig)
             {
                 // This is not exposed in IStartConfiguration to avoid a breaking change.
@@ -653,7 +646,6 @@ namespace Dynamo.Models
                 CLIMode = defaultStartConfig.CLIMode;
                 IsServiceMode = defaultStartConfig.IsServiceMode;
                 CLILocale = defaultStartConfig.CLILocale;
-                useCustomNodeCache = defaultStartConfig.UseCustomNodeCache;
             }
 
             if (config is IStartConfigCrashReporter cerConfig)
@@ -924,7 +916,7 @@ namespace Dynamo.Models
             LibraryServices.MessageLogged += LogMessage;
             LibraryServices.LibraryLoaded += LibraryLoaded;
 
-            CustomNodeManager = new CustomNodeManager(NodeFactory, MigrationManager, LibraryServices, useCustomNodeCache);
+            CustomNodeManager = new CustomNodeManager(NodeFactory, MigrationManager, LibraryServices, !IsServiceMode);
 
             LuceneSearch.LuceneUtilityNodeSearch = new LuceneSearchUtility(this, LuceneSearchUtility.DefaultNodeIndexStartConfig);
 

--- a/src/DynamoSandbox/DynamoCoreSetup.cs
+++ b/src/DynamoSandbox/DynamoCoreSetup.cs
@@ -142,7 +142,7 @@ namespace DynamoSandbox
         private void LoadDynamoView()
         {
             DynamoModel model;
-            model = StartupUtils.MakeModel(false, CLILocale, noNetworkMode, useCustomNodeCache: true, ASMPath ?? string.Empty, analyticsInfo);
+            model = StartupUtils.MakeModel(false, CLILocale, noNetworkMode, ASMPath ?? string.Empty, analyticsInfo);
             model.CERLocation = CERLocation;
 
             viewModel = DynamoViewModel.Start(


### PR DESCRIPTION
### Purpose

Use custom node cache on the basis of service mode being false.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**


### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
