### PR TITLE
DYN-9879: Py Engine Change pops up erroneously

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1755,7 +1755,11 @@ namespace Dynamo.Controls
 
             // Show the one-time Python Engine Change notification for the workspace
             var ws = dynamoViewModel.Model.CurrentWorkspace;
-            if (!ws.HasShownPythonAutoMigrationNotification && ws.ShowPythonAutoMigrationNotifications)
+            var prefSettings = dynamoViewModel.Model.PreferenceSettings;
+
+            if (!ws.HasShownPythonAutoMigrationNotification
+                && ws.ShowPythonAutoMigrationNotifications
+                && prefSettings.ShowPythonAutoMigrationNotifications)
             {
                 var cancelFirstDialogBox = ShowPythonEngineChangeNoticeAndMarkIfProceed();
                 if (cancelFirstDialogBox)

--- a/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
+++ b/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
@@ -343,6 +343,7 @@ namespace Dynamo.PythonMigration
             // Close the CPython toast notification when workspace is cleared/closed
             DynamoViewModel.ToastManager?.CloseRealTimeInfoWindow();
             lastWorkspaceGuid = Guid.Empty;
+            CurrentWorkspace.ShowPythonAutoMigrationNotifications = false;
         }
 
         private void OnWorkspaceRemoveStarted(IWorkspaceModel workspace)
@@ -515,7 +516,7 @@ namespace Dynamo.PythonMigration
                     customCount,
                     LoadedParams.StartupParams.PathManager.BackupDirectory);
 
-                CurrentWorkspace.ShowPythonAutoMigrationNotifications = preferenceSettings.ShowPythonAutoMigrationNotifications;
+                CurrentWorkspace.ShowPythonAutoMigrationNotifications = true;
             }
         }
 


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-9879](https://jira.autodesk.com/browse/DYN-9879).

Fixes an issue where the “Hide Python engine change notifications” preference did not persist reliably.
Also ensures that `WorkspaceModel.ShowPythonAutoMigrationNotifications` is reset to `false` when creating new workspaces.

![DYN-9879-fix1](https://github.com/user-attachments/assets/5c4b19ae-14cd-4fe0-aef3-a17714345ebc)


![DYN-9879-fix2](https://github.com/user-attachments/assets/18d63f79-3b53-4b13-a807-38f5f8e7a27a)



### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixes an issue where the “Hide Python engine change notifications” preference did not persist reliably.
Also ensures that `WorkspaceModel.ShowPythonAutoMigrationNotifications` is reset to `false` when creating new workspaces.

### Reviewers

@zeusongit
@DynamoDS/eidos

### FYIs

@dnenov 
@achintyabhat 
@jnealb