### PR TITLE
DYN-10101 : dynamo opens wrong samples directory when opening containing folder for a different locale

### DIFF
--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -278,15 +278,21 @@ namespace Dynamo.Core
             {
                 if (samplesDirectory == null)
                 {
-                    var locale = (Preferences as PreferenceSettings)?.Locale ?? CultureInfo.CurrentUICulture.Name;
+                    var preferences = Preferences as PreferenceSettings;
+                    var locale = preferences?.Locale ?? CultureInfo.CurrentUICulture.Name;
 
-                    if (locale == "Default")
+                    if (string.Equals(locale, "Default", StringComparison.OrdinalIgnoreCase))
                     {
-                        locale = string.IsNullOrEmpty(Dynamo.Models.DynamoModel.HostAnalyticsInfo.HostName)
-                            ? Configurations.FallbackUiCulture
-                            : (CultureInfo.DefaultThreadCurrentCulture ?? new CultureInfo(Configurations.FallbackUiCulture)).Name;
-                    }
+                        // When locale is "Default", resolve from process cultures in priority order:
+                        // 1. DefaultThreadCurrentCulture (explicitly set by host/application)
+                        // 2. CurrentUICulture (current thread's UI culture)
+                        // 3. FallbackUiCulture (Dynamo's default: "en-US")
+                        var effectiveCulture = CultureInfo.DefaultThreadCurrentCulture
+                                            ?? CultureInfo.CurrentUICulture
+                                            ?? new CultureInfo(Configurations.FallbackUiCulture);
 
+                        locale = effectiveCulture.Name;
+                    }
                     samplesDirectory = GetSamplesFolder(commonDataDir, locale);
                 }
                 return samplesDirectory;

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -521,7 +521,8 @@ namespace Dynamo.Tests.Configuration
 
             // Assert - samples path should contain the locale
             Assert.That(samplesPath, Is.Not.Null);
-            Assert.That(samplesPath, Does.EndWith(@"samples\es-ES"));
+            var expectedPathSegment = Path.Combine("samples", "es-ES");
+            Assert.That(samplesPath, Does.EndWith(expectedPathSegment));
         }
     }
 }


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-10101](https://jira.autodesk.com/browse/DYN-10101), where the open containing folder action on sample files always opened the `en-US` samples directory, regardless of the user's locale preference setting in Dynamo.

The issue was an initialization order problem:
`PathManager` was constructed and `samplesDirectory` was set using `CultureInfo.CurrentUICulture`. At this point preferences are not loaded yet, so `CurrentUICulture` was always the system default.

Proposed resolution:
- removed initialization of `samplesDirectory` in `PathManager.BuildCommonDirectories`
- converted `SamplesDirectory` to a lazy-loading property that calculates the path on first access
- at first access, preferences are already loaded, so the correct locale is used
- added logic to handle the "Default" locale setting by falling back to `en-US`
- refactored `GetSamplesFolder` to accept a `locale` argument
- added unit test

 
![DYN-10101](https://github.com/user-attachments/assets/a203266a-af6a-4702-8c26-13babd4df03c)


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixes a bug where the open containing folder action on sample files always opened the `en-US` samples directory, regardless of the user's locale preference setting in Dynamo.

### Reviewers

@zeusongit
@DynamoDS/eidos

### FYIs

@dnenov 
@achintyabhat 
