### PR TITLE
DYN-9823: This Visual is not connected to a PresentationSource.

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -1593,7 +1593,7 @@ namespace Dynamo.Controls
             }));
         }
 
-        private bool TryPointToLocal(double x, double y, UIElement target, out Point result)
+        private static bool TryPointToLocal(double x, double y, UIElement target, out Point result)
         {
             result = default;
             try


### PR DESCRIPTION
### Purpose

DYN-9823: - Fix crash when the Node AutoComplete popup placement runs while the visual tree is in a transient state. `PointToScreen` can throw "This Visual is not connected to a PresentationSource" during layout, rapid node movement/deletion, or tab switching.

This is a very tricky error to reproduce and while i was able to repro locally, i was not able to do so consistently. One way is to move the node attached to the autocomplete view very fast and deleting the node while doing so, but that only crashes 1 out of 20 times when done right and using some luck.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixed crash when moving a node very fast and simultaneously deleting a node with the Node AutoComplete bar open.

### Reviewers

@DynamoDS/synapse 

### FYIs

@avidit 