### PR TITLE
DYN-9869: Handle null Application in GetDynamoView

### DIFF
--- a/src/DynamoCoreWpf/UI/Prompts/PortPropertiesEditPrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/PortPropertiesEditPrompt.xaml.cs
@@ -140,6 +140,11 @@ namespace UI.Prompts
         // Upon inspection, both windows are direct children of the Dynamo process with no visual tree relationship
         private DynamoView GetDynamoView()
         {
+            if (Application.Current == null)
+            {
+                return null;
+            }
+
             foreach (Window window in Application.Current.Windows)
             {
                 if (window is DynamoView dynamoView)


### PR DESCRIPTION
### Purpose

Added a null check for Application.Current in GetDynamoView to prevent potential null reference exceptions when accessing application windows.
This was crashing for C3D.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Added a null check for Application.Current in GetDynamoView to prevent potential null reference exceptions when accessing application windows.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
