### PR TITLE
DYN-9774: Auto-close duration for all toasts increased to 5 seconds

### DIFF
--- a/src/DynamoCoreWpf/UI/ToastManager.cs
+++ b/src/DynamoCoreWpf/UI/ToastManager.cs
@@ -15,7 +15,7 @@ namespace Dynamo.Wpf.UI
         private const double VerticalOffset = 10;
         //The HorizontalOffset is used to move horizontally the popup (using as a reference the statusBarPanel position)
         private const double HorizontalOffset = 110;
-        internal const int AutoCloseSeconds = 3;
+        internal const int AutoCloseSeconds = 5;
 
         private RealTimeInfoWindow toastPopup;
         private UIElement mainRootElement;


### PR DESCRIPTION
### Purpose

Small PR following the latest discussion  - increases the auto-close duration for all toasts to 5 seconds.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Increases the auto-close duration for all toasts to 5 seconds.

### Reviewers

@zeusongit
@DynamoDS/eidos

### FYIs

@dnenov 
@achintyabhat 
