### PR TITLE
DYN-9386: Updated Test_MarshlingPointerToCollection() to use __ToStringFromObject()

### DIFF
--- a/test/Engine/ProtoTest/FFITests/CSFFIDataMarshalingTest.cs
+++ b/test/Engine/ProtoTest/FFITests/CSFFIDataMarshalingTest.cs
@@ -796,10 +796,10 @@ d2 = TestData.SumList([1, 2, [3, 4], [5, [6, [7]]]]);
                 arr1 = TestData.JoinList([d, [1,2,3]]);
                 arr2 = TestData.JoinList([d, d, d]);
 
-                type1 = ToString(arr1[0]);
+                type1 = __ToStringFromObject(arr1[0]);
                 rank1 = List.Rank(arr1);
 
-                type2 = ToString(arr2[0]);
+                type2 = __ToStringFromObject(arr2[0]);
                 rank2 = List.Rank(arr2);
             ";
             ValidationData[] data = { 


### PR DESCRIPTION
The code that broke the test was merged to master was in PR #16676 
DYN-9386 - Remove nodes marked with [NodeObsolete] in Dynamo 1.3.4

### Purpose

Fixed failing test Updated Test_MarshlingPointerToCollection

### Release Notes

The code that broke the test was merged to master was in PR #16676 this PR fixes that

### Reviewers


### FYIs
@zeusongit