### PR TITLE
DYN-9801: Add Locale property to ExtensionStartupParams to pass locale info from Dynamo to apps like LibG

### DIFF
--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
-using System.Text;
 using System.Threading;
 using CommandLine;
 using Dynamo.Configuration;
@@ -472,31 +470,14 @@ namespace Dynamo.Applications
 
         public static string SetLocale(CommandLineArguments cmdLineArgs)
         {
-            var supportedLocale = new HashSet<string>(Configuration.Configurations.SupportedLocaleDic.Values);
-            string libgLocale = string.Empty;
-
             if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
             {
                 // Change the application locale, if a locale information is supplied.
+                // This early call ensures the splash screen displays in the correct language
+                // before the DynamoModel is constructed (which also calls SetUICulture).
                 DynamoModel.SetUICulture(cmdLineArgs.Locale);
-                libgLocale = cmdLineArgs.Locale;
             }
-            else
-            {
-                // In case no language is specified, libG's locale should be that of the OS.
-                // There is no need to set Dynamo's locale in this case.
-                libgLocale = CultureInfo.InstalledUICulture.ToString();
-            }
-
-            // If locale is not supported by Dynamo, default to en-US.
-            if (!supportedLocale.Any(s => s.Equals(libgLocale, StringComparison.InvariantCultureIgnoreCase)))
-            {
-                libgLocale = "en-US";
-            }
-            // Change the locale that LibG depends on.
-            StringBuilder sb = new StringBuilder("LANGUAGE=");
-            sb.Append(libgLocale.Replace("-", "_"));
-            return sb.ToString();
+            return string.Empty;
         }
 
         /// <summary>

--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -473,7 +473,7 @@ namespace Dynamo.Applications
         /// </summary>
         /// <param name="cmdLineArgs">Parsed command-line arguments.</param>
         /// <returns>Always returns <see cref="string.Empty"/>.</returns>
