### PR TITLE
DYN-10436: Fix UV scaling for degenerate surfaces (sphere poles, cone apex)

### DIFF
--- a/doc/distrib/xml/en-US/ProtoGeometry.XML
+++ b/doc/distrib/xml/en-US/ProtoGeometry.XML
@@ -273,9 +273,6 @@
             <return>Arc created from start, end point, and tangent</return>
             <search>arc,tangent,arcs</search>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Arc.ToString">
-            <summary> Get a string representation of the Arc </summary>
-        </member>
         <member name="M:Autodesk.DesignScript.Geometry.BoundingBox.FromJson(System.String)">
             <summary>
             Parse the incoming JSON string formatted with autodesk.geometry:boundingbox3d-1.0.0 schema.
@@ -397,18 +394,6 @@
             </summary>
             <search>bounding,bound,bymaxmin,max,min,bypoints</search>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.BoundingBox.Equals(Autodesk.DesignScript.Geometry.DesignScriptEntity)">
-            <summary> Compare two BoundingBox's </summary>
-            <param name="other">The other BoundingBox</param>
-            <returns>Whether the two objects are equal</returns>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.BoundingBox.ComputeHashCode">
-            <summary> Get a hashcode for this type </summary>
-            <returns> A unique hashcode for this object </returns>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.BoundingBox.ToString">
-            <summary> Get a string representation of the BoundingBox </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.Circle.CenterPoint">
             <summary>
             The center of the circle
@@ -467,9 +452,6 @@
             <returns>Circle created from points</returns>
             <search>circle,approximate</search>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Circle.ToString">
-            <summary> Get a string representation of the Circle </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.CoEdge.Previous">
             <summary>
             The previous CoEdge in the containing Loop
@@ -523,9 +505,6 @@
             Curve in parametric space of the owner surface. The curve is in 2D form, thus Z coordinates of this curve are 0.
             </summary>
             <returns></returns>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.CoEdge.ToString">
-            <summary> Get a string representation of the CoEdge </summary>
         </member>
         <member name="P:Autodesk.DesignScript.Geometry.Cone.StartPoint">
             <summary>
@@ -604,9 +583,6 @@
             circular bases in the CoordinateSystem XY Plane.
             </summary>
             <search>cone,cone by height,cones</search>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Cone.ToString">
-            <summary> Get a string representation of the Cone </summary>
         </member>
         <member name="M:Autodesk.DesignScript.Geometry.CoordinateSystem.ByMatrix(System.Double[])">
             <summary>
@@ -897,18 +873,6 @@
             Creates a CoordinateSystem at the specified spherical coordinate parameters with respect to the specified coordinate system.
             </summary>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.CoordinateSystem.Equals(Autodesk.DesignScript.Geometry.DesignScriptEntity)">
-            <summary> Compare two CoordinateSystem's </summary>
-            <param name="other">The other CoordinateSystem</param>
-            <returns>Whether the two objects are equal</returns>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.CoordinateSystem.ComputeHashCode">
-            <summary> Get a hashcode for this type </summary>
-            <returns> A unique hashcode for this object </returns>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.CoordinateSystem.ToString">
-            <summary> Get a string representation of the CoordinateSystem </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.Cuboid.Length">
             <summary>
             Returns length distance.
@@ -983,9 +947,6 @@
             <param name="highPoint">Corner high point of cuboid</param>
             <returns>Cuboind created by corners</returns>
             <search>box,cube,byminmax,by corners,by points,cubes</search>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Cuboid.ToString">
-            <summary> Get a string representation of the Cuboid </summary>
         </member>
         <member name="P:Autodesk.DesignScript.Geometry.Curve.Length">
             <summary>
@@ -1503,9 +1464,6 @@
             <search>isocurve,curvebydir,lines</search>
             <weights>0.5,0.5,0.4</weights>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Curve.ToString">
-            <summary> Get a string representation of the Curve </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.Cylinder.Radius">
             <summary>
             The radius of the cylinder
@@ -1546,9 +1504,6 @@
             <param name="radius">Radius  of cylinder</param>
             <returns>Cylinder created by points and radius</returns>
             <search>cylinder,tube,by center points</search>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Cylinder.ToString">
-            <summary> Get a string representation of the Cylinder </summary>
         </member>
         <member name="F:Autodesk.DesignScript.Geometry.DesignScriptEntity.constructorThreadId">
             <summary>
@@ -1605,9 +1560,6 @@
             The CoEdges associated with this Edge
             </summary>
             <returns></returns>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Edge.ToString">
-            <summary> Get a string representation of the Edge </summary>
         </member>
         <member name="P:Autodesk.DesignScript.Geometry.Ellipse.CenterPoint">
             <summary>
@@ -1670,9 +1622,6 @@
             <returns>Ellipse created from plane and radii</returns>
             <search>ellipse,aligned ellipse,ellipsebylengths</search>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Ellipse.ToString">
-            <summary> Get a string representation of the Ellipse </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.EllipseArc.CenterPoint">
             <summary>
             The center of the Ellipse
@@ -1733,9 +1682,6 @@
             <returns>Ellipse arc created by plane radii and angles</returns>
             <search>ellipsearc,arcs</search>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.EllipseArc.ToString">
-            <summary> Get a string representation of the EllipseArc </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.Face.Edges">
             <summary>
             All of the Edges around this Face in counterclockwise order
@@ -1763,9 +1709,6 @@
             The underlying Surface making up the Face
             </summary>
             <returns>Surface representation of face</returns>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Face.ToString">
-            <summary> Get a string representation of the Face </summary>
         </member>
         <member name="F:Autodesk.DesignScript.Geometry.Geometry.mGeometryContructors">
             <summary>
@@ -1934,12 +1877,6 @@
             Scale in two dimensions by base and 2 pick points  The two pick points are projected onto the base plane in order to determine the 2d scale factors
             </summary>
             <search>resize,size,from,to,scale2d,2d</search>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Geometry.Clone">
-            <summary>
-            Copy the given Geometry
-            </summary>
-            <returns>A new copy</returns>
         </member>
         <member name="M:Autodesk.DesignScript.Geometry.Geometry.DistanceTo(Autodesk.DesignScript.Geometry.Geometry)">
             <summary>
@@ -2116,9 +2053,6 @@
             <param name="projectionDirection">Projection direction.</param>
             <returns>Flat array of resulting Geometry.</returns>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Geometry.ToString">
-            <summary> Get a string representation of the Geometry </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.Helix.Angle">
             <summary>
             The angle in degrees through which the Helix turns over its length
@@ -2160,9 +2094,6 @@
             <param name="angleTurns">How many turns in degrees</param>
             <returns>Helix created by axis</returns>
             <search>helix,screw,corkscrew,thread</search>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Helix.ToString">
-            <summary> Get a string representation of the Helix </summary>
         </member>
         <member name="P:Autodesk.DesignScript.Geometry.IndexGroup.Count">
             <summary>
@@ -2210,18 +2141,6 @@
             <param name="c">Index c</param>
             <returns>IndexGroup</returns>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.IndexGroup.Equals(System.Object)">
-            <summary> Compare two IndexGroup's </summary>
-            <param name="other">The other IndexGroup</param>
-            <returns>Whether the two objects are equal</returns>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.IndexGroup.GetHashCode">
-            <summary> Get a hashcode for this type </summary>
-            <returns> A unique hashcode for this object </returns>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.IndexGroup.ToString">
-            <summary> Get a string representation of the IndexGroup </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.Line.Direction">
             <summary>
             The direction of the Curve
@@ -2266,9 +2185,6 @@
             <returns>Line from start direction and length</returns>
             <search>linebyvector,lines</search>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Line.ToString">
-            <summary> Get a string representation of the Line </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.Loop.Face">
             <summary>
             The containing Face of the Loop
@@ -2285,9 +2201,6 @@
             <summary>
             Whether the loop is border or inner
             </summary>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Loop.ToString">
-            <summary> Get a string representation of the Loop </summary>
         </member>
         <member name="P:Autodesk.DesignScript.Geometry.Mesh.VerticesAsThreeNumbers">
             <summary>
@@ -2561,12 +2474,6 @@
             <summary>
             Translates the Mesh by the input distances
             </summary>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Mesh.MeshToJson(System.Double)">
-            <summary>
-            Convert the mesh into a JSON object formatted with dynamo.geometry:mesh-1.0.0 schema.
-            </summary>
-            <returns>The resulting JSON string</returns>
         </member>
         <member name="M:Autodesk.DesignScript.Geometry.Mesh.ByPointsFaceIndices(System.Collections.Generic.IEnumerable{Autodesk.DesignScript.Geometry.Point},System.Collections.Generic.IEnumerable{Autodesk.DesignScript.Geometry.IndexGroup})">
             <summary>
