### PR TITLE
 DYN-9244 Moving Away ProgramData Fix

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1644,6 +1644,9 @@ namespace Dynamo.Models
         {
             if (!(preferences is IDisablePackageLoadingPreferences disablePrefs)) return false;
 
+            // Get ProgramData folder path (usually C:\ProgramData)
+            string programDataPath = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+
             var isACustomPackageDirectory = preferences.CustomPackageFolders.Where(x => packagesDirectory.StartsWith(x)).Any();
 
             return
@@ -1651,7 +1654,8 @@ namespace Dynamo.Models
             //and loading from there is disabled, don't scan the directory.
             (disablePrefs.DisableBuiltinPackages && packagesDirectory == Core.PathManager.BuiltinPackagesDirectory)
             //or if custom package directories are disabled, and this is a custom package directory, don't scan.
-            || (disablePrefs.DisableCustomPackageLocations && isACustomPackageDirectory);
+            || (disablePrefs.DisableCustomPackageLocations && isACustomPackageDirectory)
+            || packagesDirectory.IndexOf(programDataPath, StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         private void InitializeNodeLibrary()


### PR DESCRIPTION
### Purpose

If you previously used Dynamo 4.0.0 and now with the previous fix try to use it, you will see that is loading packages from C:\ProgramData\Dynamo\Dynamo Core\4.0\packages. The problem is that DynamoSettings.xml in C:\Users\tellro\AppData\Roaming\Dynamo\Dynamo Core\4.0 already contains the entry for ProgramData then you need to delete the Dynamo cache in order to verify my fix. 
With this fix doesn't matter if the Dynamo cache was deleted or not, now it won't be loading any package from the ProgramData path.

### Declarations

Check these if you believe they are true

- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixing problem that is loading packages from ProgramData due that a previous version of Dynamo that doesn't have my fix was used

### Reviewers

@reddyashish @zeusongit @QilongTang 

### FYIs

