### PR TITLE
DYN-9605 : expose internals to mcpserver

### DIFF
--- a/src/DynamoCore/Properties/AssemblyInfo.cs
+++ b/src/DynamoCore/Properties/AssemblyInfo.cs
@@ -61,6 +61,7 @@ using System.Runtime.CompilerServices;
 // Internals are visible to the MCP View Extension and Extension, depending on final implementation.
 [assembly: InternalsVisibleTo("MCPExtension")]
 [assembly: InternalsVisibleTo("MCPViewExtension")]
+[assembly: InternalsVisibleTo("MCPServer")]
 
 // Disable PublicAPIAnalyzer errors for this type as they're already added to the public API text file
 #pragma warning disable RS0016 


### PR DESCRIPTION
### Purpose
We added a new dll to our MCPExtension and we need access to Dynamo internals.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes
N/A

### Reviewers
@DynamoDS/synapse 