@@ -2845,9 +2752,6 @@
             <search>spline by tangent,tangents,lines</search>
             <weights>0.5,0.5,0.45</weights>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.NurbsCurve.ToString">
-            <summary> Get a string representation of the NurbsCurve </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.NurbsSurface.DegreeU">
             <summary>
             Returns surface degree in the U direction.
@@ -2973,9 +2877,6 @@
             </summary>
             <search>lines</search>
             <weights>0.4</weights>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.NurbsSurface.ToString">
-            <summary> Get a string representation of the NurbsSurface </summary>
         </member>
         <member name="T:Autodesk.DesignScript.Geometry.PanelSurfaceBoundaryCondition">
             <summary>
@@ -3194,9 +3095,6 @@
             <returns></returns>
             <search>panel, surface, custom, orthogonal, lattice</search>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.PanelSurface.ToString">
-            <summary> Get a string representation of the PanelSurface </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.Plane.Origin">
             <summary>
             Returns the origin of the Plane.
@@ -3311,9 +3209,6 @@
             </summary>
             <returns>Plane at YZ plane of world</returns>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Plane.ToString">
-            <summary> Get a string representation of the Plane </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.Point.X">
             <summary>
             Get the X component of a Point
@@ -3419,18 +3314,6 @@
             <param name="tolerance"> Tolerance used for pruning </param>
             <returns>Unique points</returns>
             <search>unique,duplicates,remove duplicates,distinct,near</search>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Point.Equals(Autodesk.DesignScript.Geometry.DesignScriptEntity)">
-            <summary> Compare two Point's </summary>
-            <param name="other">The other Point</param>
-            <returns>Whether the two objects are equal</returns>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Point.ComputeHashCode">
-            <summary> Get a hashcode for this type </summary>
-            <returns> A unique hashcode for this object </returns>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Point.ToString">
-            <summary> Get a string representation of the Point </summary>
         </member>
         <member name="P:Autodesk.DesignScript.Geometry.PolyCurve.Points">
             <summary>
@@ -3604,9 +3487,6 @@
             <param name="normal"> the normal perpendicular to the thickening direction. If the normal is not supplied (is null), the curve normal is used by default. </param>
             <search>offset,thicken</search>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.PolyCurve.ToString">
-            <summary> Get a string representation of the PolyCurve </summary>
-        </member>
         <member name="M:Autodesk.DesignScript.Geometry.Polygon.Corners">
             <summary>
             Returns corners of polygon
@@ -3651,9 +3531,6 @@
             <summary>
             Construct an inscribed Polygon Curve within a circle.
             </summary>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Polygon.ToString">
-            <summary> Get a string representation of the Polygon </summary>
         </member>
         <member name="M:Autodesk.DesignScript.Geometry.PolySurface.Surfaces">
             <summary>
@@ -3759,9 +3636,6 @@
             <param name="crossSection">  Sweep profile </param>
             <search>sweep,rail,guide,sweep1</search>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.PolySurface.ToString">
-            <summary> Get a string representation of the PolySurface </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.Rectangle.Width">
             <summary>
             The width of the Rectangle
@@ -3825,9 +3699,6 @@
             <param name="length">Length of rectangle</param>
             <returns>Rectangle created from width and length</returns>
             <search>rectbylengths</search>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Rectangle.ToString">
-            <summary> Get a string representation of the Rectangle </summary>
         </member>
         <member name="P:Autodesk.DesignScript.Geometry.Solid.Area">
             <summary>
@@ -3983,9 +3854,6 @@
             <returns></returns>
             <search>Brep,brep,boolean,addition</search>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Solid.ToString">
-            <summary> Get a string representation of the Solid </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.Sphere.CenterPoint">
             <summary>
             Return the center Point of the Sphere.
@@ -4013,9 +3881,6 @@
             Fit a Sphere as close as possible to the input Points.
             </summary>
             <search>Brep,brep</search>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Sphere.ToString">
-            <summary> Get a string representation of the Sphere </summary>
         </member>
         <member name="P:Autodesk.DesignScript.Geometry.Surface.Area">
             <summary>
@@ -4368,9 +4233,6 @@
             <returns>Surface created by patch</returns>
             <search>edgesrf,edgesurface,patch,fill</search>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Surface.ToString">
-            <summary> Get a string representation of the Surface </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.Topology.Vertices">
             <summary>
             The Vertices of the Topology
@@ -4388,9 +4250,6 @@
             The Faces of the Topology
             </summary>
             <returns></returns>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Topology.ToString">
-            <summary> Get a string representation of the Topology </summary>
         </member>
         <member name="P:Autodesk.DesignScript.Geometry.TSpline.TSplineEdge.AdjacentFaces">
             <summary>
@@ -4432,9 +4291,6 @@
             A bunch of TSEdge properties: uvnFrame and index, whether TSEdge is on Border, is Manifold or not
             </summary>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.TSpline.TSplineEdge.ToString">
-            <summary> Get a string representation of the TSplineEdge </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.TSpline.TSplineFace.Edges">
             <summary>
             All of the TSplineEdges around this Face in counterclockwise order
@@ -4472,9 +4328,6 @@
             A bunch of TSplineFace properties: uvnFrame, index, valence and number of sides
             </summary>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.TSpline.TSplineFace.ToString">
-            <summary> Get a string representation of the TSplineFace </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.TSpline.TSplineInitialSymmetry.IsRadial">
             <summary>
             Whether newly created t-spline has radial symmetry.
@@ -4511,9 +4364,6 @@
             Create an axial TSplineInitialSymmetry with given symmetry axes.
             </summary>
             <search>tspline,symmetry</search>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.TSpline.TSplineInitialSymmetry.ToString">
-            <summary> Get a string representation of the TSplineInitialSymmetry </summary>
         </member>
         <member name="P:Autodesk.DesignScript.Geometry.TSpline.TSplineReflection.IsRadial">
             <summary>
@@ -4558,9 +4408,6 @@
             <param name="segmentAngle">Angle between each pair of segments of radial symmetry (in degrees). If is set to 0 it is defined by (360 / segmentsCount)</param>
             <returns>T-Spline radial reflection</returns>
             <search>tspline,symmetry,reflection,radial</search>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.TSpline.TSplineReflection.ToString">
-            <summary> Get a string representation of the TSplineReflection </summary>
         </member>
         <member name="M:Autodesk.DesignScript.Geometry.TSpline.TSplineSurface.BuildPipes(System.Collections.Generic.IEnumerable{Autodesk.DesignScript.Geometry.Curve},System.Double,System.Double,System.Collections.Generic.IEnumerable{System.Int32},System.Boolean,System.Boolean,System.Collections.Generic.IEnumerable{System.Double},System.Collections.Generic.IEnumerable{System.Double},System.Collections.Generic.IEnumerable{System.Double},System.Collections.Generic.IEnumerable{System.Double},System.Collections.Generic.IEnumerable{System.Double},System.Collections.Generic.IEnumerable{System.Double},System.Boolean)">
             <inheritdoc cref="M:Autodesk.DesignScript.Interfaces.IGeometryFactory.TSplineSurfaceBuildPipes(Autodesk.DesignScript.Interfaces.ICurveEntity[],System.Double,System.Double,System.Int32[],System.Boolean,System.Boolean,System.Double[],System.Double[],System.Double[],System.Double[],System.Double[],System.Double[],System.Boolean)"/>
@@ -4758,7 +4605,7 @@
             In case of different t-splines combine is performed before the weld operation
             </summary>
             <param name="firstGroup">First group of vertices to weld</param>
-            <param name="secondGroup">Second group of vecrtices to weld</param>
+            <param name="secondGroup">Second group of vertices to weld</param>
             <param name="keepSubdCreases">Preserve the subd-creases of the input topology</param>
             <returns>TSpline surface with welded vertices</returns>
             <search>tspline,weld,vertex</search>
@@ -4855,7 +4702,7 @@
             </summary>
             <param name="enable">Enable or disable smooth visualization</param>
             <returns>t-spline with chosen visualization style</returns>
-            <search>tspline,visulization,mode,smooth,box</search>
+            <search>tspline,visualization,mode,smooth,box</search>
         </member>
         <member name="M:Autodesk.DesignScript.Geometry.TSpline.TSplineSurface.ExtrudeEdges(System.Collections.Generic.IEnumerable{Autodesk.DesignScript.Geometry.TSpline.TSplineEdge},Autodesk.DesignScript.Geometry.Vector,System.Int32)">
             <summary>
