### PR TITLE
DYN-9239 - Allow DynamoCore Internals Visible to MCP View Extension & MCP Extension

### DIFF
--- a/src/DynamoCore/Properties/AssemblyInfo.cs
+++ b/src/DynamoCore/Properties/AssemblyInfo.cs
@@ -58,6 +58,8 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("DocumentationBrowserViewExtension")]
 [assembly: InternalsVisibleTo("Notifications")]
 [assembly: InternalsVisibleTo("NodeAutoCompleteViewExtension")]
+[assembly: InternalsVisibleTo("MCPExtension")]
+[assembly: InternalsVisibleTo("MCPViewExtension")]
 
 // Disable PublicAPIAnalyzer errors for this type as they're already added to the public API text file
 #pragma warning disable RS0016 

--- a/src/DynamoCore/Properties/AssemblyInfo.cs
+++ b/src/DynamoCore/Properties/AssemblyInfo.cs
@@ -58,6 +58,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("DocumentationBrowserViewExtension")]
 [assembly: InternalsVisibleTo("Notifications")]
 [assembly: InternalsVisibleTo("NodeAutoCompleteViewExtension")]
+// Internals are visible to the MCP View Extension and Extension, depending on final implementation.
 [assembly: InternalsVisibleTo("MCPExtension")]
 [assembly: InternalsVisibleTo("MCPViewExtension")]
 


### PR DESCRIPTION
### Purpose

With MCP server work, it is necessary to allow it to access internal methods. Especially with it being separate from the Dynamo core repo. This PR allows that for both extension and view extension.

Currently, the MCP server is a view extension, but that is subject to change.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

N/A

### Reviewers

@DynamoDS/eidos @DynamoDS/synapse 

### FYIs

@saintentropy 
