### PR TITLE
DYN-10112: Notes should not overlay warning/error/info bubbles over nodes

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/InfoBubbleView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/InfoBubbleView.xaml.cs
@@ -30,6 +30,7 @@ namespace Dynamo.Controls
         private bool isResizing = false;
         private bool isResizeHeight = false;
         private bool isResizeWidth = false;
+        private double previousZIndex = 0;
 
         private InfoBubbleViewModel viewModel = null;
 
@@ -1057,7 +1058,7 @@ namespace Dynamo.Controls
 
             InfoBubbleViewModel.NodeMessageVisibility nodeMessageVisibility = InfoBubbleViewModel.NodeMessageVisibility.Icon;
             HorizontalAlignment horizontalAlignment = HorizontalAlignment.Left;
-
+            ViewModel.ZIndex = previousZIndex;
             switch (border.Name)
             {
                 case "InfoBorder":
@@ -1091,7 +1092,9 @@ namespace Dynamo.Controls
             HorizontalAlignment left = HorizontalAlignment.Left;
 
             bool isIcon;
-            
+            // boost bubble's z-index to make sure the expanded content won't be blocked by other elements.
+            previousZIndex = ViewModel.ZIndex;
+            ViewModel.ZIndex = int.MaxValue - 1;
             switch (border.Name)
             {
                 case "InfoBorder":


### PR DESCRIPTION
### Purpose

Simplified approach:
Boosted z-index on mouse enter to max value and restore on mouse leave
### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

- Info bubbles render above nodes and notes reliably when visible.

