### PR TITLE
DYN-9538: Bump LibrarieJS to version 1.0.7

### DIFF
--- a/src/LibraryViewExtensionWebView2/LibraryViewExtensionWebView2.csproj
+++ b/src/LibraryViewExtensionWebView2/LibraryViewExtensionWebView2.csproj
@@ -17,7 +17,7 @@
   
   <Target Name="NpmRunBuild" BeforeTargets="BeforeBuild">
       <PropertyGroup>
-          <PackageVersion>1.0.6</PackageVersion>
+          <PackageVersion>1.0.7</PackageVersion>
           <PackageName>LibrarieJS</PackageName>
       </PropertyGroup>
       <Exec Command="&quot;$(PowerShellCommand)&quot; -ExecutionPolicy ByPass -Command &quot;&amp; '$(SolutionDir)pkgexist.ps1' '$(PackageName)' '$(PackageVersion)'&quot;" ConsoleToMSBuild="true">


### PR DESCRIPTION
### Purpose

Updated the PackageVersion property in LibraryViewExtensionWebView2.csproj to use version 1.0.7 of the LibrarieJS package.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Updated the PackageVersion property in LibraryViewExtensionWebView2.csproj to use version 1.0.7 of the LibrarieJS package.

### Reviewers


