### PR TITLE
DYN-8940 : switch node autocomplete endpoints to production

### DIFF
--- a/src/DynamoCoreWpf/App.config
+++ b/src/DynamoCoreWpf/App.config
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <configuration>
   <appSettings>
-    <add key="MLNodeAutocomplete" value="https://dev.autocomplete.dynamobim.org/autocomplete"/>
-    <add key="MLNodeClusterAutocomplete" value="https://dev.autocomplete.dynamobim.org/autocompleteclusters"/>
+    <add key="MLNodeAutocomplete" value="https://autocomplete.dynamobim.org/autocomplete"/>
+    <add key="MLNodeClusterAutocomplete" value="https://autocomplete.dynamobim.org/autocompleteclusters"/>
     <add key="VideoSettings" value="[
   {
     &quot;id&quot;: &quot;1&quot;,


### PR DESCRIPTION
### Purpose
Switch node autocomplete endpoints to production.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes
Switch node autocomplete endpoints to production.

### Reviewers
@DynamoDS/synapse 