### PR TITLE
DYN-8136 - Extensions Tab Icon 

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -365,7 +365,7 @@
                                       Header="{x:Static p:Resources.DynamoViewFileMenuGraphPropertiesGeneral}" />
                             <!-- Host properties panel to be implemented in Dynamo C4D later -->
                             <!--<MenuItem Name="advanced"
-                                      Header="{x:Static p:Resources.DynamoViewFileMenuGraphPropertiesAdvanced}" />-->                            
+                                      Header="{x:Static p:Resources.DynamoViewFileMenuGraphPropertiesAdvanced}" />-->
                         </MenuItem>
                         <Separator />
                         <MenuItem Name="exportMenu"
@@ -660,13 +660,7 @@
                     <MenuItem Name="ExtensionsMenu"
                               Focusable="False"
                               Header="{x:Static p:Resources.DynamoViewExtensionsMenu}"
-                              IsEnabled="True"
-                              Style="{StaticResource ExtensionsStyle}">
-                        <MenuItem.Icon>
-                            <Image Width="14"
-                                   Height="14"
-                                   Source="/DynamoCoreWpf;component/UI/Images/pin.png" />
-                        </MenuItem.Icon>
+                              IsEnabled="True">
                     </MenuItem>
 
                     <MenuItem Focusable="False"
@@ -1310,7 +1304,7 @@
                                                     </MultiDataTrigger.Conditions>
                                                     <!--  The value of the unsaved Workspace tab text field  -->
                                                     <Setter Property="Text" Value="Workspace" />
-                                                </MultiDataTrigger> 
+                                                </MultiDataTrigger>
                                                 <MultiDataTrigger>
                                                     <MultiDataTrigger.Conditions>
                                                         <Condition Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}" Value="{x:Type workspaces:CustomNodeWorkspaceModel}" />


### PR DESCRIPTION
### Purpose

Ensure the Extensions tab on the menu bar has a downward arrow icon so all tabs have uniform icons. Use the same icons as Help tab. [(](https://jira.autodesk.com/browse/DYN-8136)[DYN](https://jira.autodesk.com/browse/DYN-8136)[-](https://jira.autodesk.com/browse/DYN-8136)[8136](https://jira.autodesk.com/browse/DYN-8136)[)](https://jira.autodesk.com/browse/DYN-8136)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
 
<img width="1012" height="173" alt="image" src="https://github.com/user-attachments/assets/26dca8c3-d1aa-4229-84fe-4ffac6e35287" />

### Release Notes
Extensions menu will appear same as other menus on the top of the home screen.

### Reviewers

@reddyashish, @achintyabhat 

### FYIs

@stevecbc