### PR TITLE
DYN-8894- Collapsed group fixed after moving all view logic to code-behind

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -1590,8 +1590,6 @@ namespace Dynamo.Nodes
             };
 
             // Set bindings
-            border.SetBinding(FrameworkElement.WidthProperty, new Binding("Width"));
-            border.SetBinding(FrameworkElement.HeightProperty, new Binding("ModelAreaHeight"));
             border.SetBinding(UIElement.VisibilityProperty, new Binding("IsExpanded")
             {
                 ElementName = "GroupExpander",


### PR DESCRIPTION
### Purpose

This PR is in response to this [Slack thread](https://autodesk.slack.com/archives/CPJ5UQW0Z/p1753133063702839)

Collapsed group width and height fixed after moving all view logic to code-behind.

![2025-07-2211-27-57-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/cf88ea8f-02e2-4165-a8c6-c7c6aafaa71e)


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

Collapsed group width and height fixed after moving all view logic to code-behind.

### Reviewers

@zeusongit 

### FYIs

@dnenov 
