### PR TITLE
DYN-9269: Cherry-pick - Fix CBN output port name for range vs sequence (#16446)

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CodeBlockUtils.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockUtils.cs
@@ -304,7 +304,9 @@ namespace Dynamo.Graph.Nodes
                 case ExprListNode:
                 case ArrayNode:
                     return "list";
-                case RangeExprNode:
+                case RangeExprNode ren:
+                    if (ren.HasRangeAmountOperator)
+                        return "sequence";
                     return "range";
                 case IdentifierNode idNode:
                     return idNode.Value;

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -1544,6 +1544,24 @@ var06 = g;
             }
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void TestOutportNameForRangeAndSequence()
+        {
+            var code =
+                @"0..10..#5;
+            0..10..1;
+            0..#4..1;
+            0..4..~2;";
+            var cbn = CreateCodeBlockNode();
+            UpdateCodeBlockNodeContent(cbn, code);
+
+            Assert.AreEqual("range", cbn.OutPorts[0].Name);
+            Assert.AreEqual("range", cbn.OutPorts[1].Name);
+            Assert.AreEqual("sequence", cbn.OutPorts[2].Name);
+            Assert.AreEqual("range", cbn.OutPorts[3].Name);
+        }
+
         #region CodeBlockUtils Specific Tests
         [Test]
         [Category("UnitTests")]


### PR DESCRIPTION
### Purpose

DYN-9269: Cherry-pick - Fix CBN output port name for range vs sequence (#16446)

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.


### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
