### PR TITLE
DYN-10380 Unpinning a grouped note no longer ejects it from the group

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -420,18 +420,11 @@ namespace Dynamo.ViewModels
 
         private void UnpinFromNode(object parameters)
         {
-            // Find the group containing this note before recording so we
-            // can include its AnnotationModel in the same undo action group.
-            AnnotationViewModel noteGroup = WorkspaceViewModel.Annotations
-                .FirstOrDefault(x => x.AnnotationModel.ContainsModel(Model));
-
             if (!Model.SuppressUndoRecording)
             {
-                List<ModelBase> modelsToRecord = new List<ModelBase> { Model };
-                if (noteGroup != null)
-                    modelsToRecord.Add(noteGroup.AnnotationModel);
-
-                WorkspaceModel.RecordModelsForModification(modelsToRecord, WorkspaceViewModel.Model.UndoRecorder);
+                WorkspaceModel.RecordModelsForModification(
+                    new List<ModelBase> { Model },
+                    WorkspaceViewModel.Model.UndoRecorder);
             }
             Model.SuppressUndoRecording = false;
 
@@ -439,12 +432,6 @@ namespace Dynamo.ViewModels
             // can still access the node reference via subscribedPinnedNode.
             UnsuscribeFromPinnedNode();
             Model.PinnedNode = null;
-
-            if (noteGroup != null)
-            {
-                noteGroup.AnnotationModel.Nodes = noteGroup.AnnotationModel.Nodes
-                    .Where(n => n.GUID != Model.GUID);
-            }
 
             DynamoSelection.Instance.ClearSelection();
             WorkspaceViewModel.HasUnsavedChanges = true;

--- a/test/DynamoCoreWpf3Tests/NoteViewTests.cs
+++ b/test/DynamoCoreWpf3Tests/NoteViewTests.cs
@@ -640,5 +640,93 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(restoredNode.GUID, restoredNote.PinnedNode.GUID,
                 "Note should be pinned to the same node after undo.");
         }
