### PR TITLE
0000: DYN-9253: Enable snapping to proxy ports in collapsed groups

### DIFF
--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1790,6 +1790,8 @@ Dynamo.ViewModels.AnnotationViewModel.Nodes.get -> System.Collections.Generic.IE
 Dynamo.ViewModels.AnnotationViewModel.OutPorts.get -> System.Collections.ObjectModel.ObservableCollection<Dynamo.ViewModels.PortViewModel>
 Dynamo.ViewModels.AnnotationViewModel.PreviewState.get -> Dynamo.ViewModels.PreviewState
 Dynamo.ViewModels.AnnotationViewModel.RemoveGroupFromGroupCommand.get -> Dynamo.UI.Commands.DelegateCommand
+Dynamo.ViewModels.AnnotationViewModel.SnapInputEvent -> Dynamo.ViewModels.AnnotationViewModel.SnapInputEventHandler
+Dynamo.ViewModels.AnnotationViewModel.SnapInputEventHandler
 Dynamo.ViewModels.AnnotationViewModel.ToggleIsFrozenGroupCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.AnnotationViewModel.ToggleIsVisibleGroupCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.AnnotationViewModel.Top.get -> double

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -375,13 +375,11 @@ namespace Dynamo.ViewModels
                 zIndex = value;
                 RaisePropertyChanged(nameof(ZIndex));
             }
-         
         }
 
         private int SetZIndex()
         {
-            if (isConnecting)
-                return (int)zIndex;
+            if (isConnecting) return 0;
 
             var firstNode = this.Nodevm;
             var lastNode = this.NodeEnd;

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -943,6 +943,7 @@ namespace Dynamo.ViewModels
         {
             var viewModel = new AnnotationViewModel(this, annotation);
             Annotations.Add(viewModel);
+            viewModel.SnapInputEvent += nodeViewModel_SnapInputEvent;
         }
 
         private void Model_AnnotationRemoved(AnnotationModel annotation)


### PR DESCRIPTION
### Purpose

This PR addresses feedback from an Archilizer catchup meeting (no JIRA ticket as far as I know). Ensures that connectors can snap to proxy ports on collapsed groups, same as the behavior of node ports.

Changes:
- hooked up `SnapInputEvent` to proxy ports using `MouseEnter`, `MouseLeave`, and `MouseLeftButtonDown`.
- added helper methods to subscribe/unsubscribe from proxy port events when the group is collapsed/expanded.
- no changes to node snapping logic, just extended event handling to support proxy ports.
- temporarily lowered connector `ZIndex` during connection to prevent it from blocking port snapping.

![Snapping proxy ports](https://github.com/user-attachments/assets/721a3484-40d0-4bc5-a2fe-349b842405d9)


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

Allows connectors to snap to proxy ports on collapsed groups, same as the behavior of node ports.

### Reviewers

@DynamoDS/eidos
@jasonstratton

### FYIs

@dnenov 
@achintyabhat 
