### PR TITLE
DYN-10444: Fix PathManager version resolution for host integrations and Sandbox

### DIFF
--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -506,9 +506,11 @@ namespace Dynamo.Core
         /// 2) If a host directory is configured, first non-system, non-test assembly on
         ///    the current managed call stack that resides outside the DynamoCore directory.
         ///    Skipped when no host directory is set (e.g. standalone Sandbox).
-        /// 3) DynamoCore assembly location (preferred over external process assemblies).
-        /// 4) Entry assembly location.
-        /// 5) Current process main module path.
+        /// 3) If no host directory is configured, first non-system, non-test assembly
+        ///    on the current managed call stack that resides outside the DynamoCore directory.
+        /// 4) DynamoCore assembly location (preferred over external process assemblies).
+        /// 5) Entry assembly location.
+        /// 6) Current process main module path.
         /// </summary>
         /// <returns>
         /// The file path of the assembly used to determine the data directory version.
@@ -565,18 +567,62 @@ namespace Dynamo.Core
                 }
             }
 
-            // Option 3: Prefer DynamoCore assembly over external process assemblies
+            // Option 3: When there is no configured host directory yet, still try
+            // to discover a likely host integration assembly on the current call stack.
+            if (string.IsNullOrEmpty(hostApplicationDirectory))
+            {
+                var currentAssembly = typeof(PathManager).Assembly;
+                var stackTrace = new StackTrace(skipFrames: 1, fNeedFileInfo: false);
+
+                foreach (var frame in stackTrace.GetFrames() ?? Array.Empty<StackFrame>())
+                {
+                    var assembly = frame.GetMethod()?.DeclaringType?.Assembly;
+                    if (assembly == null || assembly == currentAssembly || assembly.IsDynamic)
+                        continue;
+
+                    var assemblyName = assembly.GetName().Name;
+                    if (string.IsNullOrEmpty(assemblyName))
+                        continue;
+
+                    if (assemblyName.StartsWith("System", StringComparison.OrdinalIgnoreCase) ||
+                        assemblyName.StartsWith("Microsoft", StringComparison.OrdinalIgnoreCase) ||
+                        assemblyName.Equals("mscorlib", StringComparison.OrdinalIgnoreCase) ||
+                        assemblyName.Equals("netstandard", StringComparison.OrdinalIgnoreCase) ||
+                        assemblyName.IndexOf("test", StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
+                        continue;
+                    }
+
+                    // Without a configured host directory, only consider likely
+                    // Dynamo integration assemblies to avoid selecting framework
+                    // assemblies (e.g. WPF/.NET) that can carry unrelated versions
+                    // such as 10.0 for Sandbox startup.
+                    if (assemblyName.IndexOf("Dynamo", StringComparison.OrdinalIgnoreCase) < 0)
+                        continue;
+
+                    var candidatePath = assembly.Location;
+
+                    // Skip assemblies that live in the same directory as DynamoCore.
+                    if (IsPathUnderDirectory(candidatePath, dynamoCoreDir))
+                        continue;
+
+                    if (HasNonZeroFileVersion(candidatePath))
+                        return candidatePath;
+                }
+            }
+
+            // Option 4: Prefer DynamoCore assembly over external process assemblies
             // (e.g. testhost.exe, dotnet.exe) which may carry unrelated versions.
             var dynamoCoreAssemblyPath = Assembly.GetExecutingAssembly().Location;
             if (HasNonZeroFileVersion(dynamoCoreAssemblyPath))
                 return dynamoCoreAssemblyPath;
 
-            // Option 4: Use the process entry assembly when available and versioned.
+            // Option 5: Use the process entry assembly when available and versioned.
             var entryAssemblyPath = Assembly.GetEntryAssembly()?.Location;
             if (HasNonZeroFileVersion(entryAssemblyPath))
                 return entryAssemblyPath;
 
-            // Option 5: Use the current process main module path as a hosted fallback.
+            // Option 6: Use the current process main module path as a hosted fallback.
             var processMainModulePath = TryGetCurrentProcessMainModulePath();
             if (HasNonZeroFileVersion(processMainModulePath))
                 return processMainModulePath;

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1144,7 +1144,12 @@ namespace Dynamo.Models
         /// <returns></returns>
         internal PathManager CreatePathManager(IStartConfiguration config)
         {
-            var pathManagerParams = new PathManagerParams();
+            var pathManagerParams = new PathManagerParams
+            {
+                // Always supply HostPath so TraverseForExecutableAssembly can locate host
+                // assemblies on the call stack even when version is not explicitly provided.
+                HostPath = config.DynamoHostPath
+            };
 
             var version = config.HostAnalyticsInfo.HostVersion;
             if (version != null)
@@ -1152,9 +1157,11 @@ namespace Dynamo.Models
                 // Use host versions if provided
                 pathManagerParams.MajorFileVersion = version.Major;
                 pathManagerParams.MinorFileVersion = version.Minor;
-
-                Dynamo.Core.PathManager.Initialize(pathManagerParams);
             }
+
+            // Always initialize so the singleton is created with host context before
+            // Instance is first accessed. Initialize is a no-op if already set.
+            Dynamo.Core.PathManager.Initialize(pathManagerParams);
 
             if (!config.StartInTestMode)
             {


### PR DESCRIPTION

### Purpose

Restore host-aware stack fallback when PathManager is created before host path is assigned (C3D/Revit early startup order). Remove executable-version based fallback that could pick host process version (for example 32.0) and create wrong folders. Keep Sandbox behavior stable by preferring DynamoCore version fallback, so AppData stays on the Dynamo version folder (for example 4.1). Preserve the Sandbox regression fix intent while avoiding dual folder creation across launches.

### Declarations

Check these if you believe they are true

- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fix PathManager version resolution for host integrations and Sandbox

### Reviewers

@aparajit-pratap @jasonstratton 

### FYIs

@johnpierson 