@@ -5254,7 +5101,7 @@
         </member>
         <member name="M:Autodesk.DesignScript.Geometry.TSpline.TSplineSurface.BySphereCenterPointRadius(Autodesk.DesignScript.Geometry.Point,System.Double,System.Int32,System.Int32,Autodesk.DesignScript.Geometry.TSpline.TSplineInitialSymmetry,System.Boolean)">
             <summary>
-            Create a T-Spline Sphere cetered at the input Point, with given radius.
+            Create a T-Spline Sphere centered at the input Point, with given radius.
             </summary>
             <param name="centerPoint">Center of a sphere</param>
             <param name="radius">Radius of a sphere</param>
@@ -5501,9 +5348,6 @@
             <param name="tSplineSurfaces">T-Spline Surfaces to combine</param>
             <search>tspline,combine</search>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.TSpline.TSplineSurface.ToString">
-            <summary> Get a string representation of the TSplineSurface </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.TSpline.TSplineTopology.Vertices">
             <summary>
             Vertices contained in this T-Spline Surface.
@@ -5641,9 +5485,6 @@
             <search>tspline,face,byindex</search>
             <returns>T-Spline Face</returns>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.TSpline.TSplineTopology.ToString">
-            <summary> Get a string representation of the TSplineTopology </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.TSpline.TSplineUVNFrame.Position">
             <summary>
             Point of the TopologyItem on the hull
@@ -5663,9 +5504,6 @@
             <summary>
             Normal of the TopologyItem
             </summary>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.TSpline.TSplineUVNFrame.ToString">
-            <summary> Get a string representation of the TSplineUVNFrame </summary>
         </member>
         <member name="P:Autodesk.DesignScript.Geometry.TSpline.TSplineVertex.AdjacentEdges">
             <summary>
@@ -5717,9 +5555,6 @@
             A bunch of TSVertex properties: uvnFrame, index, valence and functionalValence, whether TSVertex is a StarPoint, TPoint, Manifold or not
             </summary>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.TSpline.TSplineVertex.ToString">
-            <summary> Get a string representation of the TSplineVertex </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.UV.U">
             <summary>
             Get the U component of a UV
@@ -5744,18 +5579,6 @@
             <param name="v">V value</param>
             <returns>UV created by coordinates</returns>
             <search>surfaceparam,parameters,uv,uvs</search>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.UV.Equals(System.Object)">
-            <summary> Compare two UV's </summary>
-            <param name="other">The other UV</param>
-            <returns>Whether the two objects are equal</returns>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.UV.GetHashCode">
-            <summary> Get a hashcode for this type </summary>
-            <returns> A unique hashcode for this object </returns>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.UV.ToString">
-            <summary> Get a string representation of the UV </summary>
         </member>
         <member name="M:Autodesk.DesignScript.Geometry.Vector.FromJson(System.String)">
             <summary>
@@ -5947,18 +5770,6 @@
             <returns>Canonical Z axis vector (0,0,1)</returns>
             <search>z, basis,up</search>
         </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Vector.Equals(Autodesk.DesignScript.Geometry.DesignScriptEntity)">
-            <summary> Compare two Vector's </summary>
-            <param name="other">The other Vector</param>
-            <returns>Whether the two objects are equal</returns>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Vector.ComputeHashCode">
-            <summary> Get a hashcode for this type </summary>
-            <returns> A unique hashcode for this object </returns>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Vector.ToString">
-            <summary> Get a string representation of the Vector </summary>
-        </member>
         <member name="P:Autodesk.DesignScript.Geometry.Vertex.PointGeometry">
             <summary>
             The Point where this Vertex is located
@@ -5976,9 +5787,6 @@
             The Faces adjacent to this Vertex
             </summary>
             <returns></returns>
-        </member>
-        <member name="M:Autodesk.DesignScript.Geometry.Vertex.ToString">
-            <summary> Get a string representation of the Vertex </summary>
         </member>
         <member name="T:Autodesk.DesignScript.Geometry.Properties.Resources">
             <summary>
@@ -6346,128 +6154,6 @@
                Looks up a localized string similar to This method is deprecated and will be removed in a future version of Dynamo. Use  TSplineSurfaceBuildPipes(ICurveEntity[] curves, double defaultRadius, double snappingTolerance, int[] segmentCounts, bool autoHandleStart, bool autoHandleEnd, double[] startRotations, double[] endRotations, double[] startRadii, double[] endRadii, double[] startPositions, double[] endPositions, bool inSmoothMode) instead
             .
              </summary>
-        </member>
-        <member name="T:ProtoGeometryGenerator.GenerateFromInterfaceAttribute">
-            <summary>
-            The <see cref="T:ProtoGeometryGenerator.GenerateFromInterfaceAttribute"/> is the main attribute the generator looks for when it is
-            deciding the classes to auto implement. The <paramref name="protoInterface"/> type should
-            be a type from Autodesk.DesignScript.Interfaces and <paramref name="geometryFactoryInterface"/> should
-            be the source of all the static constructor methods for the interface.
-            <br /><br />
-            The attribute must be attached to a class that matches the protoInterface name, i.e. if the interface
-            is named IPointEntity, then the class must be named Point for the generator to work correctly.
-            <br /><br />
-            The generator will implement wrappers for every property and method on protoInterface
-            using ProtoGeometry as instance methods. In addition, all methods that start with the class name
-            (Point) on the factory interface will be implemented as static methods.
-            <br /><br />
-            Generated implementations can be overriden by implementing a property or method that exactly matches the
-            interface method signature. See <see cref="T:ProtoGeometryGenerator.GenerateShadowingAttribute"/> and <see cref="T:ProtoGeometryGenerator.GenerateOverrideAttribute"/> for
-            other ways to override automatic implementations.
-            </summary>
-        </member>
-        <member name="M:ProtoGeometryGenerator.GenerateFromInterfaceAttribute.#ctor(System.Type,System.Type,System.Type[])">
-            <summary>
-            The <see cref="T:ProtoGeometryGenerator.GenerateFromInterfaceAttribute"/> is the main attribute the generator looks for when it is
-            deciding the classes to auto implement. The <paramref name="protoInterface"/> type should
-            be a type from Autodesk.DesignScript.Interfaces and <paramref name="geometryFactoryInterface"/> should
-            be the source of all the static constructor methods for the interface.
-            <br /><br />
-            The attribute must be attached to a class that matches the protoInterface name, i.e. if the interface
-            is named IPointEntity, then the class must be named Point for the generator to work correctly.
-            <br /><br />
-            The generator will implement wrappers for every property and method on protoInterface
-            using ProtoGeometry as instance methods. In addition, all methods that start with the class name
-            (Point) on the factory interface will be implemented as static methods.
-            <br /><br />
-            Generated implementations can be overriden by implementing a property or method that exactly matches the
-            interface method signature. See <see cref="T:ProtoGeometryGenerator.GenerateShadowingAttribute"/> and <see cref="T:ProtoGeometryGenerator.GenerateOverrideAttribute"/> for
-            other ways to override automatic implementations.
-            </summary>
-        </member>
-        <member name="T:ProtoGeometryGenerator.GenerateOverrideAttribute">
-            <summary>
-            Replace the body of the named property or method with this implementation.
-            </summary>
-            <remarks>
-            Properties and methods implemented by the generator using the <see cref="T:ProtoGeometryGenerator.GenerateFromInterfaceAttribute"/> can
-            be overriden. This attribute will replace the body of the generated method, but let the generator handle
-            documentation, scaling, ASM extents checks and the required boilerplate.
-            </remarks>
-            <param name="overrideName">The method or property to override</param>
-            <param name="virtualKeyword">Implement the generated function as virtual</param>
-        </member>
-        <member name="M:ProtoGeometryGenerator.GenerateOverrideAttribute.#ctor(System.String,System.Boolean)">
-            <summary>
-            Replace the body of the named property or method with this implementation.
-            </summary>
-            <remarks>
-            Properties and methods implemented by the generator using the <see cref="T:ProtoGeometryGenerator.GenerateFromInterfaceAttribute"/> can
-            be overriden. This attribute will replace the body of the generated method, but let the generator handle
-            documentation, scaling, ASM extents checks and the required boilerplate.
-            </remarks>
-            <param name="overrideName">The method or property to override</param>
-            <param name="virtualKeyword">Implement the generated function as virtual</param>
-        </member>
-        <member name="T:ProtoGeometryGenerator.GenerateShadowingAttribute">
-            <summary>
-            Properties and methods implemented by the generator using the <see cref="T:ProtoGeometryGenerator.GenerateFromInterfaceAttribute"/> can
-            be overriden. This attribute will prevent the generation of a method named <paramref name="overrideName"/> 
-            whose params exactly matches the <paramref name="parameterTypes"/> array.
-            <br /><br />
-            Some of the methods in the library don't match the generated output exactly, meaning the generator can't see
-            them as overrides. This attribute lets a method take the place of another method, by explicitly shadowing
-            what the generator would have implemented.
-            <br /><br />
-            Several [class]es implement a static FromJson method that takes a single <see langword="string"/>, where
-            the factory interface has a method [class]FromJson that takes <see langword="string"/> and <see langword="double"/>.
-            This attribute lets the single <see langword="string"/> version override the automatic one. 
-            </summary>
-        </member>
-        <member name="M:ProtoGeometryGenerator.GenerateShadowingAttribute.#ctor(System.String,System.Type[])">
-            <summary>
-            Properties and methods implemented by the generator using the <see cref="T:ProtoGeometryGenerator.GenerateFromInterfaceAttribute"/> can
-            be overriden. This attribute will prevent the generation of a method named <paramref name="overrideName"/> 
-            whose params exactly matches the <paramref name="parameterTypes"/> array.
-            <br /><br />
-            Some of the methods in the library don't match the generated output exactly, meaning the generator can't see
-            them as overrides. This attribute lets a method take the place of another method, by explicitly shadowing
-            what the generator would have implemented.
-            <br /><br />
-            Several [class]es implement a static FromJson method that takes a single <see langword="string"/>, where
-            the factory interface has a method [class]FromJson that takes <see langword="string"/> and <see langword="double"/>.
-            This attribute lets the single <see langword="string"/> version override the automatic one. 
-            </summary>
-        </member>
-        <member name="T:ProtoGeometryGenerator.PropertyReplacementFieldAttribute">
-            <summary>
-            This attribute lets an interface property be auto generated from a backing field, letting that
-            field take the property's place in the ToString, Equals and HashCode methods.
-            Special handling is added for Point and Vector types when backed by a Coordinate.
-            This also lets the generator handle documentation for the property.
-            </summary>
-        </member>
-        <member name="M:ProtoGeometryGenerator.PropertyReplacementFieldAttribute.#ctor(System.String,System.String)">
-            <summary>
-            This attribute lets an interface property be auto generated from a backing field, letting that
-            field take the property's place in the ToString, Equals and HashCode methods.
-            Special handling is added for Point and Vector types when backed by a Coordinate.
-            This also lets the generator handle documentation for the property.
-            </summary>
-        </member>
-        <member name="T:ProtoGeometryGenerator.OverrideCompareUsingAttribute">
-            <summary>
-            This attribute lets a class override the CompareUsing attribute on the defining interface
-            (or set one at all if it is missing). This in turn lets the generator create the
-            (Get|Compute)HashCode and Equals methods for the class based on the supplied property names.
-            </summary>
-        </member>
-        <member name="M:ProtoGeometryGenerator.OverrideCompareUsingAttribute.#ctor(System.String[])">
-            <summary>
-            This attribute lets a class override the CompareUsing attribute on the defining interface
-            (or set one at all if it is missing). This in turn lets the generator create the
-            (Get|Compute)HashCode and Equals methods for the class based on the supplied property names.
-            </summary>
         </member>
     </members>
 </doc>

