### PR TITLE
DYN-9386 Remove Dynamo nodes marked for deprecation in Dynamo 1.x (#1…

### DIFF
--- a/test/core/string/TestObsoleteStringFunctions.dyn
+++ b/test/core/string/TestObsoleteStringFunctions.dyn
@@ -1,0 +1,188 @@
+{
+  "Uuid": "3c9d0464-8643-5ffe-96e5-ab1769818209",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "TestObsoleteStringFunctions",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "1c1cbeecc02e4c1ca880dc195d53ef29",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "8fd2b41b3873448c94456bc584bca00f",
+          "Name": "object",
+          "Description": "some object\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "4f15e035506f414ebbb6af00326c5926",
+          "Name": "string",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "ToString@var[]..[]",
+      "Replication": "Auto",
+      "Description": "ToString (object: var[]..[]): string"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "Id": "f359ea84d1ab468b9745f280cff75eda",
+      "NodeType": "CodeBlockNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "dce6e645c25841a3b290a89cf3cb1f11",
+          "Name": "integer",
+          "Description": "42",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly",
+      "Code": "42;"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "WatchWidth": 200.0,
+      "WatchHeight": 40.0,
+      "Id": "88ecf13c40dc42c289b3375c2773f5b1",
+      "NodeType": "ExtensionNode",
+      "Inputs": [
+        {
+          "Id": "daa632b5b49645b9aab4fa406a3de3ef",
+          "Name": "",
+          "Description": "Node to show output from",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "951d36efe6c540509f78f0de11ae8388",
+          "Name": "",
+          "Description": "Node output",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualizes a node's output"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "4f15e035506f414ebbb6af00326c5926",
+      "End": "daa632b5b49645b9aab4fa406a3de3ef",
+      "Id": "15fb121ba3434719bba4685f85934c5d",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "dce6e645c25841a3b290a89cf3cb1f11",
+      "End": "8fd2b41b3873448c94456bc584bca00f",
+      "Id": "8dd254d6697e426993aa99db99685807",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "EnableLegacyPolyCurveBehavior": null,
+  "Thumbnail": null,
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "4.0",
+      "Data": {}
+    }
+  ],
+  "Author": "None provided",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": false,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "4.0.0.2016",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "_Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Id": "1c1cbeecc02e4c1ca880dc195d53ef29",
+        "Name": "ToString",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 271.5,
+        "Y": 69.0
+      },
+      {
+        "Id": "f359ea84d1ab468b9745f280cff75eda",
+        "Name": "Code Block",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 76.0,
+        "Y": 85.0
+      },
+      {
+        "Id": "88ecf13c40dc42c289b3375c2773f5b1",
+        "Name": "Watch",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 497.5,
+        "Y": 129.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
**Release Notes**
Removes 18 user-facing node functions that were marked with [NodeObsolete] in Dynamo 1.3.4:

CoreNodes (6 items):
ReadImage, LoadImageFromPath, ReadText, WriteImage, ExportToCSV, String.FromObject

Analysis (11 items):
PointData: ValueLocations, Values, ByPointsAndValues
SurfaceData: Surface, ValueLocations, Values, BySurfaceAndPoints, BySurfacePointsAndValues
VectorData: ValueLocations, Values, ByPointsAndValues

DSOffice (1 item):
Excel.Read(string, string)