### PR TITLE
DYN-10409 Fix SynchronizationLockException crash on Save As in C3D

### DIFF
--- a/src/DynamoCoreWpf/Utilities/DelegateCommand.cs
+++ b/src/DynamoCoreWpf/Utilities/DelegateCommand.cs
@@ -49,13 +49,10 @@ namespace Dynamo.UI.Commands
         /// </summary>
         public void RaiseCanExecuteChanged()
         {
-            var handler = CanExecuteChanged;
-            if (handler == null) return;
-
             if (!_dispatcher.CheckAccess())
-                _dispatcher.BeginInvoke(new Action(() => handler(this, EventArgs.Empty)));
+                _dispatcher.BeginInvoke(new Action(() => CanExecuteChanged?.Invoke(this, EventArgs.Empty)));
             else
-                handler(this, EventArgs.Empty);
+                CanExecuteChanged?.Invoke(this, EventArgs.Empty);
         }
 
     }

--- a/src/DynamoCoreWpf/Utilities/DelegateCommand.cs
+++ b/src/DynamoCoreWpf/Utilities/DelegateCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Windows;
 using System.Windows.Input;
 
 namespace Dynamo.UI.Commands
@@ -38,12 +39,22 @@ namespace Dynamo.UI.Commands
             _execute(parameter);
         }
 
+        /// <summary>
+        /// Raises <see cref="CanExecuteChanged"/>, marshalling to the UI thread if necessary.
+        /// Calling from a non-UI thread without this guard causes
+        /// <see cref="System.Threading.SynchronizationLockException"/> inside WPF's
+        /// CommandManager.FindCommandBinding (DYN-10409).
+        /// </summary>
         public void RaiseCanExecuteChanged()
         {
-            if (CanExecuteChanged != null)
-            {
-                CanExecuteChanged(this, EventArgs.Empty);
-            }
+            var handler = CanExecuteChanged;
+            if (handler == null) return;
+
+            var dispatcher = Application.Current?.Dispatcher;
+            if (dispatcher != null && !dispatcher.CheckAccess())
+                dispatcher.BeginInvoke(new Action(() => handler(this, EventArgs.Empty)));
+            else
+                handler(this, EventArgs.Empty);
         }
 
     }

--- a/src/DynamoCoreWpf/Utilities/DelegateCommand.cs
+++ b/src/DynamoCoreWpf/Utilities/DelegateCommand.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Windows;
 using System.Windows.Input;
+using System.Windows.Threading;
 
 namespace Dynamo.UI.Commands
 {
@@ -13,6 +13,7 @@ namespace Dynamo.UI.Commands
 
         private readonly Predicate<object> _canExecute;
         private readonly Action<object> _execute;
+        private readonly Dispatcher _dispatcher;
 
         public event EventHandler CanExecuteChanged;
 
@@ -26,6 +27,7 @@ namespace Dynamo.UI.Commands
         {
             _execute = execute;
             _canExecute = canExecute;
+            _dispatcher = Dispatcher.CurrentDispatcher;
         }
 
         public bool CanExecute(object parameter)
@@ -50,9 +52,8 @@ namespace Dynamo.UI.Commands
             var handler = CanExecuteChanged;
             if (handler == null) return;
 
-            var dispatcher = Application.Current?.Dispatcher;
-            if (dispatcher != null && !dispatcher.CheckAccess())
-                dispatcher.BeginInvoke(new Action(() => handler(this, EventArgs.Empty)));
+            if (!_dispatcher.CheckAccess())
+                _dispatcher.BeginInvoke(new Action(() => handler(this, EventArgs.Empty)));
             else
                 handler(this, EventArgs.Empty);
         }

--- a/test/DynamoCoreWpfTests/DelegateCommandTests.cs
+++ b/test/DynamoCoreWpfTests/DelegateCommandTests.cs
@@ -37,7 +37,7 @@ namespace DynamoCoreWpfTests
             Task.Run(() => command.RaiseCanExecuteChanged()).Wait();
 
             // Pump the dispatcher so any BeginInvoke posted by the fix has a chance to run.
-            DispatcherUtil.DoEventsLoop(() => handlerThreadId != -1);
+            DispatcherUtil.DoEventsLoop(() => handlerThreadId != -1, timeoutSeconds: 5);
 
             Assert.AreNotEqual(-1, handlerThreadId, "CanExecuteChanged handler was never invoked");
             Assert.AreEqual(uiThreadId, handlerThreadId,
@@ -87,7 +87,7 @@ namespace DynamoCoreWpfTests
             Assert.DoesNotThrow(() => Task.WaitAll(tasks),
                 "RaiseCanExecuteChanged must not throw when called from multiple background threads");
 
-            DispatcherUtil.DoEventsLoop(() => invocationCount >= threadCount);
+            DispatcherUtil.DoEventsLoop(() => invocationCount >= threadCount, timeoutSeconds: 5);
             Assert.AreEqual(threadCount, invocationCount,
                 "All CanExecuteChanged invocations should be delivered");
         }

