### PR TITLE
make it possible to override dynamo logger. DYN-9117

### DIFF
--- a/src/DynamoCore/Logging/DynamoLogger.cs
+++ b/src/DynamoCore/Logging/DynamoLogger.cs
@@ -34,7 +34,6 @@ namespace Dynamo.Logging
         /// The message to be logged.
         /// </summary>
         public string Message { get; set; }
-    
         /// <summary>
         /// The log level at which to log the message.
         /// </summary>
@@ -123,7 +122,7 @@ namespace Dynamo.Logging
         /// <summary>
         /// Returns full path to log file
         /// </summary>
-        public string LogPath 
+        public string LogPath
         {
             get { return _logPath; }
         }
@@ -205,11 +204,11 @@ namespace Dynamo.Logging
         /// <param name="message"></param>
         /// <param name="level"></param>
         /// <param name="reportModification"></param>
-        private void Log(string message, LogLevel level, bool reportModification)
+        protected virtual void Log(string message, LogLevel level, bool reportModification)
         {
             lock (this.guardMutex)
             {
-                // In test mode or service mode, write the logs only to std out. 
+                // In test mode or service mode, write the logs only to std out.
                 if ((testMode && !cliMode) || serviceMode)
                 {
                     Console.WriteLine(string.Format("{0} : {1}", DateTime.UtcNow.ToString("u"), message));
@@ -412,7 +411,7 @@ namespace Dynamo.Logging
         /// <summary>
         /// Begin logging.
         /// </summary>
-        private void StartLoggingToConsoleAndFile(string logDirectory)
+        protected void StartLoggingToConsoleAndFile(string logDirectory)
         {
             lock (this.guardMutex)
             {
@@ -471,7 +470,7 @@ namespace Dynamo.Logging
         /// <summary>
         /// Disposes the logger and finishes logging.
         /// </summary>
-        public void Dispose()
+        public virtual void Dispose()
         {
             Dispose(_isDisposed);
 

--- a/src/DynamoCore/Logging/DynamoLogger.cs
+++ b/src/DynamoCore/Logging/DynamoLogger.cs
@@ -411,7 +411,7 @@ namespace Dynamo.Logging
         /// <summary>
         /// Begin logging.
         /// </summary>
-        protected void StartLoggingToConsoleAndFile(string logDirectory)
+        protected virtual void StartLoggingToConsoleAndFile(string logDirectory)
         {
             lock (this.guardMutex)
             {

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -556,7 +556,7 @@ namespace Dynamo.Models
             public string CERLocation { get; set; }
         }
 
-        // Remove this interface in Dynamo3.0 and merge it back into IStartConfiguration.
+        // Remove this interface in Dynamo4.0 and merge it back into IStartConfiguration.
         /// <summary>
         /// Use this interface to set the CER (crash error reporting) tool path.
         /// </summary>
@@ -568,8 +568,16 @@ namespace Dynamo.Models
             CrashReporterStartupOptions CRStartConfig { get; set; }
         }
 
+        //TODO remove in dynamo 4.0
+        /// <summary>
+        /// Provides a mechanism to configure logging for DynamoModel.
+        /// Implement this interface to supply a logger instance for capturing logs during initialization and runtime.
+        /// </summary>
         public interface IStartConfigurationLogger
         {
+            /// <summary>
+            /// Specify the logger instance.
+            /// </summary>
             DynamoLogger Logger { get; set; }
         }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -680,7 +680,7 @@ namespace Dynamo.Models
             HostAnalyticsInfo = config.HostAnalyticsInfo;
 
             DebugSettings = new DebugSettings();
-            if(Logger == null)
+            if (Logger == null)
             {
                 // If logger is not provided, create a new one.
                 Logger = new DynamoLogger(DebugSettings, pathManager.LogDirectory, IsTestMode, CLIMode, IsServiceMode);

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -605,6 +605,11 @@ namespace Dynamo.Models
             /// </summary>
             public bool CLIMode { get; set; }
             public string CLILocale { get; set; }
+            /// <summary>
+            /// Gets or sets the logger instance used for logging messages and events.
+            /// This property should be set to a valid <see cref="DynamoLogger"/> instance
+            /// to enable logging during the initialization and runtime of Dynamo.
+            /// </summary>
             public DynamoLogger Logger { get; set; }
         }
 

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -1683,7 +1683,6 @@ Dynamo.Linting.Rules.NodeLinterRule
 Dynamo.Linting.Rules.NodeLinterRule.NodeLinterRule() -> void
 Dynamo.Logging.DynamoLogger
 Dynamo.Logging.DynamoLogger.ClearStartupNotifications() -> void
-Dynamo.Logging.DynamoLogger.Dispose() -> void
 Dynamo.Logging.DynamoLogger.DynamoLogger(Dynamo.Configuration.DebugSettings debugSettings, string logDirectory, bool isTestMode, bool isCLIMode, bool isServiceMode) -> void
 Dynamo.Logging.DynamoLogger.Log(string message) -> void
 Dynamo.Logging.DynamoLogger.Log(string message, Dynamo.Logging.LogLevel level) -> void
@@ -1877,6 +1876,7 @@ Dynamo.Models.DynamoModel.DefaultStartConfiguration.IsHeadless.get -> bool
 Dynamo.Models.DynamoModel.DefaultStartConfiguration.IsHeadless.set -> void
 Dynamo.Models.DynamoModel.DefaultStartConfiguration.IsServiceMode.get -> bool
 Dynamo.Models.DynamoModel.DefaultStartConfiguration.IsServiceMode.set -> void
+Dynamo.Models.DynamoModel.DefaultStartConfiguration.Logger.set -> void
 Dynamo.Models.DynamoModel.DefaultStartConfiguration.NoNetworkMode.get -> bool
 Dynamo.Models.DynamoModel.DefaultStartConfiguration.NoNetworkMode.set -> void
 Dynamo.Models.DynamoModel.DefaultStartConfiguration.PathResolver.get -> Dynamo.Interfaces.IPathResolver
@@ -3160,6 +3160,7 @@ virtual Dynamo.Graph.Workspaces.WorkspaceModel.RegisterNode(Dynamo.Graph.Nodes.N
 virtual Dynamo.Graph.Workspaces.WorkspaceModel.ResetWorkspaceCore() -> void
 virtual Dynamo.Graph.Workspaces.WorkspaceModel.Save(string filePath, bool isBackup = false, Dynamo.Engine.EngineController engine = null) -> void
 virtual Dynamo.Linting.Rules.LinterRule.CleanupRule(Dynamo.Graph.Workspaces.WorkspaceModel muribundWorkspaceModel) -> void
+virtual Dynamo.Logging.DynamoLogger.Dispose() -> void
 virtual Dynamo.Models.DynamoModel.InsertFileImpl(Dynamo.Models.DynamoModel.InsertFileCommand command) -> void
 virtual Dynamo.Models.DynamoModel.OnCleanup() -> void
 virtual Dynamo.Models.DynamoModel.OnDeletionComplete(object sender, System.EventArgs e) -> void
@@ -3192,5 +3193,4 @@ virtual Dynamo.Search.SearchElements.NodeSearchElement.GenerateInputParameters()
 virtual Dynamo.Search.SearchElements.NodeSearchElement.GenerateOutputParameters() -> System.Collections.Generic.IEnumerable<string>
 virtual Dynamo.Search.SearchElements.NodeSearchElement.OnItemProduced(Dynamo.Graph.Nodes.NodeModel obj) -> void
 virtual Dynamo.Search.SearchElements.SearchElementBase.CreationName.get -> string
-
-
+virtual Dynamo.Search.SearchElements.SearchElementBase.CreationName.get -> string


### PR DESCRIPTION
### Purpose

In daas we want to have different logging behavior and inject a customer logger at startup.
* make some members of DynamoLogger protected.
* add a Logger property to the DefaultStartupConfig and add a new interface for startup configs that set a logger.

whitespace changes are unintentional... this PR was created in vs code - I do have editorconfig extension present there - was this file just missing the correct formatting?

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

makes it possible for dynamo integrators to override the logger.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
