### PR TITLE
DYN-9556:no internet local packages fix

### DIFF
--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -396,6 +396,8 @@ namespace Dynamo.PackageManager
                 var compatibilityMapList = CompatibilityMap();
                 PackageManagerClient.compatibilityMapList = compatibilityMapList;    // Loads the full CompatibilityMap as a side-effect
 
+                if (compatibilityMapList == null) return;   // Check if the compatilibityMapList exists
+
                 foreach (var host in compatibilityMapList)
                 {
                     foreach (var property in host.Properties())


### PR DESCRIPTION
### Purpose

A very small bugfix that was causing Local Packages to not be initialized when the internet was disconnected: https://jira.autodesk.com/browse/DYN-9556?filter=-1 

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

- the compatilibyMapList not being initialized during noInterent mode was causing a crash stifling local packages

### Reviewers

@zeusongit 
@achintyabhat 

### FYIs

