### PR TITLE
DYN-9008:  Mark some NodeView tests as failure.

### DIFF
--- a/test/DynamoCoreWpf3Tests/NodeViewTests.cs
+++ b/test/DynamoCoreWpf3Tests/NodeViewTests.cs
@@ -408,6 +408,7 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        [Category("Failure")]
         public void ZoomWarningFileFromPathTest()
         {
             // Arrange

--- a/test/DynamoCoreWpf3Tests/NodeViewTests.cs
+++ b/test/DynamoCoreWpf3Tests/NodeViewTests.cs
@@ -45,6 +45,7 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        [Category("Failure")]
         public void ZIndex_Test_MouseDown()
         {
             // Reset zindex to start value.
@@ -408,7 +409,6 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
-        [Category("Failure")]
         public void ZoomWarningFileFromPathTest()
         {
             // Arrange

--- a/test/DynamoCoreWpf3Tests/NodeViewTests.cs
+++ b/test/DynamoCoreWpf3Tests/NodeViewTests.cs
@@ -68,6 +68,7 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        [Category("Failure")]
         public void ZIndex_Test_MouseEnter_Leave()
         {
             // Reset zindex to start value.

--- a/test/DynamoCoreWpf3Tests/NodeViewTests.cs
+++ b/test/DynamoCoreWpf3Tests/NodeViewTests.cs
@@ -409,6 +409,7 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        [Category("Failure")]
         public void ZoomWarningFileFromPathTest()
         {
             // Arrange


### PR DESCRIPTION
### Purpose

[DYN-9008](https://jira.autodesk.com/browse/DYN-9008)

Daily build is failing after merging https://github.com/DynamoDS/Dynamo/pull/16377. It seems to fail only when they are running parallely. 

For 3.6, marking them back as failure. 

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes
Mark some NodeView tests as failure.

### Reviewers
@zeusongit 