-        [Obsolete("This method no longer returns a useful value and will be removed in a future Dynamo version.")]
+        [Obsolete("The API has been deprecated and will be removed in a future release of Dynamo. Make a direct call to DynamoModel.SetUICulture instead.")]
         public static string SetLocale(CommandLineArguments cmdLineArgs)
         {
             if (!string.IsNullOrEmpty(cmdLineArgs.Locale))

--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
+using System.Text;
 using System.Threading;
 using CommandLine;
 using Dynamo.Configuration;
@@ -476,11 +478,27 @@ namespace Dynamo.Applications
         [Obsolete("The API has been deprecated and will be removed in a future release of Dynamo. Make a direct call to DynamoModel.SetUICulture instead.")]
         public static string SetLocale(CommandLineArguments cmdLineArgs)
         {
+            var supportedLocale = new HashSet<string>(Configurations.SupportedLocaleDic.Values);
+            string locale = string.Empty;
+
             if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
             {
                 DynamoModel.SetUICulture(cmdLineArgs.Locale);
+                locale = cmdLineArgs.Locale;
             }
-            return string.Empty;
+            else
+            {
+                locale = CultureInfo.InstalledUICulture.ToString();
+            }
+
+            // If locale is not supported by Dynamo, default to en-US.
+            if (!supportedLocale.Any(s => s.Equals(locale, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                locale = "en-US";
+            }
+            StringBuilder sb = new StringBuilder("LANGUAGE=");
+            sb.Append(locale.Replace("-", "_"));
+            return sb.ToString();
         }
 
         /// <summary>

--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -474,7 +474,7 @@ namespace Dynamo.Applications
         /// Sets the application locale from parsed command-line arguments.
         /// </summary>
         /// <param name="cmdLineArgs">Parsed command-line arguments.</param>
-        /// <returns>Always returns <see cref="string.Empty"/>.</returns>
+        /// <returns>A locale environment string in the format <c>LANGUAGE=xx_YY</c> for the resolved locale.</returns>
         [Obsolete("The API has been deprecated and will be removed in a future release of Dynamo. Make a direct call to DynamoModel.SetUICulture instead.")]
         public static string SetLocale(CommandLineArguments cmdLineArgs)
         {

--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -468,15 +468,23 @@ namespace Dynamo.Applications
             return model;
         }
 
+        private static void SetLocale(string locale)
+        {
+            if (!string.IsNullOrEmpty(locale))
+            {
+                DynamoModel.SetUICulture(locale);
+            }
+        }
+
+        /// <summary>
+        /// Sets the application locale from parsed command-line arguments.
+        /// </summary>
+        /// <param name="cmdLineArgs">Parsed command-line arguments.</param>
+        /// <returns>Always returns <see cref="string.Empty"/>.</returns>
+        [Obsolete("Use SetLocale(string locale) instead. This overload no longer returns a useful value.")]
         public static string SetLocale(CommandLineArguments cmdLineArgs)
         {
-            if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
-            {
-                // Change the application locale, if a locale information is supplied.
-                // This early call ensures the splash screen displays in the correct language
-                // before the DynamoModel is constructed (which also calls SetUICulture).
-                DynamoModel.SetUICulture(cmdLineArgs.Locale);
-            }
+            SetLocale(cmdLineArgs.Locale);
             return string.Empty;
         }
 

--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -468,23 +468,18 @@ namespace Dynamo.Applications
             return model;
         }
 
-        private static void SetLocale(string locale)
-        {
-            if (!string.IsNullOrEmpty(locale))
-            {
-                DynamoModel.SetUICulture(locale);
-            }
-        }
-
         /// <summary>
         /// Sets the application locale from parsed command-line arguments.
         /// </summary>
         /// <param name="cmdLineArgs">Parsed command-line arguments.</param>
         /// <returns>Always returns <see cref="string.Empty"/>.</returns>
-        [Obsolete("Use SetLocale(string locale) instead. This overload no longer returns a useful value.")]
+        [Obsolete("This method no longer returns a useful value and will be removed in a future Dynamo version.")]
         public static string SetLocale(CommandLineArguments cmdLineArgs)
         {
-            SetLocale(cmdLineArgs.Locale);
+            if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
+            {
+                DynamoModel.SetUICulture(cmdLineArgs.Locale);
+            }
             return string.Empty;
         }
 

--- a/src/DynamoCLI/Program.cs
+++ b/src/DynamoCLI/Program.cs
@@ -20,6 +20,8 @@ namespace DynamoCLI
             {
                 var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
                 useConsole = !cmdLineArgs.NoConsole;
+                // Set locale early so the splash screen renders in the correct language;
+                // DynamoModel construction will also call SetUICulture from preferences.
                 if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
                 {
                     DynamoModel.SetUICulture(cmdLineArgs.Locale);

--- a/src/DynamoCLI/Program.cs
+++ b/src/DynamoCLI/Program.cs
@@ -20,7 +20,10 @@ namespace DynamoCLI
             {
                 var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
                 useConsole = !cmdLineArgs.NoConsole;
-                StartupUtils.SetLocale(cmdLineArgs);
+                if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
+                {
+                    DynamoModel.SetUICulture(cmdLineArgs.Locale);
+                }
 
                 cmdLineArgs.SetDisableAnalytics();
 

--- a/src/DynamoCLI/Program.cs
+++ b/src/DynamoCLI/Program.cs
@@ -20,7 +20,7 @@ namespace DynamoCLI
             {
                 var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
                 useConsole = !cmdLineArgs.NoConsole;
-                var locale = StartupUtils.SetLocale(cmdLineArgs);
+                StartupUtils.SetLocale(cmdLineArgs);
 
                 cmdLineArgs.SetDisableAnalytics();
 

--- a/src/DynamoCLI/Program.cs
+++ b/src/DynamoCLI/Program.cs
@@ -20,8 +20,6 @@ namespace DynamoCLI
             {
                 var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
                 useConsole = !cmdLineArgs.NoConsole;
-                // Set locale early so the splash screen renders in the correct language;
-                // DynamoModel construction will also call SetUICulture from preferences.
                 if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
                 {
                     DynamoModel.SetUICulture(cmdLineArgs.Locale);

--- a/src/DynamoSandbox/DynamoCoreSetup.cs
+++ b/src/DynamoSandbox/DynamoCoreSetup.cs
@@ -34,6 +34,8 @@ namespace DynamoSandbox
         public DynamoCoreSetup(string[] args)
         {
             var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
+            // Set locale early so the splash screen renders in the correct language;
+            // DynamoModel construction will also call SetUICulture from preferences.
             if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
             {
                 DynamoModel.SetUICulture(cmdLineArgs.Locale);

--- a/src/DynamoSandbox/DynamoCoreSetup.cs
+++ b/src/DynamoSandbox/DynamoCoreSetup.cs
@@ -34,7 +34,10 @@ namespace DynamoSandbox
         public DynamoCoreSetup(string[] args)
         {
             var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
-            StartupUtils.SetLocale(cmdLineArgs);
+            if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
+            {
+                DynamoModel.SetUICulture(cmdLineArgs.Locale);
+            }
 
             cmdLineArgs.SetDisableAnalytics();
 

--- a/src/DynamoSandbox/DynamoCoreSetup.cs
+++ b/src/DynamoSandbox/DynamoCoreSetup.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Windows;
 using Dynamo.Applications;
 using Dynamo.Controls;
@@ -28,9 +27,6 @@ namespace DynamoSandbox
         private const string sandboxWikiPage = @"https://github.com/DynamoDS/Dynamo/wiki/How-to-Utilize-Dynamo-Builds";
         private DynamoViewModel viewModel = null;
 
-        [DllImport("msvcrt.dll")]
-        public static extern int _putenv(string env);
-
         /// <summary>
         /// Constructor
         /// </summary>
@@ -38,8 +34,7 @@ namespace DynamoSandbox
         public DynamoCoreSetup(string[] args)
         {
             var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
-            var locale = StartupUtils.SetLocale(cmdLineArgs);
-            _putenv(locale);
+            StartupUtils.SetLocale(cmdLineArgs);
 
             cmdLineArgs.SetDisableAnalytics();
 

--- a/src/DynamoWPFCLI/Program.cs
+++ b/src/DynamoWPFCLI/Program.cs
@@ -28,6 +28,8 @@ namespace DynamoWPFCLI
             {
                 var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
                 useConsole = !cmdLineArgs.NoConsole;
+                // Set locale early so the splash screen renders in the correct language;
+                // DynamoModel construction will also call SetUICulture from preferences.
                 if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
                 {
                     DynamoModel.SetUICulture(cmdLineArgs.Locale);

--- a/src/DynamoWPFCLI/Program.cs
+++ b/src/DynamoWPFCLI/Program.cs
@@ -28,7 +28,7 @@ namespace DynamoWPFCLI
             {
                 var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
                 useConsole = !cmdLineArgs.NoConsole;
-                var locale = StartupUtils.SetLocale(cmdLineArgs);
+                StartupUtils.SetLocale(cmdLineArgs);
 
                 cmdLineArgs.SetDisableAnalytics();
 

--- a/src/DynamoWPFCLI/Program.cs
+++ b/src/DynamoWPFCLI/Program.cs
@@ -28,8 +28,6 @@ namespace DynamoWPFCLI
             {
                 var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
                 useConsole = !cmdLineArgs.NoConsole;
-                // Set locale early so the splash screen renders in the correct language;
-                // DynamoModel construction will also call SetUICulture from preferences.
                 if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
                 {
                     DynamoModel.SetUICulture(cmdLineArgs.Locale);

--- a/src/DynamoWPFCLI/Program.cs
+++ b/src/DynamoWPFCLI/Program.cs
@@ -28,7 +28,10 @@ namespace DynamoWPFCLI
             {
                 var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
                 useConsole = !cmdLineArgs.NoConsole;
-                StartupUtils.SetLocale(cmdLineArgs);
+                if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
+                {
+                    DynamoModel.SetUICulture(cmdLineArgs.Locale);
+                }
 
                 cmdLineArgs.SetDisableAnalytics();
 

--- a/src/Engine/ProtoCore/FFI/ExtensionAppLoader.cs
+++ b/src/Engine/ProtoCore/FFI/ExtensionAppLoader.cs
@@ -169,7 +169,11 @@ namespace ProtoFFI
 
             if (null != extensionApp)
             {
-                extensionApp.StartUp(new ExtensionStartupParams { DisableADP = Analytics.DisableAnalytics });
+                extensionApp.StartUp(new ExtensionStartupParams
+                {
+                    DisableADP = Analytics.DisableAnalytics,
+                    Locale = System.Threading.Thread.CurrentThread.CurrentUICulture.Name
+                });
             }
         }
         

--- a/src/Engine/ProtoCore/FFI/ExtensionAppLoader.cs
+++ b/src/Engine/ProtoCore/FFI/ExtensionAppLoader.cs
@@ -172,6 +172,10 @@ namespace ProtoFFI
                 extensionApp.StartUp(new ExtensionStartupParams
                 {
                     DisableADP = Analytics.DisableAnalytics,
+                    //  If the extension app is initialized on a thread that hasn’t had DynamoModel.SetUICulture applied
+                    //  (or had it changed later), Locale can differ from Dynamo’s resolved UI culture and
+                    //  LibG/gettext will be set to the wrong language. This therefore assumes that the extension app is
+                    //  initialized on the same thread as DynamoModel.SetUICulture, which is currently the case.
                     Locale = System.Threading.Thread.CurrentThread.CurrentUICulture.Name
                 });
             }

--- a/src/NodeServices/Interfaces.cs
+++ b/src/NodeServices/Interfaces.cs
@@ -155,7 +155,14 @@ namespace Autodesk.DesignScript.Interfaces
             set;
         }
 
-        public string Locale { get; set; }
+        /// <summary>
+        /// Gets the locale to use during extension startup, expressed as a
+        /// BCP 47 culture name such as <c>en-US</c>
+        /// (see <see cref="System.Globalization.CultureInfo.Name"/>).
+        /// A <see langword="null"/> or empty value indicates that no explicit
+        /// locale was provided by the host.
+        /// </summary>
+        public string Locale { get; internal set; }
     }
 
     /// <summary>

--- a/src/NodeServices/Interfaces.cs
+++ b/src/NodeServices/Interfaces.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Autodesk.DesignScript.Interfaces
@@ -154,6 +154,8 @@ namespace Autodesk.DesignScript.Interfaces
             get;
             set;
         }
+
+        public string Locale { get; set; }
     }
 
     /// <summary>

--- a/src/NodeServices/PublicAPI.Unshipped.txt
+++ b/src/NodeServices/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 Autodesk.DesignScript.Interfaces.ExtensionStartupParams.Locale.get -> string
-Autodesk.DesignScript.Interfaces.ExtensionStartupParams.Locale.set -> void
 Dynamo.Graph.Nodes.NodeCategoryAttribute
 Dynamo.Graph.Nodes.NodeCategoryAttribute.ElementCategory.get -> string
 Dynamo.Graph.Nodes.NodeCategoryAttribute.ElementCategory.set -> void

--- a/src/NodeServices/PublicAPI.Unshipped.txt
+++ b/src/NodeServices/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
+Autodesk.DesignScript.Interfaces.ExtensionStartupParams.Locale.get -> string
+Autodesk.DesignScript.Interfaces.ExtensionStartupParams.Locale.set -> void
 Dynamo.Graph.Nodes.NodeCategoryAttribute
 Dynamo.Graph.Nodes.NodeCategoryAttribute.ElementCategory.get -> string
 Dynamo.Graph.Nodes.NodeCategoryAttribute.ElementCategory.set -> void


### PR DESCRIPTION
### Purpose

Part of [DYN-9801](https://jira.autodesk.com/browse/DYN-9801). Companion Dynamo change for the LibG localization modernization in [LibG PR #1648](https://git.autodesk.com/Dynamo/LibG/pull/1648). This PR needs to be merged before LibG PR 1948.

**Root cause of the old approach being broken**

Dynamo previously set the LibG/gettext locale by calling `_putenv("LANGUAGE=xx_XX")` via a P/Invoke to `msvcrt.dll`. This was unreliable: `msvcrt.dll`'s `_environ` block and `libintl.dll`'s own CRT `_environ` block are separate memory regions in the same process, so the write was never visible to gettext. In practice, geometry error strings were never reliably localized — gettext fell back to the Windows registry (Control Panel → Region), not to Dynamo's selected language.

**What LibG PR #1648 does**

Replaces the env-var approach with a programmatic `Localization::set_language()` C++ API (exposed to managed code via SWIG) that calls `libintl_setlocale()` directly into `libintl.dll`'s address space, bypassing the CRT boundary entirely. LibG's `IExtensionApplication.StartUp()` now calls `Localization.initialize()` and `Localization.set_language()` using the locale passed in via `ExtensionStartupParams`.

**What this PR does**

- Adds `Locale` property to `ExtensionStartupParams` (`NodeServices/Interfaces.cs`) so Dynamo can pass the resolved UI locale to `IExtensionApplication` implementors like LibG.
- Declares the new property in `PublicAPI.Unshipped.txt` for the `NodeServices` assembly.
- Populates `Locale` in `ExtensionAppLoader.InitializeExtensionApp()` from `Thread.CurrentThread.CurrentUICulture.Name` (set earlier by `DynamoModel.SetUICulture()`).
- Removes the dead `_putenv("LANGUAGE=...")` call and the `msvcrt.dll` P/Invoke from `DynamoCoreSetup` — this never worked correctly (see root cause above).
- Deprecates `StartupUtils.SetLocale()` and removed calls to it.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

N/A — internal localization plumbing change; no user-visible behavior changes in this PR alone. Geometry error string localization will work correctly once the companion LibG PR #1648 ships.

### Reviewers

(FILL ME IN) Reviewer 1

This PR must be reviewed alongside [LibG PR #1648](https://git.autodesk.com/Dynamo/LibG/pull/1648) — both sides need to ship together. The key change reviewers should focus on is `ExtensionAppLoader.cs`: `Locale` is read from `Thread.CurrentThread.CurrentUICulture.Name` at the time `StartUp()` is called, which is after `DynamoModel.SetUICulture()` has run (locale is set during model construction; FFI assembly loading happens later on first graph execution).

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of