### PR TITLE
DYN-9309 OpenTemplate WorkspaceName Fix

### DIFF
--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -3184,6 +3184,7 @@ Dynamo.ViewModels.WorkspaceViewModel.DynamoPreferences.get -> Dynamo.Models.Dyna
 Dynamo.ViewModels.WorkspaceViewModel.DynamoViewModel.get -> Dynamo.ViewModels.DynamoViewModel
 Dynamo.ViewModels.WorkspaceViewModel.Errors.get -> System.Collections.ObjectModel.ObservableCollection<Dynamo.ViewModels.InfoBubbleViewModel>
 Dynamo.ViewModels.WorkspaceViewModel.FileName.get -> string
+Dynamo.ViewModels.WorkspaceViewModel.IsTemplate.get -> bool
 Dynamo.ViewModels.WorkspaceViewModel.FindByIdCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.WorkspaceViewModel.FindNodesFromElements.get -> System.Action
 Dynamo.ViewModels.WorkspaceViewModel.FindNodesFromElements.set -> void

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -349,6 +349,12 @@ namespace Dynamo.ViewModels
         }
 
         [JsonIgnore]
+        public bool IsTemplate
+        {
+            get { return Model.IsTemplate; }
+        }
+
+        [JsonIgnore]
         public bool CanEditName
         {
             get { return Model != DynamoViewModel.HomeSpace; }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -1295,6 +1295,14 @@
                                                 </MultiDataTrigger>
                                                 <MultiDataTrigger>
                                                     <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}" Value="{x:Type workspaces:HomeWorkspaceModel}" />
+                                                        <Condition Binding="{Binding Path=IsTemplate}" Value="True" />
+                                                    </MultiDataTrigger.Conditions>
+                                                    <!--  The value of the unsaved Workspace tab text field  -->
+                                                    <Setter Property="Text" Value="Workspace" />
+                                                </MultiDataTrigger> 
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
                                                         <Condition Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}" Value="{x:Type workspaces:CustomNodeWorkspaceModel}" />
                                                         <Condition Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}" Value="Unsaved" />
                                                     </MultiDataTrigger.Conditions>


### PR DESCRIPTION
### Purpose

When opening a Template the workspace name was showing the FileName in the TabName so I had to do a fix so that when a template is opened we show the word "Workspace" in the TabName.

### Declarations

Check these if you believe they are true

- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

When opening a Template the workspace name was showing the FileName in the TabName so I had to do a fix so that when a template is opened we show the word "Workspace" in the TabName.

### Reviewers

@QilongTang @zeusongit 

### FYIs

