### PR TITLE
DYN-9838: Update YouTube Referrer Calls for Learn Videos

### DIFF
--- a/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
+++ b/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
@@ -179,16 +179,9 @@ namespace Dynamo.UI.Views
                 // Use a valid HTTPS URL as required by YouTube API terms.
                 // See: https://developers.google.com/youtube/terms/required-minimum-functionality#embedded-player-api-client-identity
                 // Using the official Dynamo website as the referer domain.
-                var refererUrl = "https://dynamobim.org";
-                
                 // Filter for YouTube requests and add Referer header
                 this.dynWebView.CoreWebView2.AddWebResourceRequestedFilter("*youtube.com*", CoreWebView2WebResourceContext.All);
-                this.dynWebView.CoreWebView2.WebResourceRequested += (sender, args) =>
-                {
-                    var uri = args.Request.Uri;
-                    // Set the Referer header as required by YouTube API terms
-                    args.Request.Headers.SetHeader("Referer", refererUrl);
-                };
+                this.dynWebView.CoreWebView2.WebResourceRequested += CoreWebView2_WebResourceRequested;
 
                 // Load the embedded resources
                 htmlString = PathHelper.LoadEmbeddedResourceAsString(htmlEmbeddedFile, assembly);
@@ -236,6 +229,15 @@ namespace Dynamo.UI.Views
         {
             e.Handled = true;
             ProcessUri(e.Uri);
+        }
+
+        private void CoreWebView2_WebResourceRequested(object sender, CoreWebView2WebResourceRequestedEventArgs args)
+        {
+            var uri = args.Request.Uri;
+            // Set the Referer header as required by YouTube API terms
+            // Using the official Dynamo website as the referer domain.
+            var refererUrl = "https://dynamobim.org";
+            args.Request.Headers.SetHeader("Referer", refererUrl);
         }
 
         internal bool ProcessUri(string uri)
@@ -729,6 +731,7 @@ namespace Dynamo.UI.Views
                     if (this.dynWebView != null && this.dynWebView.CoreWebView2 != null)
                     {
                         this.dynWebView.CoreWebView2.NewWindowRequested -= CoreWebView2_NewWindowRequested;
+                        this.dynWebView.CoreWebView2.WebResourceRequested -= CoreWebView2_WebResourceRequested;
                     }
 
                     // Delete font file if it exists


### PR DESCRIPTION
### Purpose

This PR addresses YouTube API Error 153 by adding proper HTTP Referer headers to YouTube requests made from Dynamo's embedded web view. The change ensures compliance with YouTube's embedded player API requirements that mandate client identification via the HTTP Referer header.

Key Changes:

Adds HTTP Referer header to all YouTube requests using a dynamically generated URL based on the assembly name
Implements WebResourceRequested event handler to intercept and modify YouTube requests



Before:
<img width="1085" height="297" alt="image" src="https://github.com/user-attachments/assets/55304ed9-31f1-40f7-919b-da6c9bf8be1c" />


After:
<img width="2544" height="1360" alt="image" src="https://github.com/user-attachments/assets/920ad4ed-cf08-4f83-ab5d-96273021ec30" />


### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

- Fix for Learn Video Links on HomePage

### Reviewers

@DynamoDS/eidos 

### FYIs

@achintyabhat @QilongTang 
