### PR TITLE
DYN-9196:align master with current version

### DIFF
--- a/.github/workflows/dynamo_bin_diff.yml
+++ b/.github/workflows/dynamo_bin_diff.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
-            10.0.x
+            10.0.100-preview.5.25277.114
       - name: Disable problem matcher
         run: Write-Output "::remove-matcher owner=csc::"
       - name: Setup msbuild


### PR DESCRIPTION
### Purpose

Following https://github.com/DynamoDS/Dynamo/pull/16566, align the .NET version between build_current and build_master.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

- align dotnet-version between build_current and build_master in bin diff workflow

### Reviewers

@avidit 
@QilongTang 

### FYIs