--- a/test/DynamoCoreWpfTests/DelegateCommandTests.cs
+++ b/test/DynamoCoreWpfTests/DelegateCommandTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dynamo.UI.Commands;
+using DynamoCoreWpfTests.Utility;
+using NUnit.Framework;
+
+namespace DynamoCoreWpfTests
+{
+    /// <summary>
+    /// Tests for DelegateCommand threading behavior.
+    /// Regression tests for DYN-10409: RaiseCanExecuteChanged called from a background thread
+    /// (e.g. the Dynamo scheduler thread) caused SynchronizationLockException in WPF's
+    /// CommandManager.FindCommandBinding.
+    /// </summary>
+    [TestFixture]
+    public class DelegateCommandTests : DynamoTestUIBase
+    {
+        /// <summary>
+        /// When RaiseCanExecuteChanged is called from a background thread, the CanExecuteChanged
+        /// handler must be invoked on the UI thread, not the calling thread.
+        /// Before the fix this test fails: the handler fires on the background thread, which
+        /// causes WPF's CommandManager to crash with SynchronizationLockException.
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void WhenRaiseCanExecuteChangedCalledFromBackgroundThread_HandlerInvokedOnUIThread()
+        {
+            var command = new DelegateCommand(_ => { });
+            int uiThreadId = Environment.CurrentManagedThreadId;
+            int handlerThreadId = -1;
+
+            command.CanExecuteChanged += (s, e) => handlerThreadId = Environment.CurrentManagedThreadId;
+
+            // Fire from a background thread — the pre-fix code calls the handler on this thread,
+            // which is a WPF threading violation. The fix marshals via Dispatcher.BeginInvoke.
+            Task.Run(() => command.RaiseCanExecuteChanged()).Wait();
+
+            // Pump the dispatcher so any BeginInvoke posted by the fix has a chance to run.
+            DispatcherUtil.DoEventsLoop(() => handlerThreadId != -1);
+
+            Assert.AreNotEqual(-1, handlerThreadId, "CanExecuteChanged handler was never invoked");
+            Assert.AreEqual(uiThreadId, handlerThreadId,
+                "CanExecuteChanged must be invoked on the UI thread when raised from a background thread. " +
+                "Calling from a non-UI thread causes SynchronizationLockException in WPF's CommandManager (DYN-10409).");
+        }
+
+        /// <summary>
+        /// When RaiseCanExecuteChanged is called from the UI thread it should invoke the handler
+        /// synchronously on the same thread (no unnecessary async round-trip).
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void WhenRaiseCanExecuteChangedCalledFromUIThread_HandlerInvokedSynchronously()
+        {
+            var command = new DelegateCommand(_ => { });
+            int uiThreadId = Environment.CurrentManagedThreadId;
+            int handlerThreadId = -1;
+
+            command.CanExecuteChanged += (s, e) => handlerThreadId = Environment.CurrentManagedThreadId;
+
+            command.RaiseCanExecuteChanged();
+
+            // No dispatcher pump needed — UI-thread calls should be synchronous.
+            Assert.AreEqual(uiThreadId, handlerThreadId,
+                "CanExecuteChanged should be invoked synchronously when already on the UI thread");
+        }
+
+        /// <summary>
+        /// Verify that no exception escapes when RaiseCanExecuteChanged is called concurrently
+        /// from multiple background threads.
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void WhenRaiseCanExecuteChangedCalledConcurrentlyFromBackgroundThreads_NoException()
+        {
+            var command = new DelegateCommand(_ => { });
+            int invocationCount = 0;
+
+            command.CanExecuteChanged += (s, e) => Interlocked.Increment(ref invocationCount);
+
+            const int threadCount = 10;
+            var tasks = new Task[threadCount];
+            for (int i = 0; i < threadCount; i++)
+                tasks[i] = Task.Run(() => command.RaiseCanExecuteChanged());
+
+            Assert.DoesNotThrow(() => Task.WaitAll(tasks),
+                "RaiseCanExecuteChanged must not throw when called from multiple background threads");
+
+            DispatcherUtil.DoEventsLoop(() => invocationCount >= threadCount);
+            Assert.AreEqual(threadCount, invocationCount,
+                "All CanExecuteChanged invocations should be delivered");
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

Fixes DYN-10409: Dynamo for Civil 3D crashes with an unhandled `SynchronizationLockException` inside WPF's `CommandManager.FindCommandBinding` after performing a Save As to a new `.dyn` file.

**Root cause:** `DelegateCommand.RaiseCanExecuteChanged` fired `CanExecuteChanged` directly on whatever thread called it. When the Dynamo scheduler thread completes graph execution (triggered by `SetPeriodicEvaluation` after the Save As workspace reload), WPF's `CommandManager` assumes `CanExecuteChanged` is always raised on the UI thread — raising it from a background thread corrupts the internal `Monitor` lock state, causing `Monitor.Exit` to throw with `SynchronizationLockException`.

**Fix:** Capture `Dispatcher.CurrentDispatcher` at `DelegateCommand` construction time (commands are always constructed on the UI thread). `RaiseCanExecuteChanged` now checks `_dispatcher.CheckAccess()` and marshals via `BeginInvoke` when called from a non-UI thread. UI-thread callers continue to invoke synchronously.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixed a crash (`SynchronizationLockException` in WPF's `CommandManager`) that occurred in Dynamo for Civil 3D after performing a Save As to a new file while running in Automatic evaluation mode.

### Reviewers

@DynamoDS/eidos 

Additional notes: The bug has been latent since `DelegateCommand` was introduced in January 2015 but surfaces reliably under conditions now common in C3D: Automatic run mode, Save As to a cloud-synced path (OneDrive), and the `searchbar_separate_thread` feature flag enabled. Regression tests added in `DelegateCommandTests.cs` using `DynamoTestUIBase` + `DispatcherUtil.DoEventsLoop`.

### FYIs

Notes can be found here: https://git.autodesk.com/strattj/DynaNotes/blob/main/DYN-10409/README.md