### PR TITLE
DYN-10073: Fixed custom graph property value wrapping

### DIFF
--- a/src/GraphMetadataViewExtension/Controls/CustomPropertyControl.xaml
+++ b/src/GraphMetadataViewExtension/Controls/CustomPropertyControl.xaml
@@ -73,7 +73,7 @@
                  Foreground="{StaticResource NestedMemberTextColor}"
                  Margin="0,5"
                  Padding="0,5"
-                 TextWrapping="WrapWithOverflow"
+                 TextWrapping="Wrap"
                  HorizontalAlignment="Stretch"
                  Text="{Binding PropertyValue, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
     </Grid>


### PR DESCRIPTION
This PR solves the issue described in DYN-10073.

Very simple PR, updating an attribute on the text field so that it wraps properly.

Release Notes
Custom graph property value text field wraps properly

Reviewers
@johnpierson