### PR TITLE
DYN-9240: Deleting node from group leaves an invisible margin in the group

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/Charts/BarChartNodeModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/BarChartNodeModel.cs
@@ -328,6 +328,7 @@ namespace CoreNodeModelsWpf.Charts
             PortConnected -= BarChartNodeModel_PortConnected;
             PortDisconnected -= BarChartNodeModel_PortDisconnected;
             VMDataBridge.DataBridge.Instance.UnregisterCallback(GUID.ToString());
+            base.Dispose();
         }
 
         #endregion

--- a/src/Libraries/CoreNodeModelsWpf/Charts/BasicLineChartNodeModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/BasicLineChartNodeModel.cs
@@ -296,6 +296,7 @@ namespace CoreNodeModelsWpf.Charts
             PortConnected -= BasicLineChartNodeModel_PortConnected;
             PortDisconnected -= BasicLineChartNodeModel_PortDisconnected;
             VMDataBridge.DataBridge.Instance.UnregisterCallback(GUID.ToString());
+            base.Dispose();
         }
 
         #endregion

--- a/src/Libraries/CoreNodeModelsWpf/Charts/HeatSeriesNodeModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/HeatSeriesNodeModel.cs
@@ -320,6 +320,7 @@ namespace CoreNodeModelsWpf.Charts
             PortConnected -= HeatSeriesNodeModel_PortConnected;
             PortDisconnected -= HeatSeriesNodeModel_PortDisconnected;
             VMDataBridge.DataBridge.Instance.UnregisterCallback(GUID.ToString());
+            base.Dispose();
         }
 
         #endregion

--- a/src/Libraries/CoreNodeModelsWpf/Charts/PieChartNodeModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/PieChartNodeModel.cs
@@ -284,6 +284,7 @@ namespace CoreNodeModelsWpf.Charts
             PortConnected -= PieChartNodeModel_PortConnected;
             PortDisconnected -= PieChartNodeModel_PortDisconnected;
             VMDataBridge.DataBridge.Instance.UnregisterCallback(GUID.ToString());
+            base.Dispose();
         }
 
         #endregion

--- a/src/Libraries/CoreNodeModelsWpf/Charts/ScatterPlotNodeModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/ScatterPlotNodeModel.cs
@@ -332,6 +332,7 @@ namespace CoreNodeModelsWpf.Charts
             PortConnected -= ScatterPlotNodeModel_PortConnected;
             PortDisconnected -= ScatterPlotNodeModel_PortDisconnected;
             VMDataBridge.DataBridge.Instance.UnregisterCallback(GUID.ToString());
+            base.Dispose();
         }
 
         #endregion

--- a/src/Libraries/CoreNodeModelsWpf/Charts/XYLineChartNodeModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/XYLineChartNodeModel.cs
@@ -331,6 +331,7 @@ namespace CoreNodeModelsWpf.Charts
             PortConnected -= XYLineChartNodeModel_PortConnected;
             PortDisconnected -= XYLineChartNodeModel_PortDisconnected;
             VMDataBridge.DataBridge.Instance.UnregisterCallback(GUID.ToString());
+            base.Dispose();
         }
 
         #endregion


### PR DESCRIPTION
### Purpose

Fix for [DYN-9240](https://jira.autodesk.com/browse/DYN-9240)

This PR makes sure that chart nodes clean up properly when deleted. This prevents lingering layout margins in groups.
Adds `base.Dispose()` calls to the `Dispose()` methods of all chart nodes.

![DYN-9240-Fix](https://github.com/user-attachments/assets/bb88e6db-0bc8-41b0-9504-c44d7fb52c02)


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

Changes prevent lingering layout margins in groups.

### Reviewers

@DynamoDS/eidos
@zeusongit
@jasonstratton

### FYIs

@dnenov 
@achintyabhat 
