### PR TITLE
DYN-9244 ProgramData Samples Fix

### DIFF
--- a/src/DynamoCore/Configuration/Configurations.cs
+++ b/src/DynamoCore/Configuration/Configurations.cs
@@ -49,6 +49,11 @@ namespace Dynamo.Configuration
         public static readonly string DynamoAsString = "Dynamo";
 
         /// <summary>
+        /// Const string of Samples folder
+        /// </summary>
+        public static readonly string SamplesAsString = "Samples";
+
+        /// <summary>
         /// Const string for Dynamo Node Help Docs
         /// </summary>
         public static readonly string DynamoNodeHelpDocs = "NodeHelpSharedDocs";

--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -591,8 +591,9 @@ namespace Dynamo.Core
         /// </summary>
         private void BuildCommonDirectories()
         {
+            var dynamoCorePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             // Common directories.
-            commonDataDir = GetCommonDataFolder();
+            commonDataDir = Path.Combine(dynamoCorePath,Configurations.SamplesAsString);
 
             samplesDirectory = GetSamplesFolder(commonDataDir);
             defaultTemplatesDirectory = GetTemplateFolder(commonDataDir);
@@ -664,15 +665,6 @@ namespace Dynamo.Core
             var executingAssemblyName = Assembly.GetExecutingAssembly().GetName();
             productVersion = Updates.BinaryVersion.FromString(executingAssemblyName.Version.ToString());
             return productVersion;
-        }
-
-        private string GetCommonDataFolder()
-        {
-            if (pathResolver != null && !string.IsNullOrEmpty(pathResolver.CommonDataRootFolder))
-                return GetDynamoDataFolder(pathResolver.CommonDataRootFolder);
-
-            var folder = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-            return GetDynamoDataFolder(Path.Combine(folder, Configurations.DynamoAsString, "Dynamo Core"));
         }
 
         private string GetDynamoDataFolder(string folder)

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <UILib>true</UILib>
   </PropertyGroup>
@@ -2197,9 +2197,11 @@
  <Target Name="AfterBuildOps" AfterTargets="Build">
     <ItemGroup>
       <ExternTuneUpPkg Include="$(SolutionDir)..\extern\TuneUp\**\*.*" />
+	  <DistribSamples Include="$(SolutionDir)..\extern\doc\distrib\Samples\**\*.*" />
     </ItemGroup>
     <MakeDir Directories="$(OutputPath)\viewExtensions\" />
     <Copy SourceFiles="@(ExternTuneUpPkg)" DestinationFolder="$(OutputPath)\Built-In Packages\packages\TuneUp\%(RecursiveDir)" />
+	<Copy SourceFiles="@(DistribSamples)" DestinationFolder="$(OutputPath)\Samples)" SkipUnchangedFiles="True" />
   </Target>
   <Target Name="CopyPMWizardHtmlFiles" AfterTargets="Build">
     <ItemGroup>


### PR DESCRIPTION
### Purpose

With this fix now the Sample files located in Dynamo\doc\distrib\Samples will be copied when building the solution to DynamoCore\Samples, so if we try to open the Default Samples folder from DynamoHome this new path will be opened by default.
Note: I'm still pending in testing this change in Dynamo Revit.

### Declarations

Check these if you believe they are true

- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Updating the default path used for Samples when using DynamoSandbox

### Reviewers

@QilongTang @zeusongit @johnpierson 

### FYIs

@achintyabhat 
