### PR TITLE
[DYN-9230] Bump dynamo major version check for PackageManager.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -950,7 +950,7 @@ namespace Dynamo.ViewModels
                     // also identify packages that have a dynamo engine version less than 3.x as a special case,
                     // as Dynamo 3.x uses .net8 and older versions used .net framework - these packages may not be compatible.
                     // This check will return empty if the current major version is not 3.
-                    var preDYN3Deps = newPackageHeaders.Where(dep => dynamoVersion.Major == 3 && Version.Parse(dep.engine_version).Major < dynamoVersion.Major);
+                    var preDYN3Deps = newPackageHeaders.Where(dep => dynamoVersion.Major == 4 && Version.Parse(dep.engine_version).Major < dynamoVersion.Major);
 
                     // If any of the required packages use a newer version of Dynamo, show a dialog to the user
                     // allowing them to cancel the package download

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -950,7 +950,7 @@ namespace Dynamo.ViewModels
                     // also identify packages that have a dynamo engine version less than 3.x as a special case,
                     // as Dynamo 3.x uses .net8 and older versions used .net framework - these packages may not be compatible.
                     // This check will return empty if the current major version is not 3.
-                    var preDYN3Deps = newPackageHeaders.Where(dep => dynamoVersion.Major == 4 && Version.Parse(dep.engine_version).Major < dynamoVersion.Major);
+                    var preDYN4Deps = newPackageHeaders.Where(dep => dynamoVersion.Major == 4 && Version.Parse(dep.engine_version).Major < dynamoVersion.Major);
 
                     // If any of the required packages use a newer version of Dynamo, show a dialog to the user
                     // allowing them to cancel the package download

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -971,7 +971,7 @@ namespace Dynamo.ViewModels
 
                     //if any of the required packages use a pre 3.x version of Dynamo, show a dialog to the user
                     //allowing them to cancel the package download
-                    if (preDYN3Deps.Any())
+                    if (preDYN4Deps.Any())
                     {
                         var res = MessageBoxService.Show(ViewModelOwner,
                         $"{string.Format(Resources.MessagePackageOlderDynamo, DynamoViewModel.BrandingResourceProvider.ProductName)} {Resources.MessagePackOlderDynamoLink}",

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -276,7 +276,7 @@ namespace Dynamo.PackageManager
                 Log($"Loaded Package {package.Name} {package.VersionName} from {package.RootDirectory}");
                 try
                 {
-                    if (dynamoVersion.Major == 3 && Version.Parse(package.EngineVersion).Major < 3)
+                    if (dynamoVersion.Major == 4 && Version.Parse(package.EngineVersion).Major < 3)
                     {
                         Log($@"{package.Name} {package.VersionName} has an engine version of {package.EngineVersion},
                         it may not be compatible with this version of Dynamo due to .NET runtime changes. ");


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-9230. 

Bumping up the dynamo major check version to 4. Should fix the PackageManagerShowsWarningWhenDownloadingLegacyPackage test.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes
[DYN-9230] Bump dynamo major version check for PackageManager.

### Reviewers
@DynamoDS/eidos 

