### PR TITLE
fix build

### DIFF
--- a/src/DynamoCoreWpf/Properties/AssemblyInfo.cs
+++ b/src/DynamoCoreWpf/Properties/AssemblyInfo.cs
@@ -60,6 +60,9 @@ using System.Windows;
 [assembly: InternalsVisibleTo("DynamoPlayer")]
 [assembly: InternalsVisibleTo("DynamoConnector")]
 [assembly: InternalsVisibleTo("NodeAutoCompleteViewExtension")]
+// PythonMigrationViewExtension requires access to the following internal APIs:
+// TODO: List specific internal types/methods used by PythonMigrationViewExtension.
+// This friend assembly usage is intentional and tracked. Consider promoting these APIs to a public/extension API if appropriate.
 [assembly: InternalsVisibleTo("PythonMigrationViewExtension")]
 
 // Disable PublicAPIAnalyzer errors for this type as they're already added to the public API text file


### PR DESCRIPTION
### Purpose

Fix build.

`OnCurrentWorkspaceCleared` in `PythonMigrationViewExtension` uses `GuidesManager.CloseRealTimeInfoWindow`, which is marked internal in `DynamoCoreWpf`, and this wasn't accessible in the view extension.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
