### PR TITLE
DYN-9876: Handle null NodeModel, or failed focus command for the graph node manager extension.

### DIFF
--- a/src/GraphNodeManagerViewExtension/GraphNodeManagerViewModel.cs
+++ b/src/GraphNodeManagerViewExtension/GraphNodeManagerViewModel.cs
@@ -299,6 +299,12 @@ namespace Dynamo.GraphNodeManager
             }
             catch
             {
+                // Suppress exceptions from selection or focus commands.
+                // Known failure scenarios include:
+                // - Node not found (invalid GUID)
+                // - UI not ready to process focus command
+                // - Transient UI errors during command execution
+                // These are intentionally ignored to prevent UI crashes or interruptions.
                 return;
             }
         }


### PR DESCRIPTION
### Purpose

Handle null NodeModel, or failed focus command for the graph node manager extension.
This caused sporadic crashes as per task description, submitting a quick fix.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Handle null NodeModel, or failed focus command for the graph node manager extension.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
