### PR TITLE
DYN-9658: Correctly adds file information to pacman when publishing from custom node workspace

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -806,7 +806,7 @@ namespace Dynamo.PackageManager
             }
         }
 
-        private Dictionary<string, string> CustomDyfFilepaths { get; set; } = new Dictionary<string, string>();
+        internal Dictionary<string, string> CustomDyfFilepaths { get; set; } = new Dictionary<string, string>();
 
         public List<PackageAssembly> Assemblies { get; set; }
 

--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -153,8 +153,11 @@ namespace Dynamo.UI.Views
 
         private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
-            // If we have triggered on data context chagnes with the same context, return
-            if (this.DataContext as PublishPackageViewModel == previousViewModel) return;
+            var newViewModel = this.DataContext as PublishPackageViewModel;
+            
+            // If we have triggered on data context changes with the same context, return
+            if (newViewModel == previousViewModel) return;
+            
             if (previousViewModel != null)
             {
                 previousViewModel.PropertyChanged -= PublishPackageViewModel_PropertyChanged;
@@ -164,12 +167,21 @@ namespace Dynamo.UI.Views
             }
 
             // Cast and assign the new DataContext
-            publishPackageViewModel = this.DataContext as PublishPackageViewModel;
+            publishPackageViewModel = newViewModel;
             previousViewModel = publishPackageViewModel;
 
             // If the application hasn't been loaded, and the flag hasn't been flipped, flip it here
-            if(!_applicationLoaded && !_hasPendingUpdates && (bool)publishPackageViewModel?.HasChanges)
+            // Check both HasChanges AND if there's actual content to display (PackageContents, CustomDyfFilepaths, etc.)
+            var hasContent = publishPackageViewModel != null && (
+                (publishPackageViewModel.PackageContents?.Count ?? 0) > 0 ||
+                (publishPackageViewModel.CustomDyfFilepaths?.Count ?? 0) > 0 ||
+                (publishPackageViewModel.HasChanges == true)
+            );
+            
+            if(!_applicationLoaded && !_hasPendingUpdates && hasContent)
+            {
                 _hasPendingUpdates = true;
+            }
 
             // Subscribe to the new ViewModel
             if (publishPackageViewModel != null)


### PR DESCRIPTION
### Purpose

This PR addresses the issue where Custom nodes (.dyf files) published via "Publish → Publish Custom Node (.dyf)" menu didn't appear in the package contents in the publish wizard.

**Cause**
`ShowNodePublishInfo()` only populated `CustomNodeDefinitions` but not `CustomDyfFilepaths`. The wizard filters out `CustomNode` type items and only displays `CustomNodePreview` type items (created from `CustomDyfFilepaths`), resulting in empty package contents.

**Solution**

- Populate `CustomDyfFilepaths` with file paths from `CustomNodeInfo` **before** setting `CustomNodeDefinitions` (which triggers `RefreshPackageContents()`)
- Added fallback to use workspace.FileName when CustomNodeInfo.Path is empty
- Enhanced `OnDataContextChanged` to check `CustomDyfFilepaths` count in addition to HasChanges for proper pending update detection

### Changes 

![DynamoSandbox_CJDm2P8HR5](https://github.com/user-attachments/assets/5fa4382d-c923-4fa0-8b4e-0c35cd3c37f9)

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

- now correctly refreshes the datacontext and triggers update to the UI

### Reviewers

@zeusongit 

### FYIs

@benglin 