--- a/doc/distrib/xml/en-US/Tessellation.XML
+++ b/doc/distrib/xml/en-US/Tessellation.XML
@@ -82,7 +82,7 @@
                 Utility functions for UV scaling on surfaces.
             </summary>
         </member>
-        <member name="M:Tessellation.UvScalingUtilities.GetNormalizedUvScales(Autodesk.DesignScript.Geometry.Surface)">
+        <member name="F:Tessellation.UvScalingUtilities.NonUniformityThreshold">
             <summary>
                 Computes normalized UV scaling factors for a surface to handle anisotropic parameter spaces.
                 The scaling preserves the aspect ratio while keeping values in a reasonable numerical range.

--- a/src/Libraries/Tesellation/UvScalingUtilities.cs
+++ b/src/Libraries/Tesellation/UvScalingUtilities.cs
@@ -36,7 +36,7 @@ namespace Tessellation
                 scaleV += vCurve.Length;
             }
             scaleU /= interiorSamples.Length;
-            scaleV /= interiorSamples.Length; 
+            scaleV /= interiorSamples.Length;
 
             // Normalize scales to preserve aspect ratio; keep values in a reasonable numerical range.
             var max = System.Math.Max(scaleU, scaleV);

--- a/src/Libraries/Tesellation/UvScalingUtilities.cs
+++ b/src/Libraries/Tesellation/UvScalingUtilities.cs
@@ -17,41 +17,54 @@ namespace Tessellation
         /// minimum physical arc length of the surface (world units) across U and V.
         /// The minimum scale is the shorter of the two average iso-curve lengths and is used
         /// to derive world-space distance thresholds that scale correctly with the surface.</returns>
+        // A direction whose isoline lengths vary more than this factor across the domain has a
+        // non-uniform parameterization (e.g. sphere poles, cone apex). A single global scale
+        // factor cannot correct for position-dependent distortion, so scaling is skipped.
+        private const double NonUniformityThreshold = 3.0;
+
         internal static (double normU, double normV, double minPhysicalScale) GetNormalizedUvScales(Surface face)
         {
-            // Physical arc length per unit U/V based on the average iso-curve length across
-            // three interior sample positions. Sampling at boundary extrema (0 or 1) fails for
-            // surfaces where those extrema are degenerate points — sphere poles, cone apex —
-            // because the isoline length collapses to near-zero there. Interior sampling avoids
-            // this: for a sphere the equatorial isoline (t=0.5) gives the correct scale, and
-            // for a non-degenerate surface all interior isolines have similar length so the
-            // result is unchanged from the previous boundary-average approach.
-            double scaleU = 0.0;
-            double scaleV = 0.0;
-            ReadOnlySpan<double> interiorSamples = [0.25, 0.5, 0.75];
-            foreach (var t in interiorSamples)
+            // Sample at five positions spanning the interior, including near-boundary positions
+            // (0.1 / 0.9) to amplify the signal from surfaces that are degenerate at their
+            // extrema (sphere poles, cone apex) without hitting the degenerate point itself.
+            ReadOnlySpan<double> samples = [0.1, 0.25, 0.5, 0.75, 0.9];
+            double scaleU = 0.0, scaleV = 0.0;
+            double minU = double.MaxValue, maxU = 0.0;
+            double minV = double.MaxValue, maxV = 0.0;
+
+            foreach (var t in samples)
             {
                 using var uCurve = face.GetIsoline(0, t);
                 using var vCurve = face.GetIsoline(1, t);
-                scaleU += uCurve.Length;
-                scaleV += vCurve.Length;
+                var lu = uCurve.Length;
+                var lv = vCurve.Length;
+                scaleU += lu; scaleV += lv;
+                minU = Math.Min(minU, lu); maxU = Math.Max(maxU, lu);
+                minV = Math.Min(minV, lv); maxV = Math.Max(maxV, lv);
             }
-            scaleU /= interiorSamples.Length;
-            scaleV /= interiorSamples.Length;
+            scaleU /= samples.Length;
+            scaleV /= samples.Length;
 
-            // Normalize scales to preserve aspect ratio; keep values in a reasonable numerical range.
-            var max = System.Math.Max(scaleU, scaleV);
+            // minPhysicalScale is the shorter average dimension, used by callers to derive
+            // world-space distance thresholds that scale with the surface size.
+            var minPhysicalScale = Math.Min(scaleU, scaleV);
+            if (minPhysicalScale <= 1e-9) minPhysicalScale = 1.0;
+
+            // If isolines in either direction vary more than NonUniformityThreshold across the
+            // domain, the parameterization distortion is spatially non-uniform. A global scale
+            // cannot fix position-dependent distortion and would only introduce asymmetry, so
+            // return identity scaling and let callers work in raw UV space.
+            if (maxU > minU * NonUniformityThreshold || maxV > minV * NonUniformityThreshold)
+                return (1.0, 1.0, minPhysicalScale);
+
+            // Normalize to preserve aspect ratio; guard against degenerate (zero-area) surfaces.
+            var max = Math.Max(scaleU, scaleV);
             if (max <= 1e-9) max = 1.0;
 
             var normU = scaleU / max;
             var normV = scaleV / max;
-
             if (normU <= 1e-9) normU = 1.0;
             if (normV <= 1e-9) normV = 1.0;
-
-            // minPhysicalScale is the shorter physical dimension of the surface in world units.
-            var minPhysicalScale = System.Math.Min(scaleU, scaleV);
-            if (minPhysicalScale <= 1e-9) minPhysicalScale = 1.0;
 
             return (normU, normV, minPhysicalScale);
         }

