### PR TITLE
DYN-9698: Remove Purple Syntax Highlighting from Python nodes

### DIFF
--- a/src/Libraries/PythonNodeModelsWpf/Resources/ICSharpCode.PythonBinding.Resources.Python.xshd
+++ b/src/Libraries/PythonNodeModelsWpf/Resources/ICSharpCode.PythonBinding.Resources.Python.xshd
@@ -38,7 +38,7 @@
         <End>"</End>
       </Span>                   
       <MarkPrevious bold="false" color="#84d7ce">(</MarkPrevious>
-      <KeyWords name="BuiltInStatements" bold="false" color="#F2A9F2">
+      <KeyWords name="BuiltInStatements" bold="false" color="#FFBEB2">
         <Key word="assert" />
         <Key word="del" />
         <Key word="exec" />
@@ -49,7 +49,7 @@
       <KeyWords name="ClassStatement" color="#6AC0E7" bold="false">
         <Key word="class" />
       </KeyWords>
-      <KeyWords name="ExceptionHandlingStatements" bold="false" color="#F2A9F2">
+      <KeyWords name="ExceptionHandlingStatements" bold="false" color="#FFBEB2">
         <Key word="except" />
         <Key word="finally" />
         <Key word="raise" />
@@ -62,33 +62,33 @@
         <Key word="import" />
         <Key word="from" />
       </KeyWords>
-      <KeyWords name="IterationStatements" bold="false" color="#F2A9F2">
+      <KeyWords name="IterationStatements" bold="false" color="#FFBEB2">
         <Key word="for" />
         <Key word="in" />
         <Key word="while" />
       </KeyWords>
-      <KeyWords name="JumpStatements" color="#F2A9F2">
+      <KeyWords name="JumpStatements" color="#FFBEB2">
         <Key word="break" />
         <Key word="continue" />
         <Key word="yield" />
         <Key word="return" />
       </KeyWords>
-      <KeyWords name="OperatorStatements" bold="true" color="#F2A9F2">
+      <KeyWords name="OperatorStatements" bold="true" color="#FFBEB2">
         <Key word="and" />
         <Key word="as" />
         <Key word="is" />
         <Key word="not" />
         <Key word="or" />
       </KeyWords>
-      <KeyWords name="PassStatement" color="#F2A9F2">
+      <KeyWords name="PassStatement" color="#FFBEB2">
         <Key word="pass" />
       </KeyWords>
-      <KeyWords name="SelectionStatements" bold="false" color="#F2A9F2">
+      <KeyWords name="SelectionStatements" bold="false" color="#FFBEB2">
         <Key word="elif" />
         <Key word="else" />
         <Key word="if" />
       </KeyWords>
-      <KeyWords name="WithStatement" color="#F2A9F2">
+      <KeyWords name="WithStatement" color="#FFBEB2">
         <Key word="with" />
       </KeyWords>
       <KeyWords name="Constants" color="#F9F9A5">


### PR DESCRIPTION
### Purpose

Remove Purple Syntax Highlighting from Python nodes (reserve purple for future AI features)

Before
<img width="500" height="auto" alt="sample python code" src="https://github.com/user-attachments/assets/25a367ef-da00-49e4-91dd-dc63a6bdc06f" />

After
<img width="500" height="auto" alt="Screenshot 2025-10-20 at 11 07 33 AM" src="https://github.com/user-attachments/assets/49bb9cb1-a30c-41a1-a1c3-c0338a177239" />

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Remove Purple Syntax Highlighting from Python nodes

### Reviewers

@DynamoDS/synapse @DynamoDS/eidos 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
