### PR TITLE
[Cherry-pick] DYN-10383: Fix SplashScreen close re-entrancy crash in LaunchDynamo

### DIFF
--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -331,9 +331,16 @@ namespace Dynamo.UI.Views
                 viewModel.PreferenceSettings.EnableStaticSplashScreen = !isCheckboxChecked;
             }
             currentCloseMode = CloseMode.ByStartingDynamo;
-            Close();
+
             dynamoView?.Show();
             dynamoView?.Activate();
+
+            // Defer closing the splash screen until the dispatcher is idle.
+            // This method is invoked from a WebView2 JS-to-.NET callback, so calling Close()
+            // synchronously can trigger webView.Dispose() while still inside that callback,
+            // causing re-entrancy crashes. Showing dynamoView first ensures WPF always has a
+            // visible window, preventing ShutdownMode.OnLastWindowClose from terminating the app.
+            Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.ApplicationIdle, new Action(Close));
         }
 
         private void OnLoginStateChanged(LoginState state)

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -340,7 +340,7 @@ namespace Dynamo.UI.Views
             // synchronously can trigger webView.Dispose() while still inside that callback,
             // causing re-entrancy crashes. Showing dynamoView first ensures WPF always has a
             // visible window, preventing ShutdownMode.OnLastWindowClose from terminating the app.
-            Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.ApplicationIdle, new Action(Close));
+            Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.ApplicationIdle, () => Close());
         }
 
         private void OnLoginStateChanged(LoginState state)


### PR DESCRIPTION
### Purpose

Cherry-pick of #17038 to `RC4.1.0_master`.
DYN-10383 - Fix SplashScreen close re-entrancy crash in LaunchDynamo

Fix a re-entrancy crash in `SplashScreen.LaunchDynamo` where calling `Close()` synchronously inside a WebView2 JS-to-.NET callback triggers `webView.Dispose()` while still on the WebView2 call stack. This manifests as a native process termination (0xC000041D) under the Visual Studio debugger.

**Changes:**
- Move `dynamoView?.Show()` / `Activate()` before the close to ensure WPF always has a visible window, preventing `ShutdownMode.OnLastWindowClose` races.
- Replace synchronous `Close()` with `Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, () => Close())` to defer teardown until the WebView2 callback has fully unwound.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fix a splash screen crash caused by re-entrancy when closing the splash window during a WebView2 callback, by deferring the close until the dispatcher is idle.

### Reviewers

@QilongTang

### FYIs

N/A