### PR TITLE
DYN-9348 Revit Package Path Fix

### DIFF
--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -441,7 +441,7 @@ namespace Dynamo.Core
 
             BuildHostDirectories(pathManagerParams.HostPath);
 
-            //In the case of Dynamo for Revit HostInfo.HostVersion will contain the DynamoRevit version so we will use this values for installing packages in the right location
+            //HostInfo.HostVersion contains the version (Major and Minor), we will use these values for installing Dynamo packages in the right location
             if (HostInfo.HostVersion != null)
             {
                 pathManagerParams.MajorFileVersion = HostInfo.HostVersion.Major;

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -117,6 +117,9 @@ namespace Dynamo.Models
     /// </summary>
     public static class HostInfo
     {
+        /// <summary>
+        /// This field will be used to contain the HostVersion which can be accessed from other places in the code.
+        /// </summary>
         public static Version HostVersion;
     }
 


### PR DESCRIPTION
### Purpose

Considering that we are using DynamoCore 3.6.0 and DynamoRevit 3.4.0, previously when installing a package in Dynamo for Revit was installing the package in the path created using DynamoCore version (e.g. C:\Users\user\AppData\Roaming\Dynamo\Dynamo Revit\3.6) but after this change now is using the DynamoRevit version path (e.g. C:\Users\user\AppData\Roaming\Dynamo\Dynamo Revit\3.4\packages).

**Note: This fix is only for Dynamo for Revit**

### Declarations

Check these if you believe they are true

- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

Changing the package path installation for Dynamo Revit to use the DynamoRevit version (instead of DynamoCore version)

### Reviewers

@QilongTang 

### FYIs

@zeusongit 
