### PR TITLE
DYN-9829: Show Python Engine change notification label updated

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -8389,24 +8389,6 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hide Python Engine change notifications.
-        /// </summary>
-        public static string PreferencesViewHidePythonEngineChangeNotifications {
-            get {
-                return ResourceManager.GetString("PreferencesViewHidePythonEngineChangeNotifications", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to CPython is no longer supported in Dynamo 4.0 or above and will be converted to the new default engine PythonNet3. Disable the toggle to hide all notifications about engine changes..
-        /// </summary>
-        public static string PreferencesViewHidePythonEngineChangeNotificationsTooltip {
-            get {
-                return ResourceManager.GetString("PreferencesViewHidePythonEngineChangeNotificationsTooltip", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to When toggled on, file names of exported images include date and time of export..
         /// </summary>
         public static string PreferencesViewIncludeTimestampExportPathTooltip {
@@ -8565,6 +8547,24 @@ namespace Dynamo.Wpf.Properties {
         public static string PreferencesViewShowPreviewBubbles {
             get {
                 return ResourceManager.GetString("PreferencesViewShowPreviewBubbles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show Python Engine change notifications.
+        /// </summary>
+        public static string PreferencesViewShowPythonEngineChangeNotifications {
+            get {
+                return ResourceManager.GetString("PreferencesViewShowPythonEngineChangeNotifications", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CPython is no longer supported in Dynamo 4.0 or above and will be converted to the new default engine PythonNet3. Disable the toggle to hide all notifications about engine changes..
+        /// </summary>
+        public static string PreferencesViewShowPythonEngineChangeNotificationsTooltip {
+            get {
+                return ResourceManager.GetString("PreferencesViewShowPythonEngineChangeNotificationsTooltip", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -4213,10 +4213,10 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="PreferencesViewHideOutportsDescription" xml:space="preserve">
     <value>Hide unconnected output ports by default</value>
   </data>
-  <data name="PreferencesViewHidePythonEngineChangeNotifications" xml:space="preserve">
-    <value>Hide Python Engine change notifications</value>
+  <data name="PreferencesViewShowPythonEngineChangeNotifications" xml:space="preserve">
+    <value>Show Python Engine change notifications</value>
   </data>
-  <data name="PreferencesViewHidePythonEngineChangeNotificationsTooltip" xml:space="preserve">
+  <data name="PreferencesViewShowPythonEngineChangeNotificationsTooltip" xml:space="preserve">
     <value>CPython is no longer supported in Dynamo 4.0 or above and will be converted to the new default engine PythonNet3. Disable the toggle to hide all notifications about engine changes.</value>
   </data>
   <data name="MessageBoxDontShowAgainLabel" xml:space="preserve">

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -4200,10 +4200,10 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="PreferencesViewHideOutportsDescription" xml:space="preserve">
     <value>Hide unconnected output ports by default</value>
   </data>
-  <data name="PreferencesViewHidePythonEngineChangeNotifications" xml:space="preserve">
-    <value>Hide Python Engine change notifications</value>
+  <data name="PreferencesViewShowPythonEngineChangeNotifications" xml:space="preserve">
+    <value>Show Python Engine change notifications</value>
   </data>
-  <data name="PreferencesViewHidePythonEngineChangeNotificationsTooltip" xml:space="preserve">
+  <data name="PreferencesViewShowPythonEngineChangeNotificationsTooltip" xml:space="preserve">
     <value>CPython is no longer supported in Dynamo 4.0 or above and will be converted to the new default engine PythonNet3. Disable the toggle to hide all notifications about engine changes.</value>
   </data>
   <data name="MessageBoxDontShowAgainLabel" xml:space="preserve">

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -2878,8 +2878,6 @@ Dynamo.ViewModels.PreferencesViewModel.GroupStyleFontSizeList.set -> void
 Dynamo.ViewModels.PreferencesViewModel.HideAutocompleteMethodOptions.get -> bool
 Dynamo.ViewModels.PreferencesViewModel.HideNodesBelowSpecificConfidenceLevelIsChecked.get -> bool
 Dynamo.ViewModels.PreferencesViewModel.HideNodesBelowSpecificConfidenceLevelIsChecked.set -> void
-Dynamo.ViewModels.PreferencesViewModel.HidePythonAutoMigrationNotificationIsChecked.get -> bool
-Dynamo.ViewModels.PreferencesViewModel.HidePythonAutoMigrationNotificationIsChecked.set -> void
 Dynamo.ViewModels.PreferencesViewModel.HostGenericScaleUnits.get -> string
 Dynamo.ViewModels.PreferencesViewModel.importSettings(string filePath) -> bool
 Dynamo.ViewModels.PreferencesViewModel.importSettingsContent(string content) -> bool
@@ -2963,6 +2961,8 @@ Dynamo.ViewModels.PreferencesViewModel.ShowDefaultGroupDescription.get -> bool
 Dynamo.ViewModels.PreferencesViewModel.ShowDefaultGroupDescription.set -> void
 Dynamo.ViewModels.PreferencesViewModel.ShowEdges.get -> bool
 Dynamo.ViewModels.PreferencesViewModel.ShowEdges.set -> void
+Dynamo.ViewModels.PreferencesViewModel.ShowPythonAutoMigrationNotificationIsChecked.get -> bool
+Dynamo.ViewModels.PreferencesViewModel.ShowPythonAutoMigrationNotificationIsChecked.set -> void
 Dynamo.ViewModels.PreferencesViewModel.UnconnectedOutputsCollapsed.get -> bool
 Dynamo.ViewModels.PreferencesViewModel.UnconnectedOutputsCollapsed.set -> void
 Dynamo.ViewModels.PreferencesViewModel.UseRenderInstancing.get -> bool
@@ -5502,8 +5502,8 @@ static Dynamo.Wpf.Properties.Resources.PreferencesViewGeneralTab.get -> string
 static Dynamo.Wpf.Properties.Resources.PreferencesViewGroupStylesHeader.get -> string
 static Dynamo.Wpf.Properties.Resources.PreferencesViewHideInportsDescription.get -> string
 static Dynamo.Wpf.Properties.Resources.PreferencesViewHideOutportsDescription.get -> string
-static Dynamo.Wpf.Properties.Resources.PreferencesViewHidePythonEngineChangeNotifications.get -> string
-static Dynamo.Wpf.Properties.Resources.PreferencesViewHidePythonEngineChangeNotificationsTooltip.get -> string
+static Dynamo.Wpf.Properties.Resources.PreferencesViewShowPythonEngineChangeNotifications.get -> string
+static Dynamo.Wpf.Properties.Resources.PreferencesViewShowPythonEngineChangeNotificationsTooltip.get -> string
 static Dynamo.Wpf.Properties.Resources.PreferencesViewIncludeTimestampExportPathTooltip.get -> string
 static Dynamo.Wpf.Properties.Resources.PreferencesViewLanguageLabel.get -> string
 static Dynamo.Wpf.Properties.Resources.PreferencesViewLanguageSwitchHelp.get -> string

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -1080,13 +1080,13 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Controls the IsChecked property in the "Hide CPython notifications" toggle button
         /// </summary>
-        public bool HidePythonAutoMigrationNotificationIsChecked
+        public bool ShowPythonAutoMigrationNotificationIsChecked
         {
-            get => !preferenceSettings.ShowPythonAutoMigrationNotifications;
+            get => preferenceSettings.ShowPythonAutoMigrationNotifications;
             set
             {
-                preferenceSettings.ShowPythonAutoMigrationNotifications = !value;
-                RaisePropertyChanged(nameof(HidePythonAutoMigrationNotificationIsChecked));
+                preferenceSettings.ShowPythonAutoMigrationNotifications = value;
+                RaisePropertyChanged(nameof(ShowPythonAutoMigrationNotificationIsChecked));
             }
         }
 
@@ -1900,8 +1900,8 @@ namespace Dynamo.ViewModels
                 case nameof(ShowWhitespaceIsChecked):
                     description = Res.ResourceManager.GetString(nameof(Res.PreferencesViewShowWhitespaceInPythonEditor), System.Globalization.CultureInfo.InvariantCulture);
                     goto default;
-                case nameof(HidePythonAutoMigrationNotificationIsChecked):
-                    description = Res.ResourceManager.GetString(nameof(Res.PreferencesViewHidePythonEngineChangeNotifications), System.Globalization.CultureInfo.InvariantCulture);
+                case nameof(ShowPythonAutoMigrationNotificationIsChecked):
+                    description = Res.ResourceManager.GetString(nameof(Res.PreferencesViewShowPythonEngineChangeNotifications), System.Globalization.CultureInfo.InvariantCulture);
                     goto default;
                 case nameof(NodeAutocompleteIsChecked):
                     description = Res.ResourceManager.GetString(nameof(Res.PreferencesViewEnableNodeAutoComplete), System.Globalization.CultureInfo.InvariantCulture);

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -787,9 +787,9 @@
                                                       Width="{StaticResource ToggleButtonWidth}"
                                                       Height="{StaticResource ToggleButtonHeight}"
                                                       VerticalAlignment="Center"
-                                                      IsChecked="{Binding Path=HidePythonAutoMigrationNotificationIsChecked}"
+                                                      IsChecked="{Binding Path=ShowPythonAutoMigrationNotificationIsChecked}"
                                                       Style="{StaticResource EllipseToggleButton1}"/>
-                                        <Label Content="{x:Static p:Resources.PreferencesViewHidePythonEngineChangeNotifications}"
+                                        <Label Content="{x:Static p:Resources.PreferencesViewShowPythonEngineChangeNotifications}"
                                                VerticalAlignment="Center"
                                                Margin="10,0,0,0"
                                                Foreground="{StaticResource PreferencesWindowFontColor}"/>
@@ -803,7 +803,7 @@
                                                    Style="{StaticResource QuestionIconClickable}"
                                                    ToolTipService.ShowDuration="30000">
                                                 <Image.ToolTip>
-                                                    <ToolTip Content="{x:Static p:Resources.PreferencesViewHidePythonEngineChangeNotificationsTooltip}"
+                                                    <ToolTip Content="{x:Static p:Resources.PreferencesViewShowPythonEngineChangeNotificationsTooltip}"
                                                              Style="{StaticResource GenericToolTipLight}"/>
                                                 </Image.ToolTip>
                                             </Image>


### PR DESCRIPTION
### Purpose

This PR is related to [DYN-9829](https://jira.autodesk.com/browse/DYN-9829)

It updates the label of the Python engine change notification toggle in the Preferences window to remove the double negative. The toggle is off by default.

<img width="1001" height="732" alt="Screenshot 2025-12-17 173058" src="https://github.com/user-attachments/assets/8b75b755-c99d-425d-b7f2-f5e6b552f3d3" />


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Changes update the label of the Python engine change notification toggle in the Preferences window to remove the double negative. The toggle is off by default.

### Reviewers

@zeusongit
@DynamoDS/eidos

### FYIs

@dnenov
@jnealb