+        /// <summary>
+        /// DYN-10380: Unpinning a note that belongs to a group should not eject
+        /// it from the group. Only the pin relationship should be broken.
+        /// </summary>
+        [Test]
+        public void UnpinGroupedNote_NoteRemainsInGroup()
+        {
+            Open(@"UI\UINotes.dyn");
+            var nodeGUID = "bbc16882-75c2-4a50-a4e4-5e50e191af8f";
+            var noteGUID = "4677e999-d5f5-4bb2-9706-a97bf3a86711";
+            var nodeView = NodeViewWithGuid(nodeGUID);
+            var noteView = NoteViewWithGuid(noteGUID);
+            var nodeModel = nodeView.ViewModel.NodeModel;
+            var noteModel = noteView.ViewModel.Model;
+
+            // Pin note to node
+            DynamoSelection.Instance.ClearSelection();
+            DynamoSelection.Instance.Selection.AddUnique(nodeModel);
+            DynamoSelection.Instance.Selection.AddUnique(noteModel);
+            noteView.ViewModel.PinToNodeCommand.Execute(null);
+            Assert.IsNotNull(noteModel.PinnedNode, "Pre-condition: note should be pinned.");
+
+            // Group the pinned pair
+            DynamoSelection.Instance.ClearSelection();
+            DynamoSelection.Instance.Selection.AddUnique(nodeModel);
+            DynamoSelection.Instance.Selection.AddUnique(noteModel);
+            ViewModel.AddAnnotationCommand.Execute(null);
+            DispatcherUtil.DoEvents();
+            var annotation = ViewModel.HomeSpaceViewModel.Annotations.First();
+            Assert.IsTrue(annotation.AnnotationModel.ContainsModel(noteModel),
+                "Pre-condition: note should be in the group.");
+
+            // Unpin the note
+            noteView.ViewModel.UnpinFromNodeCommand.Execute(null);
+
+            // Note should be unpinned but still in the group
+            Assert.IsNull(noteModel.PinnedNode, "Note should be unpinned.");
+            Assert.IsTrue(annotation.AnnotationModel.ContainsModel(noteModel),
+                "Note should remain in the group after unpinning.");
+        }
+
+        /// <summary>
+        /// DYN-10380: Undo/redo of unpin on a grouped note should preserve group
+        /// membership throughout the entire cycle.
+        /// </summary>
+        [Test]
+        public void UnpinGroupedNote_UndoRedo_PreservesGroupMembership()
+        {
+            Open(@"UI\UINotes.dyn");
+            var nodeGUID = "bbc16882-75c2-4a50-a4e4-5e50e191af8f";
+            var noteGUID = "4677e999-d5f5-4bb2-9706-a97bf3a86711";
+            var nodeView = NodeViewWithGuid(nodeGUID);
+            var noteView = NoteViewWithGuid(noteGUID);
+            var nodeModel = nodeView.ViewModel.NodeModel;
+            var noteModel = noteView.ViewModel.Model;
+
+            // Pin note to node
+            DynamoSelection.Instance.ClearSelection();
+            DynamoSelection.Instance.Selection.AddUnique(nodeModel);
+            DynamoSelection.Instance.Selection.AddUnique(noteModel);
+            noteView.ViewModel.PinToNodeCommand.Execute(null);
+
+            // Group the pinned pair
+            DynamoSelection.Instance.ClearSelection();
+            DynamoSelection.Instance.Selection.AddUnique(nodeModel);
+            DynamoSelection.Instance.Selection.AddUnique(noteModel);
+            ViewModel.AddAnnotationCommand.Execute(null);
+            DispatcherUtil.DoEvents();
+            var annotation = ViewModel.HomeSpaceViewModel.Annotations.First();
+
+            // Unpin the note
+            noteView.ViewModel.UnpinFromNodeCommand.Execute(null);
+            Assert.IsNull(noteModel.PinnedNode, "Note should be unpinned.");
+            Assert.IsTrue(annotation.AnnotationModel.ContainsModel(noteModel),
+                "Note should remain in group after unpin.");
+
+            // Undo the unpin — note should be re-pinned and still in the group
+            Model.CurrentWorkspace.Undo();
+            Assert.IsNotNull(noteModel.PinnedNode, "Undo should restore the pin.");
+            Assert.IsTrue(annotation.AnnotationModel.ContainsModel(noteModel),
+                "Note should remain in group after undo of unpin.");
+
+            // Redo the unpin — note should be unpinned and still in the group
+            Model.CurrentWorkspace.Redo();
+            Assert.IsNull(noteModel.PinnedNode, "Redo should unpin the note.");
+            Assert.IsTrue(annotation.AnnotationModel.ContainsModel(noteModel),
+                "Note should remain in group after redo of unpin.");
+        }
     }
 }


### PR DESCRIPTION
### Purpose

Regression fix for DYN-10380. Unpinning a Note that belongs to a group was incorrectly ejecting it from the group. This was a regression from 4.0.2 found during Test Fest 3.

**Steps to reproduce:**
1. Pin a Note to a Node
2. Group the pair
3. Unpin the Note
4. Select and drag the Note — it moves freely, outside the group ❌

**Root cause:** `NoteViewModel.UnpinFromNode()` was unconditionally removing the note from its containing `AnnotationModel` on every unpin. This block was introduced in the DYN-10130 fix as a symmetric counterpart to `PinToNode`'s auto-add behavior, but it was wrong for the general case: group membership is independent of pin state. The undo system already handles group restoration for the pin action through recorded model state, so the explicit removal was both redundant for undo and destructive for user-initiated unpins.

**Fix:** Removed the group-ejection block from `UnpinFromNode` and simplified undo recording to only record the `NoteModel` (no longer modifying the group, so no need to record it).

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fix regression where unpinning a Note inside a group caused the Note to be ejected from the group. The Note now correctly remains in the group after unpinning.

### Reviewers

@DynamoDS/eidos 

### FYIs

Additional notes: Two new regression tests added to `NoteViewTests` in `DynamoCoreWpf3Tests`:
- `UnpinGroupedNote_NoteRemainsInGroup` — verifies the note stays in the group after unpin
- `UnpinGroupedNote_UndoRedo_PreservesGroupMembership` — verifies group membership is preserved through the full undo/redo cycle

Existing test `UndoPinNode_RestoresGroupMembership` (DYN-10130) continues to pass — undoing a *pin* to a grouped node still correctly removes the note from the group via the undo system.
