### PR TITLE
DYN-8945: Improve npm registry reachability check in script

### DIFF
--- a/src/setnpmreg.ps1
+++ b/src/setnpmreg.ps1
@@ -23,7 +23,6 @@ function Test-UrlReachable {
         return $true
     }
     catch {
-        Write-Host "Error: $($_.Exception.Message)" -ForegroundColor Yellow
         return $false
     }
     finally {
@@ -31,20 +30,14 @@ function Test-UrlReachable {
     }
 }
 
-try {
-    Write-Host "Checking if adsk npm registry is reachable..." -ForegroundColor Blue
-    
-    if (Test-UrlReachable -url $adskNpmRegistry) {
-        Write-Host "adsk npm registry is reachable" -ForegroundColor Green
-        createNpmrcFile -registry $adskNpmRegistry
-        Write-Output "//npm.autodesk.com/artifactory/api/npm/:_authToken=`${NPM_TOKEN}" | Out-File -FilePath .npmrc -Encoding UTF8 -Append
-    }
-    else {
-        Write-Host "adsk npm registry is not reachable" -ForegroundColor Red
-        createNpmrcFile -registry $npmRegistry
-    }
+Write-Host "Checking if adsk npm registry is reachable..." -ForegroundColor Blue
+
+if (Test-UrlReachable -url $adskNpmRegistry) {
+    Write-Host "adsk npm registry is reachable" -ForegroundColor Green
+    createNpmrcFile -registry $adskNpmRegistry
+    Write-Output "//npm.autodesk.com/artifactory/api/npm/:_authToken=`${NPM_TOKEN}" | Out-File -FilePath .npmrc -Encoding UTF8 -Append
 }
-catch {
+else {
     Write-Host "adsk npm registry is not reachable" -ForegroundColor Red
     createNpmrcFile -registry $npmRegistry
 }


### PR DESCRIPTION
### Purpose

Replaces Invoke-WebRequest with a custom Test-UrlReachable function using WebClient for checking registry availability. Adds error message output when the adsk npm registry is not reachable for better troubleshooting. The original script was failing on perf CI pipelines.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

- Replaces Invoke-WebRequest with a custom Test-UrlReachable function using WebClient for checking registry availability

### Reviewers

@DynamoDS/eidos 
