### PR TITLE
[Cherry-pick] DYN-9871: Loading Python backup files gives errors (#16735)

### DIFF
--- a/src/DynamoCore/Migration/PythonEngineUpgradeService.cs
+++ b/src/DynamoCore/Migration/PythonEngineUpgradeService.cs
@@ -151,7 +151,7 @@ namespace Dynamo.Models.Migration.Python
                     if (!TryGetCustomIdAndPath(cws, out var resolvedDefId, out var dyfPath)
                         || string.IsNullOrEmpty(dyfPath)) continue;
 
-                    SaveCustomNodeBackup(
+                    SaveMigrationBackup(
                         cws,
                         dyfPath,
                         PythonServices.PythonEngineManager.CPython3EngineName);
@@ -177,7 +177,7 @@ namespace Dynamo.Models.Migration.Python
         /// <summary>
         /// Build a backup file path for a .dyn or .dyf backup
         /// </summary>
-        public string BuildDynBackupFilePath(WorkspaceModel workspace, string token)
+        public string BuildBackupFilePath(WorkspaceModel workspace, string token)
         {
             if (workspace == null || pathManager == null) return null;
             if (DynamoModel.IsTestMode) return null;
@@ -195,42 +195,26 @@ namespace Dynamo.Models.Migration.Python
         }
 
         /// <summary>
-        /// Save a .dyn backup of the given workspace with the given token.
-        /// </summary>
-        public string SaveGraphBackup(WorkspaceModel workspace, string token)
-        {
-            var path = BuildDynBackupFilePath(workspace, token);
-            if (string.IsNullOrEmpty(path)) return null;
-
-            try
-            {
-                workspace.Save(path, true);
-                return path;
-            }
-            catch (Exception ex)
-            {
-                this.dynamoModel?.Logger?.Log(ex);
-                return null;
-            }
-        }
-
-        /// <summary>
         /// Save a .dyf backup of the given custom node workspace before engine upgrade.
         /// </summary>
-        private string SaveCustomNodeBackup(WorkspaceModel workspace, string sourcePath, string token) 
+        internal void SaveMigrationBackup(WorkspaceModel workspace, string sourcePath, string token) 
         {
-            var backupPath = BuildDynBackupFilePath(workspace, token);
-            if (string.IsNullOrEmpty(backupPath)) return null;
+            var backupPath = BuildBackupFilePath(workspace, token);
+            if (string.IsNullOrEmpty(backupPath)) return;
 
             try
             {
+                var dir = Path.GetDirectoryName(backupPath);
+                if (!string.IsNullOrEmpty(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+
                 File.Copy(sourcePath, backupPath);
-                return backupPath;
             }
             catch (Exception ex)
             {
                 this.dynamoModel?.Logger?.Log(ex);
-                return null;
             }
         }
 

--- a/src/PythonMigrationViewExtension/MigrationAssistant/PythonMigrationAssistantViewModel.cs
+++ b/src/PythonMigrationViewExtension/MigrationAssistant/PythonMigrationAssistantViewModel.cs
@@ -113,10 +113,16 @@ namespace Dynamo.PythonMigration.MigrationAssistant
         {
             // only create a backup file the first time a migration is performed on this graph/custom node file
             var path = GetPythonMigrationBackupPath();
-            if (File.Exists(path))
-                return;
+            if (File.Exists(path)) return;
 
-            this.workspace.Save(path, true);
+            var dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+
+            var json = workspace.GetStringRepOfWorkspace();
+            File.WriteAllText(path, json);
 
             // notify user a backup file has been created
             if (!Models.DynamoModel.IsTestMode)


### PR DESCRIPTION
Cherry-pick of #16735 to `RC4.0.0_master` 
### Purpose

This PR addresses [DYN-9871](https://jira.autodesk.com/browse/DYN-9871) where backup files created during Python migration load with all nodes positioned at (0,0).

**The root cause was twofold:**
- automatic migration backups were created before the view had finished loading, so the View section in the .dyn file was missing.
- manual migration backups (via `PythonMigrationAssistantViewModel`) used `WorkspaceModel.Save`, which only serializes the model, not the view.

**Summary of Changes**
- Automatic migration:
  - backups for both .dyn and .dyf files now use `File.Copy` . This guarantees a exact copy of the user’s last saved file and removes the dependency on view loading order
- Manual migration:
- backup creation now uses `WorkspaceModel.GetStringRepOfWorkspace()`, to make sure the serialized file includes both model and view data. This should be safe because manual migration only occurs when the workspace and view are already fully initialized

**Possible alternatives:**
Two UI-dependent approaches were evaluated for the automatic migration case:
- use `WorkspaceViewModel.Save` with a `Dispatcher.BeginInvoke` to delay backup creation until the view is ready
- hook into `Loaded` to trigger backup creation at the exact moment the view finishes loading

Both solutions work, but were rejected because they introduce tighter coupling to the UI layer and rely on UI timing, whereas using `File.Copy` is simpler, more robust, and works in both headless and UI scenarios.


![DYN-9871-fix](https://github.com/user-attachments/assets/781ca80b-42d6-4056-9bad-0f97a22b01bc)


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixes Python migration backups so node positions are preserved by copying saved graphs for auto-migration and fully serializing view data during manual migration.

### Reviewers

@zeusongit
@DynamoDS/eidos

### FYIs

@dnenov 
@achintyabhat 
