### PR TITLE
DYN-9210 : fix crash due to invalid transient nodes

### DIFF
--- a/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
+++ b/src/NodeAutoCompleteViewExtension/ViewModels/NodeAutoCompleteBarViewModel.cs
@@ -24,6 +24,7 @@ using Dynamo.PackageManager;
 using Dynamo.Properties;
 using Dynamo.Search;
 using Dynamo.Search.SearchElements;
+using Dynamo.Selection;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Utilities;
@@ -832,6 +833,7 @@ namespace Dynamo.NodeAutoComplete.ViewModels
             {
                 foreach (var transientNode in transientNodes)
                 {
+                    DynamoSelection.Instance?.Selection?.Remove(transientNode.NodeModel);
                     wsViewModel.Model.RemoveAndDisposeNode(transientNode.NodeModel);
                 }
             }


### PR DESCRIPTION
### Purpose
Fix crash contexts due to invalid transient nodes that remain in the selection.
While iterating through transient dna options we remove the nodes but we do not remove them from the selection.
This causes issues with certain commands that rely on/iterate through the selection later on.
One such command is AddModelToGroup but most likely there are other contexts as well ( essentially any code that for some reasons iterates though selection ).


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes
Remove transient nodes from the selection when they are delete in order to avoid issues later on.

### Reviewers
@DynamoDS/synapse 

