### PR TITLE
[DYN-8952] Fix custom group styles duplicating issue on host environments.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -1598,8 +1598,13 @@ namespace Dynamo.ViewModels
             //By Default the warning state of the Visual Settings tab (Group Styles section) will be disabled
             isWarningEnabled = false;
 
-            // Initialize group styles with default and non-default GroupStyleItems
-            StyleItemsList = GroupStyleItem.DefaultGroupStyleItems.AddRange(preferenceSettings.GroupStyleItemsList.Where(style => style.IsDefault != true)).ToObservableCollection();
+            // Initialize group styles with default and custom GroupStyleItems.
+            var customStyles = preferenceSettings.GroupStyleItemsList.Where(style => style.IsDefault != true).ToList();
+            preferenceSettings.GroupStyleItemsList.Clear();
+            preferenceSettings.GroupStyleItemsList.AddRange(GroupStyleItem.DefaultGroupStyleItems);
+            preferenceSettings.GroupStyleItemsList.AddRange(customStyles);
+
+            StyleItemsList = preferenceSettings.GroupStyleItemsList.ToObservableCollection();
 
             //When pressing the "Add Style" button some controls will be shown with some values by default so later they can be populated by the user
             AddStyleControl = new StyleItem() { Name = string.Empty, HexColorString = GetRandomHexStringColor() };


### PR DESCRIPTION
### Purpose

Related to https://jira.autodesk.com/browse/DYN-8952. 

This should fix the custom group styles duplicating in the Revit environment when Dynamo is reopened. When dynamo is closed in host environment, the styles are still in memory and when preferencesVM is initialized, they are added again.

Tested it on Revit and sandbox with these changes.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes
[DYN-8952] Fix custom group styles duplicating issue on host environments.

### Reviewers
@DynamoDS/eidos 

