### PR TITLE
DYN-: Dyn 10228 file new from template

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3994,7 +3994,7 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
     <value>_File</value>
   </data>
   <data name="DynamoViewFileMenuOpenTemplate" xml:space="preserve">
-    <value>_Template</value>
+    <value>From Template...</value>
   </data>
   <data name="WorkspaceSaveTemplateDirectoryBlockMsg" xml:space="preserve">
     <value>Workspaces cannot be saved directly to the Templates folder. Please choose a different folder to save your file.

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3985,7 +3985,7 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
     <value>_File</value>
   </data>
   <data name="DynamoViewFileMenuOpenTemplate" xml:space="preserve">
-    <value>_Template</value>
+    <value>From Template...</value>
   </data>
   <data name="WorkspaceSaveTemplateDirectoryBlockMsg" xml:space="preserve">
     <value>Workspaces cannot be saved directly to the Templates folder. Please choose a different folder to save your file.

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2046,7 +2046,7 @@ namespace Dynamo.ViewModels
             }
             fltr += "|" + string.Format(Resources.FileDialogAllFiles, "*.*");
 
-            fileDialog.FileName = workspace.Name + ext;
+            fileDialog.FileName = (workspace.IsTemplate ? "Untitled" : workspace.Name) + ext;
             fileDialog.AddExtension = true;
             fileDialog.DefaultExt = ext;
             fileDialog.Filter = fltr;

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -321,6 +321,11 @@
                                       Command="{Binding NewHomeWorkspaceCommand}"
                                       Header="{x:Static p:Resources.DynamoViewFileMenuNewHomeWorkSpace}"
                                       InputGestureText="Ctrl + N" />
+                            <MenuItem Name="newFromTemplateMenuItem"
+                                      Command="{Binding ShowOpenTemplateDialogCommand}"
+                                      CommandParameter="Template"
+                                      Header="{x:Static p:Resources.DynamoViewFileMenuOpenTemplate}"
+                                      InputGestureText="Ctrl + T" />
                             <MenuItem Name="newFuncButton"
                                       Command="{Binding ShowNewFunctionDialogCommand}"
                                       Header="{x:Static p:Resources.DynamoViewFileMenuNewCustomNode}"
@@ -331,11 +336,6 @@
                                       Command="{Binding ShowOpenDialogAndOpenResultCommand}"
                                       Header="{x:Static p:Resources.DynamoViewFileMenuOpenFile}"
                                       InputGestureText="Ctrl + O" />
-                            <MenuItem Name="openTemplateMenuItem"
-                                      Command="{Binding ShowOpenTemplateDialogCommand}"
-                                      CommandParameter="Template"
-                                      Header="{x:Static p:Resources.DynamoViewFileMenuOpenTemplate}"
-                                      InputGestureText="Ctrl + T" />
                         </MenuItem>
                         <MenuItem Name="insertButton"
                                   Command="{Binding ShowInsertDialogAndInsertResultCommand}"


### PR DESCRIPTION
### Purpose

This PR addresses DYN-10228 https://jira.autodesk.com/browse/DYN-10228 The changes in the code aim to modify the Dynamo template access workflow by moving template creation from File > Open > Template to File > New > From Template 
Selecting a template creates a new unsaved Dynamo file based on the template.

Changes : 

- Added newFromTemplateMenuItem under File > New 
- Removed the old openTemplateMenuItem from  File > Open
- Updated ressource strings to reflect the new menu location
- Update DynamoViewmodel to set default filename to "Untitled" when saving new file based on the template ( instead of template's name which was the default)


<img width="1280" height="720" alt="Gif" src="https://github.com/user-attachments/assets/bde0de84-66d5-409d-82b1-e7810510c58c" />

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Enables templates to be opened in a new editable workspace from File > New > From Template replacing the old workflow  
File > Open > Template


### Reviewers
@zeusongit
@DynamoDS/eidos

### FYIs
@dnenov
@johnpierson