### PR TITLE
DYN-9196 Update NuGet packages to target .NET 10.0

### DIFF
--- a/src/NodeServices/DynamoServices.csproj
+++ b/src/NodeServices/DynamoServices.csproj
@@ -16,13 +16,13 @@
       even though it should take precedence according to the docs.
       Dotnet build and builds in vs seem to work fine without this hack.-->
         <TargetFramework>$(Undefined)</TargetFramework>
-        <TargetFrameworks>netstandard2.0;net8.0;</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net10.0;</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup>
         <NoWarn>MSB3539;CS1591;NUnit2005;NUnit2007;CS0618;CS0612;CS0672</NoWarn>
     </PropertyGroup>
     <ItemGroup>
-        <!--exclude these dependencies as Sys.Ref.MetadataLoadContext.dll is already pulled in from other projects and the transitive deps are part of the .net8 runtime.-->
+        <!--exclude these dependencies as Sys.Ref.MetadataLoadContext.dll is already pulled in from other projects and the transitive deps are part of the .net10 runtime.-->
         <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" ExcludeAssets="runtime" />
     </ItemGroup>
     <ItemGroup>

--- a/src/build.xml
+++ b/src/build.xml
@@ -5,7 +5,7 @@
 <PropertyGroup>
     <Solution>Dynamo.All.sln</Solution>
     <Platform>Any CPU</Platform>
-    <DotNet>net8.0</DotNet>
+    <DotNet>net10.0</DotNet>
     <Configuration>Release</Configuration>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <NuGetPath>$(MSBuildProjectDirectory)\..\tools\Nuget\NuGet.exe</NuGetPath>

--- a/tools/NuGet/template-nuget/DynamoVisualProgramming.DynamoServices.nuspec
+++ b/tools/NuGet/template-nuget/DynamoVisualProgramming.DynamoServices.nuspec
@@ -18,20 +18,20 @@
             <group targetFramework="netstandard2.0">
                 <dependency id="System.Reflection.MetadataLoadContext" version="8.0.0" />
             </group>
-            <!--when targeting .net8 metadataloadcontext's transitive deps can be loaded from the runtime-->
+            <!--when targeting .net10 metadataloadcontext's transitive deps can be loaded from the runtime-->
             <group targetFramework="net10.0">
                 <dependency id="System.Reflection.MetadataLoadContext" version="8.0.0" exclude="build,analyzers,runtime" />
             </group>
         </dependencies>
     </metadata>
     <!--these binaries are pulled from the intermediate build
-    path because the install harvest path will only include the net8 version-->
+    path because the install harvest path will only include the net10 version-->
     <files>
         <file src="..\..\NodeServices\obj\netstandard2.0\DynamoServices.dll" target="lib\netstandard2.0" />
         <file src="DynamoServices.xml" target="lib\netstandard2.0" />
 
-        <file src="..\..\NodeServices\obj\net8.0\DynamoServices.dll" target="lib\net8.0" />
-        <file src="DynamoServices.xml" target="lib\net8.0" />
+        <file src="..\..\NodeServices\obj\net10.0\DynamoServices.dll" target="lib\net10.0" />
+        <file src="DynamoServices.xml" target="lib\net10.0" />
 
         
         <file src="..\..\..\doc\distrib\Images\logo_square_32x32.png" target="content\images\logo.png" />


### PR DESCRIPTION
### Purpose

Migrate NuGet package configuration from .net8.0 to .net10.0. This ensures all generated NuGet packages will correctly target .net10.0 instead of .net8.0, maintaining consistency with the project's current .NET version alignment.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

- fixed DynamoServices.csproj and .nuspec to use net10.0 paths 
- updated build.xml DotNet property to set correct $TargetFramework$
- ensures all NuGet packages target .NET 10.0 instead of .NET 8.0

### Reviewers

@QilongTang 
@Mikhinja 

### FYIs

@zeusongit 
