### PR TITLE
DYN-9693: Python migration toast notification should close when closing a graph

### DIFF
--- a/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
+++ b/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
@@ -196,9 +196,16 @@ namespace Dynamo.PythonMigration
                 .ForEach(x => SubscribeToPythonNodeEvents(x as PythonNodeBase));
         }
 
+        private void OnCurrentWorkspaceCleared(IWorkspaceModel workspace)
+        {
+            // Close the CPython toast notification when workspace is cleared/closed
+            DynamoViewModel.MainGuideManager?.CloseRealTimeInfoWindow();
+        }
+
         private void SubscribeToDynamoEvents()
         {
             LoadedParams.CurrentWorkspaceChanged += OnCurrentWorkspaceChanged;
+            LoadedParams.CurrentWorkspaceCleared += OnCurrentWorkspaceCleared;
             DynamoViewModel.Model.Logger.NotificationLogged += OnNotificationLogged;
             SubscribeToWorkspaceEvents();
         }
@@ -240,6 +247,7 @@ namespace Dynamo.PythonMigration
             if (LoadedParams != null)
             {
                 LoadedParams.CurrentWorkspaceChanged -= OnCurrentWorkspaceChanged;
+                LoadedParams.CurrentWorkspaceCleared -= OnCurrentWorkspaceCleared;
                 DynamoViewModel.CurrentSpaceViewModel.Model.NodeAdded -= OnNodeAdded;
                 DynamoViewModel.Model.Logger.NotificationLogged -= OnNotificationLogged;
             }


### PR DESCRIPTION
### Purpose

When a user opens a graph with CPython3 nodes they see a toast notification, if the user closes the graph without dismissing the toast notification, it stays, and when the graph is reopened the notification jumps to a different location on the screen

<img width="2097" height="1048" alt="Screenshot 2025-10-15 152444" src="https://github.com/user-attachments/assets/22c3f3bb-cb32-4381-a8f8-18aaa566cfcd" />

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Python migration toast notification should close when closing a graph

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
