### PR TITLE
DYN-8945: Upgrade performance test to net10

### DIFF
--- a/tools/Performance/DynamoPerformanceTests/PerformanceTestHelper.cs
+++ b/tools/Performance/DynamoPerformanceTests/PerformanceTestHelper.cs
@@ -108,7 +108,7 @@ namespace DynamoPerformanceTests
             /// </summary>
             protected Job JobDefault = Job.Default
                 .WithPlatform(BenchmarkDotNet.Environments.Platform.X64)
-                .WithRuntime(CoreRuntime.CreateForNewVersion("net8.0-windows7.0", "NET 8.0"));
+                .WithRuntime(CoreRuntime.CreateForNewVersion("net10.0-windows7.0", "NET 10.0"));
 
             public DynamoBenchmarkConfigBase()
             {


### PR DESCRIPTION
### Purpose

In an earlier PR we fixed running nightly performance tests pipeline, in this PR we fix the error that failed those tests or atleast gave us incomplete results, running this locally fixed the tests with net10 upgrade.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

- Upgrade performance test to net10

### Reviewers

