### PR TITLE
DYN-9348-Revit-PackagePath Suggested Option 1

### DIFF
--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -50,12 +50,35 @@ namespace Dynamo.Core
 
     internal class PathManager : IPathManager
     {
-        internal static Lazy<PathManager>
-         lazy =
-         new Lazy<PathManager>
-         (() => new PathManager(new PathManagerParams()));
+        private static Lazy<PathManager> lazy;
+        private static bool isInitialized = false;
 
-        public static PathManager Instance { get { return lazy.Value; } }
+        /// <summary>
+        /// Initialize the PathManager singleton passing as a parameter a PathManagerParams object (which contains the Major and Minor version values).
+        /// </summary>
+        /// <param name="parameters"></param>
+        public static void Initialize(PathManagerParams parameters)
+        {
+            if (!isInitialized)
+            {
+                lazy = new Lazy<PathManager>(() => new PathManager(parameters));
+                isInitialized = true;
+            }  
+        }
+
+        public static PathManager Instance
+        {
+            get
+            {
+                if (lazy == null)
+                {
+                    // Fallback to default if not initialized
+                    lazy = new Lazy<PathManager>(() => new PathManager(new PathManagerParams()));
+                    isInitialized = true;
+                }
+                return lazy.Value;
+            }
+        }
 
         #region Class Private Data Members
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -659,6 +659,23 @@ namespace Dynamo.Models
         /// <param name="config">Start configuration</param>
         protected DynamoModel(IStartConfiguration config)
         {
+            //If we have a version from the host, use it to set up the PathManager lazy loading Singleton.
+            var version = config.HostAnalyticsInfo.HostVersion;
+            if (version != null)
+            {
+                var pathManagerParams = new PathManagerParams
+                {
+                    MajorFileVersion = version.Major,
+                    MinorFileVersion = version.Minor,
+                };
+                Dynamo.Core.PathManager.Initialize(pathManagerParams);
+            }
+            else
+            {
+                // Initialize the PathManager singleton with default values.
+                Dynamo.Core.PathManager.Initialize(new PathManagerParams());
+            }
+
             DynamoModel.IsCrashing = false;
 
             if (config is DefaultStartConfiguration defaultStartConfig)


### PR DESCRIPTION
### Purpose

Fix for installing Dynamo packages using the DynamoRevit version path (e.g.  C:\Users\<user>\AppData\Roaming\Dynamo\Dynamo Revit\27.0\packages)
After providing the context to GitHub Copilot for updating the PathManager lazy loading singleton for changing the PathManagerParams in the constructor (using HostAnalyticsInfo.HostVersion), the next alternatives were provided by Copilot:

1. Set Before First Access (Recommended) - Adding a static Initialize method Pass via IPathResolver
2. Modify the Lazy Initialization Logic
3. Set Static Properties Before First Use
4. Recreate the Singleton (Not Recommended)

In this PR is implemented the first one with some minor changes based in GitHub Copilot suggestions.

### Declarations

Check these if you believe they are true

- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fix for installing Dynamo packages using the DynamoRevit version path (e.g.  C:\Users\<user>\AppData\Roaming\Dynamo\Dynamo Revit\27.0\packages)

### Reviewers

@QilongTang @zeusongit 

### FYIs

