### PR TITLE
DYN-9680 Crash Missing Dynamo folder

### DIFF
--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -575,7 +575,7 @@ namespace Dynamo.UI.Views
                 }
                 catch (Exception ex)
                 {
-                    viewModel.Model.Logger.Log("programDataDir was not set successfully: " + ex.Message);
+                    viewModel.Model.Logger.Log("Error loading preferences from programDataDir: " + ex.Message);
                 }
             }
         }


### PR DESCRIPTION
### Purpose
Dynamo crashing when C:\ProgramData\Dynamo doesn't exist.
Due that C:\ProgramData\Dynamo folder is not created any more then the code was expecting that folder to exist so Dynamo was crashing. I moved the code inside the try/catch and also added a validation that just execute the code if the directory exists.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Dynamo crashing when C:\ProgramData\Dynamo doesn't exist.

### Reviewers

@QilongTang @zeusongit 

### FYIs

@jnealb 
