### PR TITLE
DYN-9816: Python node sample file restored

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
@@ -219,8 +219,14 @@ namespace Dynamo.DocumentationBrowser
                             openNodeAnnotationEventArgs.MinimumQualifiedName, 
                             openNodeAnnotationEventArgs.PackageName);
 
-                        bool isBuiltInByPath = IsBuiltInDocPath(mdLink);
-                        ownedByPackage = !string.IsNullOrEmpty(openNodeAnnotationEventArgs.PackageName) && !isBuiltInByPath;
+                        bool isBuiltInByPath = false;
+                        if (!string.IsNullOrEmpty(packageName))
+                        {
+                            isBuiltInByPath = IsBuiltInDocPath(mdLink);
+                        }
+
+                        ownedByPackage = !string.IsNullOrEmpty(packageName) && !isBuiltInByPath;
+
                         link = string.IsNullOrEmpty(mdLink) ? new Uri(String.Empty, UriKind.Relative) : new Uri(mdLink);
                         graphPath = GetGraphLinkFromMDLocation(link, ownedByPackage);
                         targetContent = CreateNodeAnnotationContent(openNodeAnnotationEventArgs);
@@ -294,6 +300,8 @@ namespace Dynamo.DocumentationBrowser
 
         private bool IsBuiltInDocPath(string mdLink)
         {
+            if (string.IsNullOrEmpty(mdLink)) return false;
+
             try
             {
                 var binDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
@@ -305,11 +313,15 @@ namespace Dynamo.DocumentationBrowser
                 var hostFull = hostFallback == null ? string.Empty : Path.GetFullPath(hostFallback);
                 var coreFull = coreFallback == null ? string.Empty : Path.GetFullPath(coreFallback);
 
+                if (!string.IsNullOrEmpty(sharedFull) && !sharedFull.EndsWith(Path.DirectorySeparatorChar)) sharedFull += Path.DirectorySeparatorChar;
+                if (!string.IsNullOrEmpty(hostFull) && !hostFull.EndsWith(Path.DirectorySeparatorChar)) hostFull += Path.DirectorySeparatorChar;
+                if (!string.IsNullOrEmpty(coreFull) && !coreFull.EndsWith(Path.DirectorySeparatorChar)) coreFull += Path.DirectorySeparatorChar;
+
                 return (!string.IsNullOrEmpty(sharedFull) && mdFull.StartsWith(sharedFull, StringComparison.OrdinalIgnoreCase)) ||
                        (!string.IsNullOrEmpty(hostFull) && mdFull.StartsWith(hostFull, StringComparison.OrdinalIgnoreCase)) ||
                        (!string.IsNullOrEmpty(coreFull) && mdFull.StartsWith(coreFull, StringComparison.OrdinalIgnoreCase));
             }
-            catch (ArgumentException)
+            catch (Exception)
             {
                 return false;
             }


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-5916](https://jira.autodesk.com/browse/DYN-9816) where the Python node’s sample in the Documentation Browser wasn’t loading after the move to PythonNet3.

After the Python engine upgrade, Python nodes report a dependency on the PythonNet3 Engine package. In `DocumentationBrowserViewModel.HandleLocalResource()` we were using the presence of a `PackageName` to set `ownedByPackage = true`.

I added a small helper that checks where the node’s markdown `mdLink` actually lives. If it comes from a Dynamo documentation folder - shared docs or fallbacks, we treat it as built-in and force `ownedByPackage = false` - even if a package dependency is present.

![DYN-9816](https://github.com/user-attachments/assets/da967f88-bf3e-4488-84cd-b5af37583dd4)

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixe regression where the Python node sample was not loading.

### Reviewers

@zeusongit
@DynamoDS/eidos

### FYIs

@achintyabhat
@dnenov
