### PR TITLE
DYN-9622: Fix typo in 'Navigate Downstream' menu text

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.en-GB.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-GB.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -3198,7 +3198,7 @@ You can manage this in Preferences -&gt; Security.</value>
     <value>Navigate Upstream</value>
   </data>
   <data name="ConnectorContextMenuHeaderEndNode" xml:space="preserve">
-    <value>Navigate Downtream</value>
+    <value>Navigate Downstream</value>
   </data>
   <data name="ContextMenuNodeConnections" xml:space="preserve">
     <value>Node Connections</value>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3537,7 +3537,7 @@ You can manage this in Preferences -&gt; Security.</value>
     <value>Navigate Upstream</value>
   </data>
   <data name="ConnectorContextMenuHeaderEndNode" xml:space="preserve">
-    <value>Navigate Downtream</value>
+    <value>Navigate Downstream</value>
   </data>
   <data name="ContextMenuNodeConnections" xml:space="preserve">
     <value>Node Connections</value>

--- a/src/DynamoCoreWpf/Properties/Resources.zh-CN.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.zh-CN.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -3196,7 +3196,7 @@
     <value>向上浏览</value>
   </data>
   <data name="ConnectorContextMenuHeaderEndNode" xml:space="preserve">
-    <value>导航 Downtream</value>
+    <value>导航 Downstream</value>
   </data>
   <data name="ContextMenuNodeConnections" xml:space="preserve">
     <value>节点连接</value>


### PR DESCRIPTION
### Purpose

PR in response to [DYN-9622] (https://jira.autodesk.com/browse/DYN-9622).

Corrected the spelling of 'Downstream' in the ConnectorContextMenuHeaderEndNode resource across en-GB, en-US, and zh-CN localisation files.

<img width="1920" height="1032" alt="Screenshot 2025-12-09 133216" src="https://github.com/user-attachments/assets/62da0b20-18f0-47bd-874a-9320b907c3bc" />


### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Corrected the spelling of 'Downstream' in the Connector Context Menu

### Reviewers
@zeusongit

### FYIs
@dnenov
