### PR TITLE
DYN-9644: fix cancel uploading issue

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -2805,7 +2805,13 @@ namespace Dynamo.PackageManager
         {
             var publishPath = GetPublishFolder();
             if (string.IsNullOrEmpty(publishPath))
+            {
+                // Reset uploading state when user cancels folder selection
+                Uploading = false;
+                // Notify the front-end that the user has cancelled the upload
+                UploadCancelled?.Invoke();
                 return;
+            }
 
             UploadType = PackageUploadHandle.UploadType.Local;
 

--- a/test/DynamoCoreWpf3Tests/PublishPackageViewModelTests.cs
+++ b/test/DynamoCoreWpf3Tests/PublishPackageViewModelTests.cs
@@ -79,6 +79,36 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void PublishLocallyCommand_WhenUserCancelsFolderDialog_ResetsUploadingState()
+        {
+            // Arrange
+            var vm = new PublishPackageViewModel(ViewModel);
+            ViewModel.OnRequestPackagePublishDialog(vm);
+            
+            // Add a custom node to make the package valid
+            string packagedirectory = Path.Combine(TestDirectory, "pkgs");
+            var packages = Directory.EnumerateDirectories(packagedirectory);
+            var firstnode = packages.First();
+            vm.AddFile(firstnode);
+            
+            // Set up the folder dialog to return cancel
+            vm.RequestShowFolderBrowserDialog += (sender, e) => {
+                e.Cancel = true; // Simulate user cancelling the dialog
+            };
+            
+            // Track if UploadCancelled event was triggered
+            bool uploadCancelledTriggered = false;
+            vm.UploadCancelled += () => uploadCancelledTriggered = true;
+            
+            // Act
+            vm.PublishLocallyCommand.Execute();
+            
+            // Assert
+            Assert.IsFalse(vm.Uploading, "Uploading should be false when user cancels folder dialog");
+            Assert.IsTrue(uploadCancelledTriggered, "UploadCancelled event should be triggered when user cancels folder dialog");
+        }
+
+        [Test]
         public void CanRemoveCustomNodesWithIdenticalNames()
         {
             var vm = new PublishPackageViewModel(this.ViewModel);


### PR DESCRIPTION
### Purpose

Addresses `CORE: Stuck when cancelling publishing a package in Package Manager`. The issue was that when cancelling out of the folder selection dialog, we weren't notifying the frontend client. 

### Changes

![BBIDuwIO8k](https://github.com/user-attachments/assets/06b88dfd-4f7e-46b5-b6f4-0c068da04d8b)

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

- the backend was not notifying the web client when cancelling out of the folder selection dialog during the publish process
- now correctly sets the Uploading back to False, and notifies the client
- added test for this flow

### Reviewers

@QilongTang 

### FYIs

@zeusongit 
@jnealb 