### PR TITLE
DYN-8055: Port contect menu centered

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -389,6 +389,10 @@ namespace Dynamo.ViewModels
 
         private CustomPopupPlacement[] PlacePortContextMenu(Size popupSize, Size targetSize, Point offset)
         {
+            // Offset to center the popup over the visible port
+            // Port visual is vertically centered inside a 34px InPorts control with 29px port height
+            const double portMarginOffset = 2.5;
+
             // The actual zoom here is confusing
             // What matters is the zoom factor measured from the scaled : unscaled node size
             var zoom = node.WorkspaceViewModel.Zoom;
@@ -411,14 +415,14 @@ namespace Dynamo.ViewModels
             // Calculate absolute popup halfheight to deduct from the overall y pos
             // Then add the header, port height and port index position
             var popupHeightOffset = - popupSize.Height * 0.5;
-            var headerHeightOffset = NodeModel.HeaderHeight * zoom;
-            var portHalfHeight = PortModel.Height * 0.5 * zoom;
-            var rowOffset = PortModel.Index * PortModel.Height * zoom;
-            var customNodeOffset = NodeModel.CustomNodeTopBorderHeight * zoom;
+            var headerHeightOffset = NodeModel.HeaderHeight;
+            var portHalfHeight = PortModel.Height * 0.5;
+            var rowOffset = PortModel.Index * PortModel.Height;
+            var customNodeOffset = NodeModel.CustomNodeTopBorderHeight;
 
             // popupSize.Height is already DPI-scaled (in screen pixels), so we do NOT apply dpiScale to it
             // All other layout values are in logical units and must be multiplied by dpiScale for correct placement
-            var y = popupHeightOffset + (headerHeightOffset + portHalfHeight + rowOffset + customNodeOffset) * dpiScale;
+            var y = popupHeightOffset + (headerHeightOffset + portHalfHeight + rowOffset + customNodeOffset + portMarginOffset) * zoom * dpiScale;
 
             var placement = new CustomPopupPlacement(new Point(x, y), PopupPrimaryAxis.None);
 


### PR DESCRIPTION
### Purpose

This PR addresses feedback in [DYN-8055](https://jira.autodesk.com/browse/DYN-8055). It refines the placement logic of the port context menu to visually center it over the port.

Changes:
- local const double `portMarginOffset = 2.5` . The offset accounts for the 2.5px padding above the 29px port background within the 34px `InPorts` control.

<img width="2539" height="1183" alt="Screenshot 2025-07-25 114335" src="https://github.com/user-attachments/assets/b7ff7b41-7f06-4909-83fa-2e27100c2faa" />

<img width="2019" height="604" alt="Screenshot 2025-07-25 114350" src="https://github.com/user-attachments/assets/cde54d16-c8f7-4a57-9466-6aa5c7e15307" />


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

Refines the placement of the port context menu to visually center it over the port.

### Reviewers

@DynamoDS/eidos
@jasonstratton
@zeusongit 

### FYIs

@dnenov
@achintyabhat
