### PR TITLE
DYN-10416: Cleanup frozen geometry when the parent node is deleted

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -969,7 +969,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             OnSceneItemsChanged();
         }
 
-        private void DeleteGeometries(KeyValuePair<string, Element3D>[] geometryModels, bool requestUpdate)
+        private void DeleteGeometries(KeyValuePair<string, Element3D>[] geometryModels, bool requestUpdate, bool forceDelete = false)
         {
             lock (element3DDictionaryMutex)
             {
@@ -980,12 +980,16 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
                 foreach (var kvp in geometryModels)
                 {
-                    
+
                     var model3D = Element3DDictionary[kvp.Key] as GeometryModel3D;
-                    // check if the geometry is frozen. if the gemoetry is frozen 
-                    // then do not detach from UI.
-                    var frozenModel = AttachedProperties.GetIsFrozen(model3D);
-                    if (frozenModel) continue;
+                    // Skip deletion for frozen geometry during re-evaluation so that
+                    // frozen nodes retain their cached visuals. When forceDelete is true
+                    // (node permanently removed from workspace) we always clean up.
+                    if (!forceDelete)
+                    {
+                        var frozenModel = AttachedProperties.GetIsFrozen(model3D);
+                        if (frozenModel) continue;
+                    }
 
                     Element3DDictionary.Remove(kvp.Key);
                     model3D.Dispose();
@@ -1010,7 +1014,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         public override void DeleteGeometryForNode(NodeModel node, bool requestUpdate = true)
         {
             var geometryModels = FindAllGeometryModel3DsForNode(node);
-            DeleteGeometries(geometryModels, requestUpdate);
+            DeleteGeometries(geometryModels, requestUpdate, forceDelete: true);
         }
 
         /// <summary>

--- a/test/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/test/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -868,6 +868,27 @@ namespace WpfVisualizationTests
             Assert.IsTrue((dynGeometry.FirstOrDefault().SceneNode.RenderCore as DynamoGeometryMeshCore).dataCore.IsFrozenData);
         }
 
+        [Test]
+        public void WhenFrozenNodeIsDeletedThenItsGeometryIsCleared()
+        {
+            // Arrange: open a graph with mesh geometry, run it, freeze a node
+            OpenVisualizationTest("Display.ByGeometryColor.dyn");
+            RunCurrentModel();
+            Assert.Greater(BackgroundPreviewGeometry.TotalMeshes(), 0);
+
+            var nodeToDelete = Model.CurrentWorkspace.Nodes
+                .First(x => x.Name.Contains("ByGeometryColor"));
+            nodeToDelete.IsFrozen = true;
+            DispatcherUtil.DoEvents();
+
+            // Act: delete the frozen node
+            Model.DeleteModelInternal(new List<ModelBase> { nodeToDelete });
+            DispatcherUtil.DoEvents();
+
+            // Assert: geometry must be cleared despite the node having been frozen
+            Assert.AreEqual(0, BackgroundPreviewGeometry.TotalMeshes());
+        }
+
        [Test]
         public void Display_ByGeometryColor_HasColoredMesh()
         {


### PR DESCRIPTION
### Purpose

Cause:

The guard was added in 2015 for a re-evaluation scenario: when a frozen node's graph re-runs, RemoveGeometryForUpdatedPackages calls DeleteGeometryForIdentifier to pre-clear geometry before writing new render packages — the frozen guard correctly prevents wiping cached geometry that won't be regenerated. But the same DeleteGeometries is called by DeleteGeometryForNode when the node is actually removed from the workspace, which is a completely different scenario where geometry must always be cleaned up.

Added a forceDelete parameter to `DeleteGeometries` so frozen `GeometryModel3D` instances are skipped during normal re-evaluation but can be removed when a node is permanently deleted.
Update `DeleteGeometryForNode` to call `DeleteGeometries` with `forceDelete:true`. 

Added a test `WhenFrozenNodeIsDeletedThenItsGeometryIsCleared` to ensure deleting a frozen node clears its geometry from the background preview.

This preserves frozen visuals during routine updates while ensuring cleanup on node removal.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Cleanup frozen geometry when the parent node is deleted