### PR TITLE
DYN-5965 Library Duplicated Nodes Fix

### DIFF
--- a/src/LibraryViewExtensionWebView2/Packages/LibrarieJS/layoutSpecs.json
+++ b/src/LibraryViewExtensionWebView2/Packages/LibrarieJS/layoutSpecs.json
@@ -1342,8 +1342,11 @@
                         "path": "DSCoreNodes.DSCore.String.Join"
                     },
                     {
-                        "path": "Core.String"
+                        "path": "Core.String.Formatted String from Object"
                     },
+                    {
+                        "path": "Core.String.Formatted String from Array"
+                    }
                 ],
               "childElements": []
             }


### PR DESCRIPTION
### Purpose

Dynamo was showing 2 nodes (String from Object, String from Array) duplicates in Library under String -> Generate, now with this fix is showing only the 2 nodes.

### Declarations

Check these if you believe they are true

- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Dynamo was showing 2 nodes (String from Object, String from Array) duplicates in Library under String -> Generate, now with this fix is showing only the 2 nodes.

### Reviewers

@QilongTang @reddyashish @zeusongit @mjkkirschner 

### FYIs

@Amoursol 
