### PR TITLE
DYN-8876 Make node context menu child of main dynamo window

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -2132,7 +2132,7 @@ namespace Dynamo.Controls
         /// A common method to handle the node Options Button being clicked and
         /// the user right-clicking on the node body to open its ContextMenu.
         /// </summary>
-            private void DisplayNodeContextMenu(object sender, RoutedEventArgs e)
+        private void DisplayNodeContextMenu(object sender, RoutedEventArgs e)
         {
             if (ViewModel?.NodeModel?.IsTransient is true ||
                 ViewModel?.NodeModel?.HasTransientConnections() is true)

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -2132,7 +2132,7 @@ namespace Dynamo.Controls
         /// A common method to handle the node Options Button being clicked and
         /// the user right-clicking on the node body to open its ContextMenu.
         /// </summary>
-        private void DisplayNodeContextMenu(object sender, RoutedEventArgs e)
+            private void DisplayNodeContextMenu(object sender, RoutedEventArgs e)
         {
             if (ViewModel?.NodeModel?.IsTransient is true ||
                 ViewModel?.NodeModel?.HasTransientConnections() is true)
@@ -2162,6 +2162,7 @@ namespace Dynamo.Controls
             grid.ContextMenu = MainContextMenu;
             grid.ContextMenu.Visibility = Visibility.Visible;
             MainContextMenu.DataContext = viewModel;
+            MainContextMenu.PlacementTarget = grid;
             MainContextMenu.Closed += MainContextMenu_OnClosed;
             MainContextMenu.IsOpen = true;
             e.Handled = true;


### PR DESCRIPTION
### Purpose
Context menu window becomes child of the main app window; accessibility tree reflects correct ownership.

<img width="1916" height="1078" alt="image" src="https://github.com/user-attachments/assets/a6f5a9ec-8e37-4dfa-8469-6b99503727c9" />


### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers

@avidit 

### FYIs

@QilongTang @zeusongit 
