### PR TITLE
DYN-10440: Fix Microsoft.CodeAnalysis satellite assemblies leaking into pt-BR build output

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -212,7 +212,8 @@
     <Copy SourceFiles="@(LibGProtoGeometryXml)" DestinationFolder="$(OutputPath)" />
     <Copy SourceFiles="@(LibGProtoGeometryXml)" DestinationFolder="$(OutputPath)\$(UICulture)" />
     <ItemGroup>
-      <LibGProtoGeometryUICultureAllLanguages Include="$(LibGMainPackagePath)\tools\netstandard2.1\$(LibGOsToken)\**\*.resources.dll;$(LibGMainPackagePath)\tools\netstandard2.1\$(LibGOsToken)\**\*.resx" />
+      <LibGProtoGeometryUICultureAllLanguages Include="$(LibGMainPackagePath)\tools\netstandard2.1\$(LibGOsToken)\**\*.resources.dll;$(LibGMainPackagePath)\tools\netstandard2.1\$(LibGOsToken)\**\*.resx"
+                                             Exclude="$(LibGMainPackagePath)\tools\netstandard2.1\$(LibGOsToken)\**\Microsoft.CodeAnalysis*.resources.dll" />
     </ItemGroup>
     <Copy SourceFiles="@(LibGProtoGeometryUICultureAllLanguages)" DestinationFolder="$(OutputPath)\%(RecursiveDir)" />
     <Copy SourceFiles="@(LibGMainDeps)" DestinationFolder="$(OutputPath)$(LIBGVerMain)\asm_deps\" />

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -508,7 +508,7 @@
     </Reference> 
       <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
           <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <IncludeAssets>build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
     <PackageReference Include="Prism.Core" Version="8.1.97" />
     <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="5.0.103" />

--- a/src/DynamoUtilities/DynamoUtilities.csproj
+++ b/src/DynamoUtilities/DynamoUtilities.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />

--- a/src/NodeServices/DynamoServices.csproj
+++ b/src/NodeServices/DynamoServices.csproj
@@ -24,7 +24,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
             <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <IncludeAssets>build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <!--exclude these dependencies as Sys.Ref.MetadataLoadContext.dll is already pulled in from other projects and the transitive deps are part of the .net8/net10 runtime.-->
         <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" ExcludeAssets="runtime" />


### PR DESCRIPTION
### Purpose

The LibG NuGet package (`DynamoVisualProgramming.LibG_232_0_0`) ships `Microsoft.CodeAnalysis.CSharp.resources.dll` and `Microsoft.CodeAnalysis.resources.dll` under `tools/netstandard2.1/windows/pt-BR/` as unexpected cargo alongside its legitimate locale resources (`ProtoGeometry.resources.dll`, `LibG.ProtoInterface.resources.dll`, etc.).

The `BeforeBuildOps` target in `DynamoCore.csproj` copies all `*.resources.dll` files from that path recursively using `**\*.resources.dll`, which picks up the `Microsoft.CodeAnalysis` satellite assemblies and writes them to `$(OutputPath)\pt-BR\`. This was first surfaced by Florin while updating `PackageApprovedDllList.txt` for the Dynamo Core 4.1 upgrade in Revit (REVIT-250592).

**Fix**: add an `Exclude` to the `LibGProtoGeometryUICultureAllLanguages` item in `DynamoCore.csproj` to filter out `Microsoft.CodeAnalysis*.resources.dll` files from that copy, while still copying all legitimate LibG locale resources.

Also removes `runtime` from `IncludeAssets` for `Microsoft.CodeAnalysis.PublicApiAnalyzers` across all four referencing projects (`DynamoCore`, `DynamoCoreWpf`, `DynamoUtilities`, `DynamoServices`) as a correctness cleanup — the package has no `lib/` folder and is a build-time-only analyzer, so `runtime` was always a no-op there.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

N/A — build/packaging fix only; no user-facing or API changes.

### Reviewers

(FILL ME IN)

### FYIs

Florin (reported the issue)