### PR TITLE
DYN-9970 Fix Documentation Browser breadcrumb collision

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
@@ -452,6 +452,23 @@ namespace Dynamo.DocumentationBrowser
             {
                 if (!BreadCrumbsDictionary.TryGetValue(e.OriginalName, out breadCrumbs))
                 {
+                    // Prefer exact node-name matches at the end of a key (e.g. Input.String)
+                    // before using broader substring matching.
+                    var keySuffix = "." + e.OriginalName;
+                    foreach (var pair in BreadCrumbsDictionary)
+                    {
+                        if (pair.Key.EndsWith(keySuffix, StringComparison.Ordinal))
+                        {
+                            breadCrumbs = pair.Value;
+                            break;
+                        }
+                    }
+
+                    if (breadCrumbs != null)
+                    {
+                        return breadCrumbs;
+                    }
+
                     foreach (var pair in BreadCrumbsDictionary)
                     {
                         if (pair.Key.Contains(e.OriginalName))

--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
@@ -455,18 +455,12 @@ namespace Dynamo.DocumentationBrowser
                     // Prefer exact node-name matches at the end of a key (e.g. Input.String)
                     // before using broader substring matching.
                     var keySuffix = "." + e.OriginalName;
-                    foreach (var pair in BreadCrumbsDictionary)
-                    {
-                        if (pair.Key.EndsWith(keySuffix, StringComparison.Ordinal))
-                        {
-                            breadCrumbs = pair.Value;
-                            break;
-                        }
-                    }
+                    var exactSuffixMatch = BreadCrumbsDictionary
+                        .FirstOrDefault(pair => pair.Key.EndsWith(keySuffix, StringComparison.Ordinal));
 
-                    if (breadCrumbs != null)
+                    if (exactSuffixMatch.Key != null)
                     {
-                        return breadCrumbs;
+                        return exactSuffixMatch.Value;
                     }
 
                     foreach (var pair in BreadCrumbsDictionary)

--- a/test/DynamoCoreWpf2Tests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
+++ b/test/DynamoCoreWpf2Tests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
@@ -910,6 +910,9 @@ namespace DynamoCoreWpfTests
                 "GetBreadCrumbsValue",
                 BindingFlags.NonPublic | BindingFlags.Instance);
 
+            Assert.IsNotNull(method, "GetBreadCrumbsValue method not found on DocumentationBrowserViewModel. " +
+                "If the method was renamed or its accessibility changed, update this test accordingly.");
+
             // Act
             var breadCrumbs = method.Invoke(docsViewModel, new object[] { nodeAnnotationEventArgs }) as string;
 

--- a/test/DynamoCoreWpf2Tests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
+++ b/test/DynamoCoreWpf2Tests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
@@ -877,6 +877,46 @@ namespace DynamoCoreWpfTests
             Assert.That(graphPathValue.Contains(Path.Combine("PackageWithNodeDocumentation", "doc", dynFileName)));
         }
 
+        [Test]
+        public void StringInputNodeDocumentationShowsInputBasicBreadcrumbs()
+        {
+            // Arrange
+            var nodeName = "String";
+            this.ViewModel.ExecuteCommand(
+                new DynamoModel.CreateNodeCommand(
+                    Guid.NewGuid().ToString(), nodeName, 0, 0, false, false)
+            );
+
+            var node = ViewModel.Model.CurrentWorkspace.Nodes
+                .LastOrDefault(x => x.GetType().FullName == "CoreNodeModels.Input.StringInput");
+            Assert.IsNotNull(node, "Expected to create CoreNodeModels.Input.StringInput node.");
+
+            var nodeAnnotationEventArgs = new OpenNodeAnnotationEventArgs(node, this.ViewModel)
+            {
+                // Simulate the exact ambiguity that previously resolved to DateTime / FromString.
+                OriginalName = "String"
+            };
+
+            var docsViewModel = new DocumentationBrowserViewModel
+            {
+                BreadCrumbsDictionary = new Dictionary<string, string>
+                {
+                    { "DateTime.FromString", "Input / DateTime" },
+                    { "Input.String", "Input / Basic" }
+                }
+            };
+
+            var method = typeof(DocumentationBrowserViewModel).GetMethod(
+                "GetBreadCrumbsValue",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+
+            // Act
+            var breadCrumbs = method.Invoke(docsViewModel, new object[] { nodeAnnotationEventArgs }) as string;
+
+            // Assert
+            Assert.AreEqual("Input / Basic", breadCrumbs);
+        }
+
         #region Helpers
 
         private DocumentationBrowserViewExtension SetupNewViewExtension(bool runLoadedMethod = false)


### PR DESCRIPTION
### Purpose

Fix Documentation Browser breadcrumb collision for String node

Updated breadcrumb resolution in DocumentationBrowserViewModel.cs to prefer exact suffix matches (for example .String) before falling back to broad substring matching. Prevents String node docs from incorrectly resolving to Input/DateTime via DateTime.FromString. Added regression test in DocumentationBrowserViewExtensionTests.cs to verify StringInput shows Input/Basic breadcrumbs and not DateTime.

It only changes ambiguous cases where substring collisions existed (like String matching DateTime.FromString). In those cases, it now picks the more precise match.


### Declarations

Check these if you believe they are true

- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fix Documentation Browser breadcrumb collision for String node

### Reviewers

@aparajit-pratap @QilongTang @jasonstratton 

### FYIs

