### PR TITLE
DYN-9537: Fix unit tests for cross version schemas support

### DIFF
--- a/test/DynamoCoreTests/UnitsOfMeasureTests.cs
+++ b/test/DynamoCoreTests/UnitsOfMeasureTests.cs
@@ -779,7 +779,11 @@ namespace Dynamo.Tests
             var unitType = Unit.ByTypeID($"{milimeters}-99.9.9");
             Assert.NotNull(unitType);
             Assert.AreEqual("Millimeters", unitType.Name);
-            Assert.AreEqual($"{milimeters}-2.0.0", unitType.TypeId);
+            
+            // Depending on the test system, the latest known version could be either -2.0.0 or -1.0.1
+            var expectedVersions = new[] { $"{milimeters}-2.0.0", $"{milimeters}-1.0.1" };
+            Assert.That(expectedVersions, Contains.Item(unitType.TypeId), 
+                $"Expected TypeId to be one of the known versions, but got: {unitType.TypeId}");
         }
         [Test, Category("UnitTests")]
         public void CanCreateForgeUnitType_FromPastTypeString()
@@ -788,7 +792,11 @@ namespace Dynamo.Tests
             var unitType = Unit.ByTypeID($"{milimeters}-0.0.1");
             Assert.NotNull(unitType);
             Assert.AreEqual("Millimeters", unitType.Name);
-            Assert.AreEqual($"{milimeters}-2.0.0", unitType.TypeId);
+            
+            // Depending on the test system, the latest known version could be either -2.0.0 or -1.0.1
+            var expectedVersions = new[] { $"{milimeters}-2.0.0", $"{milimeters}-1.0.1" };
+            Assert.That(expectedVersions, Contains.Item(unitType.TypeId), 
+                $"Expected TypeId to be one of the known versions, but got: {unitType.TypeId}");
         }
         [Test, Category("UnitTests")]
         public void ForgeUnitEquality()

--- a/test/DynamoCoreWpf3Tests/UnitsUITests.cs
+++ b/test/DynamoCoreWpf3Tests/UnitsUITests.cs
@@ -198,7 +198,6 @@ namespace DynamoCoreWpfTests
             Assert.AreNotEqual("autodesk.unit.quantity:force", GetTypeName<DynamoUnits.Quantity>(node3.CachedValue.Data));
             Assert.AreEqual("autodesk.unit.quantity:flowPerVolume", GetTypeName<DynamoUnits.Quantity>(node3.CachedValue.Data));
             Assert.AreEqual("autodesk.unit.symbol:mm", GetTypeName<DynamoUnits.Symbol>(node4.CachedValue.Data));
-            Assert.AreEqual("autodesk.unit.unit:maxwells", GetTypeName<DynamoUnits.Unit>(node5.CachedValue.Data));
             Assert.AreEqual("autodesk.unit.unit:meters", GetTypeName<DynamoUnits.Unit>(node6.CachedValue.Data));
             Assert.AreEqual("autodesk.unit.unit:millimeters", GetTypeName<DynamoUnits.Unit>(node7.CachedValue.Data));
             Assert.AreEqual(3, node8.CachedValue.GetElements().Count());


### PR DESCRIPTION
### Purpose 🎯

This PR fixes unit test stability issues in the Forge Units tests by handling cross-version schema compatibility. The tests were failing inconsistently across different test systems because they expected a specific version format (`-2.0.0`) but some systems return a different format (`-1.0.1`). This variation occurs depending on whether ASC (Autodesk Shared Components) is installed or the system falls back to bundled schemas.

**Changes**: These changes only affect test assertions and don't modify any production code. The tests now accept both `-2.0.0` and `-1.0.1` version formats as valid fallback versions. The `ForgeUnitDropdownsLoadWithMalformedData` test was updated to avoid checking fragile schema index dependencies that vary between ASC and bundled schema environments.

**Fixed Tests:**

-   `CanCreateForgeUnitType_FromFutureTypeString`
-   `CanCreateForgeUnitType_FromPastTypeString`
-   `ForgeUnitDropdownsLoadWithMalformedData`

**Context**: The alternate schema loading mechanism was introduced in [PR #16529](https://github.com/DynamoDS/Dynamo/pull/16529/files), which enhanced DynamoUnits with auto schema discovery from ASC installations.

### Declarations ✅

Check these if you believe they are true

-   [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
-   [x] The level of testing this PR includes is appropriate
-   [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes 📝

**Test Stability**: Fixed unit tests for Forge unit type creation to handle cross-version schema compatibility, improving test reliability across different environments.

### Reviewers 👥

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

### FYIs 📢

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
