### PR TITLE
DYN-0000: Bump RC4.1.1_master version to 4.1.1

### DIFF
--- a/ABOUT.txt
+++ b/ABOUT.txt
@@ -1,4 +1,4 @@
-@DYNAMO v.4.1.0 © 2025 Autodesk, Inc.  All rights reserved.
+@DYNAMO v.4.1.1 © 2025 Autodesk, Inc.  All rights reserved.
 
 Dynamo License
 

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("4.1.0.2940")]
+[assembly: AssemblyVersion("4.1.1.2940")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("4.1.0.2940")]
+[assembly: AssemblyFileVersion("4.1.1.2940")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
@@ -69,7 +69,7 @@ using System.Runtime.InteropServices;
 <#+
 int MajorVersion = 4;
 int MinorVersion = 1;
-int BuildNumber = 0;
+int BuildNumber = 1;
 // The datetime baseline we choose using this algorithm will affect build number and all nuget packages uploaded
 // Please only change when major or minor version got incremented
 int RevisionNumber = ((int)(DateTime.UtcNow - new DateTime(2025,1,1)).TotalDays)*10+((int)DateTime.UtcNow.Hour)/3;

--- a/src/Config/upiconfig.xml
+++ b/src/Config/upiconfig.xml
@@ -14,7 +14,7 @@
             <upi_attribute name='id' value='Win64'/>
             <upi_element name='level'>
               <upi_attribute name='name' value='build'/>
-              <upi_attribute name='id' value='4.1.0' />
+              <upi_attribute name='id' value='4.1.1' />
             </upi_element>
           </upi_element>
         </upi_element>

--- a/tools/autobuild/build.json
+++ b/tools/autobuild/build.json
@@ -2,8 +2,8 @@
   "product_id": "DYN",
   "release_id": "4.1.0",
   "master_id": "Win64",
-  "build_id": "4.1.0",
-  "name": "4.1.0",
-  "build_milestone": "FCS",
+  "build_id": "4.1.1",
+  "name": "4.1.1",
+  "build_milestone": "Update 1",
   "description":"Build"
 }


### PR DESCRIPTION
### Purpose

Bump version to 4.1.1 in the RC4.1.1_master release candidate branch.

### Files

- `ABOUT.txt` — Updated
- `src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt` — Updated
- `src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs` — Updated
- `src/Config/upiconfig.xml` — Updated
- `tools/autobuild/build.json` — Updated
- `doc/distrib/License.rtf` — **Needs manual update** (version character count changed — please update License.rtf manually)
- `tools/NuGet/BuildPackages.bat` — Already at 4.1.1