### PR TITLE
DYN-9806: Python migrator disabled tooltip corrected

### DIFF
--- a/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml.cs
+++ b/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml.cs
@@ -332,7 +332,7 @@ namespace PythonNodeModelsWpf
                     PythonEngineManager.PythonNet3EngineName)
                 : String.Format(
                     PythonNodeModels.Properties.Resources.PythonScriptEditorMigrationAssistantButtonDisabledTooltip,
-                    PythonEngineManager.CPython3EngineName);
+                    PythonEngineManager.PythonNet3EngineName);
             tooltip.Content = message;
         }
 


### PR DESCRIPTION
### Purpose

Small PR to correct the Python engine name in the 2->3 migrator when disabled.

<img width="943" height="567" alt="Screenshot 2025-11-18 070458" src="https://github.com/user-attachments/assets/01762a53-34d6-417a-8946-363c23804429" />

 

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Small PR to correct the Python engine name in the 2->3 migrator when disabled.

### Reviewers

@zeusongit
@DynamoDS/eidos

### FYIs

@dnenov 
