### PR TITLE
9348: DYN-9742 PackagePath Crash Fix

### DIFF
--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -61,13 +61,11 @@ namespace Dynamo.Core
         {
             lock (lockObject)
             {
-                if (lazy != null)
+                //If is already initialized then do nothing
+                if (lazy == null)
                 {
-                    // Or do we want to reset the existing instance? See below for discussions.
-                    throw new InvalidOperationException("PathManager has already been initialized.");
-                }
-
-                lazy = new Lazy<PathManager>(() => new PathManager(parameters));
+                    lazy = new Lazy<PathManager>(() => new PathManager(parameters));
+                }                 
             }
         }
 


### PR DESCRIPTION

### Purpose

Fixing Revit crash when opening Dynamo close it and re-open Dynamo again.
Due that Revit when launching Dynamo the first time creates the PathManager with parameters then the second time launching Dynamo is throwing an exception saying that was already initialized, then in this fix I'm updating the code to not throwing the exception and do nothing if was already initialized.

### Declarations

Check these if you believe they are true

- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixing Revit crash when opening Dynamo close it and re-open Dynamo again.

### Reviewers

@QilongTang @benglin @zeusongit 

### FYIs

