### PR TITLE
DYN-9704 LogConsole UnTrustedPaths

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1037,7 +1037,7 @@ namespace Dynamo.Models
             DynamoReady(new ReadyParams(this));
 
             string programDataPath = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-            foreach(var trustedLoc in PreferenceSettings.TrustedLocations)
+            foreach (var trustedLoc in PreferenceSettings.TrustedLocations)
             {
                 if (trustedLoc.StartsWith(programDataPath))
                 {


### PR DESCRIPTION
### Purpose

When using a DynamoSettings.xml which contains TrustedLocations pointing to ProgramData path we will log that info in the Dynamo console.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

When using a DynamoSettings.xml which contains TrustedLocations pointing to ProgramData path we will log that info in the Dynamo console.


### Reviewers

@zeusongit 

### FYIs

@jnealb 