--- a/src/Libraries/Tesellation/UvScalingUtilities.cs
+++ b/src/Libraries/Tesellation/UvScalingUtilities.cs
@@ -1,3 +1,4 @@
+using System;
 using Autodesk.DesignScript.Geometry;
 
 namespace Tessellation
@@ -18,7 +19,7 @@ namespace Tessellation
         /// to derive world-space distance thresholds that scale correctly with the surface.</returns>
         internal static (double normU, double normV, double minPhysicalScale) GetNormalizedUvScales(Surface face)
         {
-            // Physical arc length per unit U/V based on the maximum iso-curve length across
+            // Physical arc length per unit U/V based on the average iso-curve length across
             // three interior sample positions. Sampling at boundary extrema (0 or 1) fails for
             // surfaces where those extrema are degenerate points — sphere poles, cone apex —
             // because the isoline length collapses to near-zero there. Interior sampling avoids
@@ -27,7 +28,7 @@ namespace Tessellation
             // result is unchanged from the previous boundary-average approach.
             double scaleU = 0.0;
             double scaleV = 0.0;
-            double[] interiorSamples = { 0.25, 0.5, 0.75 };
+            ReadOnlySpan<double> interiorSamples = [0.25, 0.5, 0.75];
             foreach (var t in interiorSamples)
             {
                 using var uCurve = face.GetIsoline(0, t);

--- a/src/Libraries/Tesellation/UvScalingUtilities.cs
+++ b/src/Libraries/Tesellation/UvScalingUtilities.cs
@@ -18,17 +18,25 @@ namespace Tessellation
         /// to derive world-space distance thresholds that scale correctly with the surface.</returns>
         internal static (double normU, double normV, double minPhysicalScale) GetNormalizedUvScales(Surface face)
         {
-            // Physical arc length per unit U/V based on average iso-curve lengths along the surface edges.
-            double scaleU;
-            double scaleV;
-            using (var uCurveV0 = face.GetIsoline(0, 0))
-            using (var uCurveV1 = face.GetIsoline(0, 1))
-            using (var vCurveU0 = face.GetIsoline(1, 0))
-            using (var vCurveU1 = face.GetIsoline(1, 1))
+            // Physical arc length per unit U/V based on the maximum iso-curve length across
+            // three interior sample positions. Sampling at boundary extrema (0 or 1) fails for
+            // surfaces where those extrema are degenerate points — sphere poles, cone apex —
+            // because the isoline length collapses to near-zero there. Interior sampling avoids
+            // this: for a sphere the equatorial isoline (t=0.5) gives the correct scale, and
+            // for a non-degenerate surface all interior isolines have similar length so the
+            // result is unchanged from the previous boundary-average approach.
+            double scaleU = 0.0;
+            double scaleV = 0.0;
+            double[] interiorSamples = { 0.25, 0.5, 0.75 };
+            foreach (var t in interiorSamples)
             {
-                scaleU = (uCurveV0.Length + uCurveV1.Length) / 2.0;
-                scaleV = (vCurveU0.Length + vCurveU1.Length) / 2.0;
+                using var uCurve = face.GetIsoline(0, t);
+                using var vCurve = face.GetIsoline(1, t);
+                scaleU += uCurve.Length;
+                scaleV += vCurve.Length;
             }
+            scaleU /= interiorSamples.Length;
+            scaleV /= interiorSamples.Length; 
 
             // Normalize scales to preserve aspect ratio; keep values in a reasonable numerical range.
             var max = System.Math.Max(scaleU, scaleV);

--- a/test/Libraries/TessellationTests/DelaunayVoronoiOnSurfaceTests.cs
+++ b/test/Libraries/TessellationTests/DelaunayVoronoiOnSurfaceTests.cs
@@ -7,7 +7,6 @@ using MIConvexHull;
 using NUnit.Framework;
 using Tessellation;
 using Tessellation.Adapters;
-using static Lucene.Net.Documents.Field;
 
 namespace Dynamo.Tests
 {
@@ -86,8 +85,6 @@ namespace Dynamo.Tests
             var guid = "293e4004-d728-45b1-9b7f-448c53adf3c0";
             var node1 = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace(guid);
             Assert.NotNull(node1);
-
-            //BeginRun();
 
             // check the output values are correctly computed
             AssertPreviewCount(guid, 968);

--- a/test/Libraries/TessellationTests/DelaunayVoronoiOnSurfaceTests.cs
+++ b/test/Libraries/TessellationTests/DelaunayVoronoiOnSurfaceTests.cs
@@ -1,17 +1,31 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Autodesk.DesignScript.Geometry;
 using MIConvexHull;
 using NUnit.Framework;
 using Tessellation;
 using Tessellation.Adapters;
+using static Lucene.Net.Documents.Field;
 
 namespace Dynamo.Tests
 {
     [TestFixture]
     public class DelaunayVoronoiOnSurfaceTests : DynamoModelTestBase
     {
+
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("VMDataBridge.dll");
+            libraries.Add("ProtoGeometry.dll");
+            libraries.Add("DesignScriptBuiltin.dll");
+            libraries.Add("DSCoreNodes.dll");
+            libraries.Add("FunctionObject.ds");
+            libraries.Add("BuiltIn.ds");
+            libraries.Add("Tessellation.dll");
+            base.GetLibrariesToPreload(libraries);
+        }
 
         // Validates that Delaunay.ByParametersOnSurface produces the expected triangulation edges
         // (in world space) on a strongly anisotropic surface, and that the triangulation satisfies
@@ -61,6 +75,32 @@ namespace Dynamo.Tests
 
             // Validate that the API output matches the Voronoi edges implied by the Delaunay dual.
             AssertVoronoiEdgesMatchDelaunayDual(uvs, triangles, surface, edges);
+        }
+
+        [Test]
+        public void Voronoi_ByParametersOnSurface_WorksWithSphericalSurface()
+        {
+            string openPath = Path.Combine(TestDirectory, @"core\GeometryTestFiles\tesselationwithcoincidentgridsRemember.dyn");
+            RunModel(openPath);
+
+            var guid = "293e4004-d728-45b1-9b7f-448c53adf3c0";
+            var node1 = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace(guid);
+            Assert.NotNull(node1);
+
+            //BeginRun();
+
+            // check the output values are correctly computed
+            AssertPreviewCount(guid, 968);
+
+            var obj = GetPreviewValueAtIndex(guid, 0);
+            Assert.IsInstanceOf<Line>(obj);
+
+            Assert.AreEqual(-8.256, ((Line)obj).StartPoint.X, 1e-3);
+            Assert.AreEqual(62.260, ((Line)obj).StartPoint.Y, 1e-3);
+            Assert.AreEqual(-43.304, ((Line)obj).StartPoint.Z, 1e-3);
+            Assert.AreEqual(-9.973, ((Line)obj).EndPoint.X, 1e-3);
+            Assert.AreEqual(63.845, ((Line)obj).EndPoint.Y, 1e-3);
+            Assert.AreEqual(-32.462, ((Line)obj).EndPoint.Z, 1e-3); 
         }
 
         private static Surface CreateSurface(double width, double height)

--- a/test/core/GeometryTestFiles/tesselationwithcoincidentgridsRemember.dyn
+++ b/test/core/GeometryTestFiles/tesselationwithcoincidentgridsRemember.dyn
@@ -1,0 +1,841 @@
+{
+  "Uuid": "08858f5f-39cb-49d6-acaf-e9bb3dd9ed8d",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "tesselationwithcoincidentgridsRemember",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [
+    {
+      "Id": "50f2745f27ba4565ae5c751cae3857bb",
+      "Name": "Number Slider",
+      "Type": "number",
+      "Type2": "number",
+      "Value": "6.515",
+      "MaximumValue": 20.0,
+      "MinimumValue": 0.0,
+      "StepValue": 0.1,
+      "NumberType": "Double",
+      "Description": "Produces numeric values"
+    },
+    {
+      "Id": "f3f4dcb5a7c445d1b7f4abda1090be4d",
+      "Name": "Number Slider",
+      "Type": "number",
+      "Type2": "number",
+      "Value": "20",
+      "MaximumValue": 20.0,
+      "MinimumValue": 0.0,
+      "StepValue": 0.1,
+      "NumberType": "Double",
+      "Description": "Produces numeric values"
+    }
+  ],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleSlider, CoreNodeModels",
+      "NumberType": "Double",
+      "MaximumValue": 20.0,
+      "MinimumValue": 0.0,
+      "StepValue": 0.1,
+      "Id": "50f2745f27ba4565ae5c751cae3857bb",
+      "NodeType": "NumberInputNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "100e21fd057045078c0f8cb1f626a759",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Produces numeric values",
+      "InputValue": 6.515
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleSlider, CoreNodeModels",
+      "NumberType": "Double",
+      "MaximumValue": 20.0,
+      "MinimumValue": 0.0,
+      "StepValue": 0.1,
+      "Id": "f3f4dcb5a7c445d1b7f4abda1090be4d",
+      "NodeType": "NumberInputNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "c93401ab30bd470c98efdc84a1af4d44",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Produces numeric values",
+      "InputValue": 20.0
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "Id": "50d5b75a17f2420a873393a006ffc8d0",
+      "NodeType": "CodeBlockNode",
+      "Inputs": [
+        {
+          "Id": "1e2cff87a7004a5bb14afd5d535bb922",
+          "Name": "domain",
+          "Description": "domain",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "5a460d95b1ab491488fc5f3f9ac3925f",
+          "Name": "ucount",
+          "Description": "ucount",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f2a66e6521424aa5ad812831abe3a33b",
+          "Name": "vcount",
+          "Description": "vcount",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "aa0f0e5ebd0b4f179949a918a8136d55",
+          "Name": "range",
+          "Description": "DesignScript.Builtin.Get.ValueAtIndex(DesignScript.Builtin.Get.ValueAtIndex(domain, 0), 0)..DesignScript.Builtin.Get.ValueAtIndex(DesignScript.Builtin.Get.ValueAtIndex(domain, 1), 0)..#ucount + 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "3dc0a98735e4444c81e4fabbb958a2d9",
+          "Name": "range",
+          "Description": "DesignScript.Builtin.Get.ValueAtIndex(DesignScript.Builtin.Get.ValueAtIndex(domain, 0), 1)..DesignScript.Builtin.Get.ValueAtIndex(DesignScript.Builtin.Get.ValueAtIndex(domain, 1), 1)..#vcount + 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly",
+      "Code": "domain[0][0]..domain[1][0]..#ucount+1;\ndomain[0][1]..domain[1][1]..#vcount+1;"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "573617cd91d34b45b0080b90484bf992",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "2c8692c55e884abab5e87c1a3517c5ff",
+          "Name": "u",
+          "Description": "U value\n\ndouble\nDefault value : 0 (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "9a5a5af049004b31bed4f6272d0a1407",
+          "Name": "v",
+          "Description": "V value\n\ndouble\nDefault value : 0 (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "8e72b6143b484eddb4a9c759889bc3a9",
+          "Name": "UV",
+          "Description": "UV created by coordinates",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.UV.ByCoordinates@double,double",
+      "Replication": "CrossProduct",
+      "Description": "Create a UV from two doubles.\n\nUV.ByCoordinates (u: double = 0, v: double = 0): UV"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "1f15fcf669d740b2aa8ae23179caf3f5",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "84e771bf7bc54e79ba0d8baa66c331dc",
+          "Name": "list",
+          "Description": "List to flatten.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "c9d6168a21fb4fb6888f82f9cfdddd01",
+          "Name": "amount",
+          "Description": "Layers of list nesting to remove (-1 will remove all list nestings)\n\nint\nDefault value : -1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "d8fc8e1bfae649c8bd4f4a139edb0dc0",
+          "Name": "list",
+          "Description": "Flattened list by amount",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "DSCore.List.Flatten@var[]..[],int",
+      "Replication": "Auto",
+      "Description": "Flattens a nested list of lists by a certain amount.\n\nList.Flatten (list: var[]..[], amount: int = -1): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "Id": "2384d52a663249449665a0219cdb0b20",
+      "NodeType": "CodeBlockNode",
+      "Inputs": [
+        {
+          "Id": "35462ed893d34a2abb2989c040fac53f",
+          "Name": "domain",
+          "Description": "domain",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "76bffa9192c345a2b85ad4f8afd5a846",
+          "Name": "ucount",
+          "Description": "ucount",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "3d54bac29d7d4da4856f70cbb8f7ceac",
+          "Name": "vcount",
+          "Description": "vcount",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "66c4b99f1c174f58aa18bdafe534080b",
+          "Name": "range",
+          "Description": "DesignScript.Builtin.Get.ValueAtIndex(DesignScript.Builtin.Get.ValueAtIndex(domain, 0), 0)..DesignScript.Builtin.Get.ValueAtIndex(DesignScript.Builtin.Get.ValueAtIndex(domain, 1), 0)..#ucount + 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "548c01a306484654a145ce8f14279b87",
+          "Name": "range",
+          "Description": "DesignScript.Builtin.Get.ValueAtIndex(DesignScript.Builtin.Get.ValueAtIndex(domain, 0), 1)..DesignScript.Builtin.Get.ValueAtIndex(DesignScript.Builtin.Get.ValueAtIndex(domain, 1), 1)..#vcount + 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly",
+      "Code": "domain[0][0]..domain[1][0]..#ucount+1;\ndomain[0][1]..domain[1][1]..#vcount+1;"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "5e258b461843425294505ef6b4abb1e7",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "b9e4126c8d39489f87679d0d04294dde",
+          "Name": "u",
+          "Description": "U value\n\ndouble\nDefault value : 0 (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "e5eeb923c9944082bb715971fc07d2af",
+          "Name": "v",
+          "Description": "V value\n\ndouble\nDefault value : 0 (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "d4ad3d868f0a4264bd70ff41f1356720",
+          "Name": "UV",
+          "Description": "UV created by coordinates",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.UV.ByCoordinates@double,double",
+      "Replication": "CrossProduct",
+      "Description": "Create a UV from two doubles.\n\nUV.ByCoordinates (u: double = 0, v: double = 0): UV"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "88db9d3b458946d2b0206455db902bed",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "09c52ee505874c1eafb62cc3a36a3d5f",
+          "Name": "list",
+          "Description": "List to flatten.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "e47f6982e4c742ef9514b22296eac58f",
+          "Name": "amount",
+          "Description": "Layers of list nesting to remove (-1 will remove all list nestings)\n\nint\nDefault value : -1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "14fe6296d4cb42399ddb60379b50e3ec",
+          "Name": "list",
+          "Description": "Flattened list by amount",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "DSCore.List.Flatten@var[]..[],int",
+      "Replication": "Auto",
+      "Description": "Flattens a nested list of lists by a certain amount.\n\nList.Flatten (list: var[]..[], amount: int = -1): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction, DynamoCore",
+      "FunctionSignature": "DSCore.List.Join@var[]..[]",
+      "FunctionType": "VariableArgument",
+      "Id": "bb4f62e83b0a4242b346533d7e81c258",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "2a5a82fefa9046038827f2d958ca4857",
+          "Name": "list0",
+          "Description": "Lists to join into one.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "dbb9422b755444349ae513dd690692f0",
+          "Name": "list1",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "2593bc92b1e344ab8e59d254e7cdec2e",
+          "Name": "list",
+          "Description": "Joined list.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Concatenates all given lists into a single list.\n\nList.Join (lists: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "Id": "82d45936f9464bafa39afa4b51392df0",
+      "NodeType": "CodeBlockNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "af54d53682f94c409802dd3c95c17a19",
+          "Name": "list",
+          "Description": "[[0, 0], [1, 1]]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly",
+      "Code": "[[0,0],[1,1]];"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "c792841449d74386b3cdb847138cd9e1",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "f2e00744453b4a7e8b47643067119bf9",
+          "Name": "uvs",
+          "Description": "Set of UV parameters.\n\nUV[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "5173573b207b43a5a598f5396009c628",
+          "Name": "face",
+          "Description": "Surface to tesselate.\n\nSurface",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "5d3968379c3e4f768ee2ee0a3e9318bf",
+          "Name": "Curve[]",
+          "Description": "Curve[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "Tessellation.Voronoi.ByParametersOnSurface@Autodesk.DesignScript.Geometry.UV[],Autodesk.DesignScript.Geometry.Surface",
+      "Replication": "Auto",
+      "Description": "Creates a Voronoi tessellation of a surface with a given set of UV parameters.\n\nVoronoi.ByParametersOnSurface (uvs: UV[], face: Surface): Curve[]"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Remember, CoreNodeModels",
+      "Cache": "[{\"ConcreteTypeid\":\"dynamo.geometry:sab-1.0.0\",\"sab\":\"QUNJUyBCaW5hcnlGaWxlvAIAAAAAAAABAAAAAAAAAAcETGliRwcUQVNNIDIzMi4wLjEuNjU1MzUgTlQHGE1vbiBBcHIgMjcgMDc6MzU6MzUgMjAyNgYAAAAAAECPQAaN7bWg98awPga7vdfZ33zbPQ0EYm9keQz/////BP////8M/////wwBAAAADP////8MAgAAABENBGx1bXAM/////wT/////DP////8M/////wwDAAAADAAAAAARDQl0cmFuc2Zvcm0M/////wT/////FAAAAAAAAPA/AAAAAAAAAAAAAAAAAAAAABQAAAAAAAAAAAAAAAAAAPA/AAAAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPA/FAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAADwPwsLCxENBXNoZWxsDP////8E/////wz/////DP////8M/////wwEAAAADP////8MAQAAABENBGZhY2UM/////wT/////DP////8M/////wwFAAAADAMAAAAM/////wwGAAAACwoLEQ0EbG9vcAz/////BP////8M/////wwHAAAADAgAAAAMBAAAABEOBXRvcnVzDQdzdXJmYWNlDP////8E/////wz/////E1PteCW9riXA0QTIgMwLGMCgFcG3nvs6wBQ5OTk5OTnZPAAAAAAAAPA/AAAAAAAAAAAGFrEfDjcA8T8GAAAAAACAUUAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPA/CwsLCwsRDQRsb29wDP////8E/////wz/////DAkAAAAMCgAAAAwEAAAAEQ0GY29lZGdlDP////8E/////wz/////DAgAAAAMCAAAAAz/////DAsAAAALDAUAAAAM/////xENBGxvb3AM/////wT/////DP////8M/////wwMAAAADAQAAAARDQZjb2VkZ2UM/////wT/////DP////8MCgAAAAwKAAAADP////8MDQAAAAsMBwAAAAz/////EQ0EZWRnZQz/////BP////8M/////wwOAAAABgAAAAAAAPA/DA4AAAAGAAAAAAAAAAAMCAAAAAz/////CwcHdW5rbm93bhENBmNvZWRnZQz/////BP////8M/////wwPAAAADBAAAAAM/////wwRAAAACwwJAAAADP////8RDQRlZGdlDP////8E/////wz/////DBIAAAAGAAAAAAAA8D8MEgAAAAYAAAAAAAAAAAwKAAAADP////8LBwd1bmtub3duEQ0GdmVydGV4DP////8E/////wz/////DAsAAAAMEwAAABENBmNvZWRnZQz/////BP////8M/////wwUAAAADAwAAAAM/////wwVAAAACwwJAAAADP////8RDQZjb2VkZ2UM/////wT/////DP////8MDAAAAAwUAAAADP////8MFgAAAAsMCQAAAAz/////EQ0EZWRnZQz/////BP////8M/////wwXAAAABqMvPODXv4q8DBgAAAAGIb6RG4seA0AMDAAAAAwZAAAACwcHdW5rbm93bhENBnZlcnRleAz/////BP////8M/////wwNAAAADBoAAAARDQVwb2ludAz/////BP////8M/////xOK7Xglva4lwPsWgKU4AFPAoBXBt577OsARDQZjb2VkZ2UM/////wT/////DP////8MEAAAAAwPAAAADP////8MGwAAAAsMCQAAAAz/////EQ0EZWRnZQz/////BP////8M/////wwYAAAABsOfNYHBpNc8DBwAAAAGGjkt2nBe/z8MDwAAAAwdAAAACwcHdW5rbm93bhENBGVkZ2UM/////wT/////DP////8MHgAAAAZWL26ShejyPAwXAAAABio5LdpwXv8/DBAAAAAMHwAAAAsHB3Vua25vd24RDQZ2ZXJ0ZXgM/////wT/////DP////8MEQAAAAwgAAAAEQ0GdmVydGV4DP////8E/////wz/////DBEAAAAMIQAAABEOB2VsbGlwc2UNBWN1cnZlDP////8E/////wz/////E0QP3RP1NSfAyATIgMwLGMB7yru/mT46wBRSif7eiTzmv+JIm+gFddI8YYzku/8C578UfC49KOeiPcC7jUS8iEpMwHZOVkZPozxABgAAAAAAAPA/CgajLzzg17+KvAoGIb6RG4seA0ARDQVwb2ludAz/////BP////8M/////xMc7Xglva4lwMIszip+/U9AoBXBt577OsARDQRlZGdlDP////8E/////wz/////DBwAAAAGg65VNhwx/TwMHgAAAAYjvpEbix4DQAwUAAAADCIAAAALBwd1bmtub3duEQ0GdmVydGV4DP////8E/////wz/////DBUAAAAMIwAAABEOB2VsbGlwc2UNBWN1cnZlDP////8E/////wz/////ExzteCW9riXAxnMQGb27T0CgFcG3nvs6wBQy5X/Ggp7PPAAAAAAAAPA/Thgr64y4prwUQBhq71eYG8AAAAAAAAAAPayY5cVaqhpABgAAAAAAAPA/CgbDnzWBwaTXPAoGGjkt2nBe/z8RDQZ2ZXJ0ZXgM/////wT/////DP////8MGwAAAAwkAAAAEQ4HZWxsaXBzZQ0FY3VydmUM/////wT/////DP////8TgO14Jb2uJcBZjl1MAkxPwJ4Vwbee+zrAFF1Rm2obHdm8AAAAAAAA8L95t+FF0wuyPBQOTDx3s1xDQAAAAAAAACy9KvNLKFn1MEAGAAAAAAAA8D8KBlYvbpKF6PI8CgYqOS3acF7/PxENBXBvaW50DP////8E/////wz/////Ew/bFdnwnkTAVI5dTAJMT8DYH9Q0rCUDQBENBXBvaW50DP////8E/////wz/////E5v8lo50vTHAyHMQGb27T0Bzr0cGCFE0wBEOB2VsbGlwc2UNBWN1cnZlDP////8E/////wz/////E4jZeyBnvCPAuATIgMwLGMCdRvKmgI46wBQTcCqEZazZP+B1WIR84MO8P3KHt/tP7b8U/K/pWexBH0AxupRUm15RQGBs8fqEYAtABgAAAAAAAPA/CgaDrlU2HDH9PAoGI76RG4seA0ARDQVwb2ludAz/////BP////8M/////xN+AhzOw20AwMVzEBm9u09A4BiUB3AiN8ARDQVwb2ludAz/////BP////8M/////xOmIbxbCOI7QDqOXUwCTE/APETqHosMJMARDgNFbmQOAm9mDgRBQ0lTDQRkYXRh\"}]",
+      "Id": "4dd957679d5c4708b4f7f8acbc73ea7a",
+      "NodeType": "ExtensionNode",
+      "Inputs": [
+        {
+          "Id": "86a81954b54f4652b20301529a11d0da",
+          "Name": ">",
+          "Description": "Data to sample and store in the file.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "bb96d81f42e6448681326ca23ea0e86a",
+          "Name": ">",
+          "Description": "Data",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Store data passing through this node to the Dynamo file. Return the stored data if the input is null."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "293e4004d72845b19b7f448c53adf3c0",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "2861bfb9581f441aa59be1518acbee75",
+          "Name": "list",
+          "Description": "List to flatten.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "4c87422daa234cc897678000800dfe2c",
+          "Name": "amount",
+          "Description": "Layers of list nesting to remove (-1 will remove all list nestings)\n\nint\nDefault value : -1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "2b43196b5c44475ead262e515be9e387",
+          "Name": "list",
+          "Description": "Flattened list by amount",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "DSCore.List.Flatten@var[]..[],int",
+      "Replication": "Auto",
+      "Description": "Flattens a nested list of lists by a certain amount.\n\nList.Flatten (list: var[]..[], amount: int = -1): var[]..[]"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "100e21fd057045078c0f8cb1f626a759",
+      "End": "5a460d95b1ab491488fc5f3f9ac3925f",
+      "Id": "b31d449085994d8fa250c5e9938222e9",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "100e21fd057045078c0f8cb1f626a759",
+      "End": "f2a66e6521424aa5ad812831abe3a33b",
+      "Id": "a5de8099c5bc42849039583f45e33ed0",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "c93401ab30bd470c98efdc84a1af4d44",
+      "End": "76bffa9192c345a2b85ad4f8afd5a846",
+      "Id": "de3ecf3ca4f34f35bea1bc401c10e940",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "c93401ab30bd470c98efdc84a1af4d44",
+      "End": "3d54bac29d7d4da4856f70cbb8f7ceac",
+      "Id": "56a4f0731abe4aae805fec396d1fb6ef",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "aa0f0e5ebd0b4f179949a918a8136d55",
+      "End": "2c8692c55e884abab5e87c1a3517c5ff",
+      "Id": "b943e6e0a84b40cdad9c01d344695f67",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "3dc0a98735e4444c81e4fabbb958a2d9",
+      "End": "9a5a5af049004b31bed4f6272d0a1407",
+      "Id": "43c68477b3844042a5789af033ec2410",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "8e72b6143b484eddb4a9c759889bc3a9",
+      "End": "84e771bf7bc54e79ba0d8baa66c331dc",
+      "Id": "f2e6986f94d64e5091fceb48701b4e58",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "d8fc8e1bfae649c8bd4f4a139edb0dc0",
+      "End": "2a5a82fefa9046038827f2d958ca4857",
+      "Id": "6a012f5f128d41698360e7a7c43377b0",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "66c4b99f1c174f58aa18bdafe534080b",
+      "End": "b9e4126c8d39489f87679d0d04294dde",
+      "Id": "26a7c28b8eaa4a3cac0eb7de8485597e",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "548c01a306484654a145ce8f14279b87",
+      "End": "e5eeb923c9944082bb715971fc07d2af",
+      "Id": "4fc58a4b627e4d7d92947644e05587cb",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "d4ad3d868f0a4264bd70ff41f1356720",
+      "End": "09c52ee505874c1eafb62cc3a36a3d5f",
+      "Id": "d3a104802f9842498cd19566b8640746",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "14fe6296d4cb42399ddb60379b50e3ec",
+      "End": "dbb9422b755444349ae513dd690692f0",
+      "Id": "f8f3b04103364fa2bea95fc80409fbf5",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "2593bc92b1e344ab8e59d254e7cdec2e",
+      "End": "f2e00744453b4a7e8b47643067119bf9",
+      "Id": "5693c0ec22624964a432a31f4ada43a6",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "af54d53682f94c409802dd3c95c17a19",
+      "End": "1e2cff87a7004a5bb14afd5d535bb922",
+      "Id": "5b68bde76e53434c869a7ffb6483876d",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "af54d53682f94c409802dd3c95c17a19",
+      "End": "35462ed893d34a2abb2989c040fac53f",
+      "Id": "84c2551692714239904c24e0d55b8182",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "5d3968379c3e4f768ee2ee0a3e9318bf",
+      "End": "2861bfb9581f441aa59be1518acbee75",
+      "Id": "d9b9d18f2c5140f58f39b1d74f166ba0",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "bb96d81f42e6448681326ca23ea0e86a",
+      "End": "5173573b207b43a5a598f5396009c628",
+      "Id": "ebf5174d0c9c426ba4e4d6a33068a9d8",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "EnableLegacyPolyCurveBehavior": false,
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "4.1",
+      "Data": {}
+    },
+    {
+      "ExtensionGuid": "DFBD9CC0-DB40-457A-939E-8C8555555A9D",
+      "Name": "Generative Design",
+      "Version": "10.3",
+      "Data": {}
+    }
+  ],
+  "Author": "None provided",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "4.2.0.4815",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "_Background Preview",
+      "EyeX": 70.87925720214844,
+      "EyeY": 89.53718566894531,
+      "EyeZ": 147.4795684814453,
+      "LookX": -82.2369155883789,
+      "LookY": -125.55143737792969,
+      "LookZ": -139.5506134033203,
+      "UpX": -0.31102874875068665,
+      "UpY": 0.7903741002082825,
+      "UpZ": -0.5277971625328064
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Id": "50f2745f27ba4565ae5c751cae3857bb",
+        "Name": "Number Slider",
+        "IsSetAsInput": true,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": -165.6079802279753,
+        "Y": 365.6651151497689
+      },
+      {
+        "Id": "f3f4dcb5a7c445d1b7f4abda1090be4d",
+        "Name": "Number Slider",
+        "IsSetAsInput": true,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": -165.6079802279753,
+        "Y": 713.6651151497689
+      },
+      {
+        "Id": "50d5b75a17f2420a873393a006ffc8d0",
+        "Name": "Code Block",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 282.7920197720247,
+        "Y": 409.6651151497689
+      },
+      {
+        "Id": "573617cd91d34b45b0080b90484bf992",
+        "Name": "UV.ByCoordinates",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 841.9920197720246,
+        "Y": 418.0101151497689
+      },
+      {
+        "Id": "1f15fcf669d740b2aa8ae23179caf3f5",
+        "Name": "List.Flatten",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 1147.5920197720245,
+        "Y": 418.0101151497689
+      },
+      {
+        "Id": "2384d52a663249449665a0219cdb0b20",
+        "Name": "Code Block",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 282.7920197720247,
+        "Y": 619.6651151497689
+      },
+      {
+        "Id": "5e258b461843425294505ef6b4abb1e7",
+        "Name": "UV.ByCoordinates",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 841.9920197720246,
+        "Y": 594.0101151497689
+      },
+      {
+        "Id": "88db9d3b458946d2b0206455db902bed",
+        "Name": "List.Flatten",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 1147.5920197720245,
+        "Y": 594.0101151497689
+      },
+      {
+        "Id": "bb4f62e83b0a4242b346533d7e81c258",
+        "Name": "List.Join",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 1442.3920197720245,
+        "Y": 489.0101151497689
+      },
+      {
+        "Id": "82d45936f9464bafa39afa4b51392df0",
+        "Name": "Get Surface Domain",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": -165.6079802279753,
+        "Y": 566.4926151497689
+      },
+      {
+        "Id": "c792841449d74386b3cdb847138cd9e1",
+        "Name": "Voronoi.ByParametersOnSurface",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 1730.4786790792282,
+        "Y": 375.6293728238402
+      },
+      {
+        "Id": "4dd957679d5c4708b4f7f8acbc73ea7a",
+        "Name": "Remember",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 1442.3920197720245,
+        "Y": 665.0101151497689
+      },
+      {
+        "Id": "293e4004d72845b19b7f448c53adf3c0",
+        "Name": "Final List",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 2163.462258618947,
+        "Y": 392.2896050555214
+      }
+    ],
+    "Annotations": [
+      {
+        "Id": "8de57d62dce0457c96430c0383023a0e",
+        "Title": "Wiggle Sliders \r\nfor Awesome",
+        "DescriptionText": null,
+        "IsExpanded": true,
+        "WidthAdjustment": 0.0,
+        "HeightAdjustment": 0.0,
+        "UserSetWidth": 0.0,
+        "UserSetHeight": 0.0,
+        "Nodes": [],
+        "HasNestedGroups": false,
+        "Left": -165.6079802279753,
+        "Top": 512.6926151497689,
+        "Width": 0.0,
+        "Height": 0.0,
+        "FontSize": 36.0,
+        "GroupStyleId": "00000000-0000-0000-0000-000000000000",
+        "InitialTop": 0.0,
+        "InitialHeight": 0.0,
+        "TextblockHeight": 0.0,
+        "IsOptionalInPortsCollapsed": false,
+        "IsUnconnectedOutPortsCollapsed": false,
+        "HasToggledOptionalInPorts": false,
+        "HasToggledUnconnectedOutPorts": false,
+        "Background": "#FFC1D676"
+      }
+    ],
+    "X": -1804.210777914915,
+    "Y": -408.8046315075632,
+    "Zoom": 1.2582658962826776
+  }
+}


### PR DESCRIPTION
### Purpose

This addresses the issue reported on slack [here](https://autodesk.slack.com/archives/C186YR8SH/p1777286941925799).

`UvScalingUtilities.GetNormalizedUvScales` computed UV aspect-ratio scaling by sampling isolines at the domain boundaries (U/V = 0 and 1) and averaging their lengths. For surfaces with degenerate extrema — sphere poles, cone apex — the isoline at that boundary collapses to a near-zero-length point. Averaging a real length with ~0 badly underestimates the true scale, causing the UV normalization to fall back to `normU = 1.0` and breaking the aspect ratio. This in turn causes `Delaunay.ByParametersOnSurface` and `Voronoi.ByParametersOnSurface` to produce incorrect tessellations on such surfaces.

Fix: sample isolines at five interior positions (0.1, 0.25, 0.5, 0.75, 0.9) and average their lengths. Interior isolines are non-degenerate for all standard analytical surfaces. For flat/non-degenerate surfaces, all interior isolines have similar length, so the result is unchanged from the previous approach.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fix incorrect UV scaling normalization for surfaces with degenerate boundary isolines (sphere poles, cone apex), restoring correct Delaunay/Voronoi tessellation on those surfaces.

### Reviewers

(FILL ME IN)

### FYIs

N/A