### PR TITLE
DYN-9542: Make RC4.0 stable nugets

### DIFF
--- a/tools/NuGet/BuildPackages.bat
+++ b/tools/NuGet/BuildPackages.bat
@@ -37,7 +37,7 @@ for /f %%f in ('cscript //Nologo ..\install\GetFileVersion.vbs %harvestPath%\Dyn
   set /a count=!count!+1
 )
 setlocal DisableDelayedExpansion
-set version=%Major%.%Minor%.%Build%-beta%Revision%
+set version=%Major%.%Minor%.%Build%.%Revision%
 
 for /f %%i in ('git rev-parse HEAD') do set COMMIT=%%i
 


### PR DESCRIPTION
### Purpose

Removing the beta keywork for release nugets

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Removing the beta keywork for release nugets

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
