### PR TITLE
DYN-9616: [Regression] Fix pan tool to remain active until the user choose to deactivate it

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -950,6 +950,7 @@ namespace Dynamo.Views
                 ContextMenuPopup.IsOpen = true;
             }
 
+            // Only toggle pan mode if we were not connecting a port and were panning using middle mouse button.
             if (!ViewModel.IsConnecting && ViewModel.IsPanning && e.ChangedButton == MouseButton.Middle && e.ButtonState == MouseButtonState.Released)
             {
                 ViewModel.RequestTogglePanMode();

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -950,7 +950,7 @@ namespace Dynamo.Views
                 ContextMenuPopup.IsOpen = true;
             }
 
-            if (!ViewModel.IsConnecting && ViewModel.IsPanning && e.MiddleButton == MouseButtonState.Released)
+            if (!ViewModel.IsConnecting && ViewModel.IsPanning && e.ChangedButton == MouseButton.Middle && e.ButtonState == MouseButtonState.Released)
             {
                 ViewModel.RequestTogglePanMode();
             }


### PR DESCRIPTION
### Purpose

Updated the mouse release event handler to check for the middle mouse button specifically when toggling pan mode, ensuring correct behavior when releasing the middle mouse button. This was conflicting with the `PanMode` state

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

 Fix pan tool to remain active until the user choose to deactivate it

### Reviewers


