### PR TITLE
DYN-7587 : Clicking No still installs a conflicting package

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -597,6 +597,51 @@ namespace Dynamo.Core
         }
 
         /// <summary>
+        /// Determines whether custom nodes under <paramref name="customNodeDirectory"/> would conflict
+        /// with definitions already registered from a different package (the case that throws
+        /// <see cref="CustomNodePackageLoadException"/> in <see cref="SetNodeInfo"/>).
+        /// </summary>
+        /// <returns>True if any <c>.dyf</c> in the directory shares a function id with an existing
+        /// package member from another package name.</returns>
+        public bool TryGetConflictingPackageCustomNodeInfo(
+            string customNodeDirectory,
+            bool isTestMode,
+            PackageInfo incomingPackageInfo,
+            out CustomNodeInfo conflictingExistingInfo)
+        {
+            conflictingExistingInfo = null;
+            if (string.IsNullOrEmpty(customNodeDirectory) || !Directory.Exists(customNodeDirectory) || incomingPackageInfo == null)
+            {
+                return false;
+            }
+
+            foreach (var file in Directory.EnumerateFiles(customNodeDirectory, "*.dyf"))
+            {
+                CustomNodeInfo newInfo;
+                if (!TryGetInfoFromPath(file, isTestMode, out newInfo))
+                {
+                    continue;
+                }
+
+                CustomNodeInfo existingInfo;
+                if (!NodeInfos.TryGetValue(newInfo.FunctionId, out existingInfo))
+                {
+                    continue;
+                }
+
+                if (existingInfo.IsPackageMember
+                    && existingInfo.PackageInfo != null
+                    && incomingPackageInfo.Name != existingInfo.PackageInfo.Name)
+                {
+                    conflictingExistingInfo = existingInfo;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         ///     Enumerates all of the files in the search path and get's their guids.
         ///     Does not instantiate the nodes.
         /// </summary>

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -603,7 +603,7 @@ namespace Dynamo.Core
         /// </summary>
         /// <returns>True if any <c>.dyf</c> in the directory shares a function id with an existing
         /// package member from another package name.</returns>
-        public bool TryGetConflictingPackageCustomNodeInfo(
+        internal bool TryGetConflictingPackageCustomNodeInfo(
             string customNodeDirectory,
             bool isTestMode,
             PackageInfo incomingPackageInfo,
@@ -611,23 +611,17 @@ namespace Dynamo.Core
         {
             conflictingExistingInfo = null;
             if (string.IsNullOrEmpty(customNodeDirectory) || !Directory.Exists(customNodeDirectory) || incomingPackageInfo == null)
-            {
                 return false;
-            }
 
             foreach (var file in Directory.EnumerateFiles(customNodeDirectory, "*.dyf"))
             {
                 CustomNodeInfo newInfo;
                 if (!TryGetInfoFromPath(file, isTestMode, out newInfo))
-                {
                     continue;
-                }
 
                 CustomNodeInfo existingInfo;
                 if (!NodeInfos.TryGetValue(newInfo.FunctionId, out existingInfo))
-                {
                     continue;
-                }
 
                 if (existingInfo.IsPackageMember
                     && existingInfo.PackageInfo != null
@@ -637,7 +631,6 @@ namespace Dynamo.Core
                     return true;
                 }
             }
-
             return false;
         }
 

--- a/src/DynamoCore/PublicAPI.Shipped.txt
+++ b/src/DynamoCore/PublicAPI.Shipped.txt
@@ -370,6 +370,7 @@ Dynamo.Core.CustomNodeManager.TryGetCustomNodeData(System.Guid id, string name, 
 Dynamo.Core.CustomNodeManager.TryGetFunctionDefinition(System.Guid id, bool isTestMode, out Dynamo.CustomNodeDefinition definition) -> bool
 Dynamo.Core.CustomNodeManager.TryGetFunctionWorkspace(System.Guid id, bool isTestMode, out Dynamo.Graph.Workspaces.CustomNodeWorkspaceModel ws) -> bool
 Dynamo.Core.CustomNodeManager.TryGetFunctionWorkspace(System.Guid id, bool isTestMode, out Dynamo.Graph.Workspaces.ICustomNodeWorkspaceModel ws) -> bool
+Dynamo.Core.CustomNodeManager.TryGetConflictingPackageCustomNodeInfo(string customNodeDirectory, bool isTestMode, Dynamo.Graph.Workspaces.PackageInfo incomingPackageInfo, out Dynamo.CustomNodeInfo conflictingExistingInfo) -> bool
 Dynamo.Core.IDSDKManager
 Dynamo.Core.IDSDKManager.Dispose() -> void
 Dynamo.Core.IDSDKManager.GetAccessToken() -> string

--- a/src/DynamoCore/PublicAPI.Shipped.txt
+++ b/src/DynamoCore/PublicAPI.Shipped.txt
@@ -370,7 +370,6 @@ Dynamo.Core.CustomNodeManager.TryGetCustomNodeData(System.Guid id, string name, 
 Dynamo.Core.CustomNodeManager.TryGetFunctionDefinition(System.Guid id, bool isTestMode, out Dynamo.CustomNodeDefinition definition) -> bool
 Dynamo.Core.CustomNodeManager.TryGetFunctionWorkspace(System.Guid id, bool isTestMode, out Dynamo.Graph.Workspaces.CustomNodeWorkspaceModel ws) -> bool
 Dynamo.Core.CustomNodeManager.TryGetFunctionWorkspace(System.Guid id, bool isTestMode, out Dynamo.Graph.Workspaces.ICustomNodeWorkspaceModel ws) -> bool
-Dynamo.Core.CustomNodeManager.TryGetConflictingPackageCustomNodeInfo(string customNodeDirectory, bool isTestMode, Dynamo.Graph.Workspaces.PackageInfo incomingPackageInfo, out Dynamo.CustomNodeInfo conflictingExistingInfo) -> bool
 Dynamo.Core.IDSDKManager
 Dynamo.Core.IDSDKManager.Dispose() -> void
 Dynamo.Core.IDSDKManager.GetAccessToken() -> string

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4962,7 +4962,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package installation was cancelled because one or more custom nodes conflict with another installed package..
+        ///   Looks up a localized string similar to Installation cancelled due to custom node conflict..
         /// </summary>
         public static string MessagePackageInstallCancelledDueToCustomNodeConflict {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4971,6 +4971,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Restart Dynamo to remove the conflicting package..
+        /// </summary>
+        public static string MessagePackageInstallRestartToCompleteCustomNodeReplace {
+            get {
+                return ResourceManager.GetString("MessagePackageInstallRestartToCompleteCustomNodeReplace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This package or one of its dependencies were created for a newer version of Dynamo. It may not work in this version. Do you want to continue?.
         /// </summary>
         public static string MessagePackageNewerDynamo {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4962,6 +4962,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package installation was cancelled because one or more custom nodes conflict with another installed package..
+        /// </summary>
+        public static string MessagePackageInstallCancelledDueToCustomNodeConflict {
+            get {
+                return ResourceManager.GetString("MessagePackageInstallCancelledDueToCustomNodeConflict", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This package or one of its dependencies were created for a newer version of Dynamo. It may not work in this version. Do you want to continue?.
         /// </summary>
         public static string MessagePackageNewerDynamo {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1343,7 +1343,10 @@ You can always redownload the package.</value>
     <value>Failed to load an invalid package.</value>
   </data>
   <data name="MessagePackageInstallCancelledDueToCustomNodeConflict" xml:space="preserve">
-    <value>Package installation was cancelled because one or more custom nodes conflict with another installed package.</value>
+    <value>Installation cancelled due to custom node conflict.</value>
+  </data>
+  <data name="MessagePackageInstallRestartToCompleteCustomNodeReplace" xml:space="preserve">
+    <value>Restart Dynamo to remove the conflicting package and load this one.</value>
   </data>
   <data name="MessageFailedToFindNodeById" xml:space="preserve">
     <value>No node could be found with that Id.</value>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1342,6 +1342,9 @@ You can always redownload the package.</value>
   <data name="MessageInvalidPackage" xml:space="preserve">
     <value>Failed to load an invalid package.</value>
   </data>
+  <data name="MessagePackageInstallCancelledDueToCustomNodeConflict" xml:space="preserve">
+    <value>Package installation was cancelled because one or more custom nodes conflict with another installed package.</value>
+  </data>
   <data name="MessageFailedToFindNodeById" xml:space="preserve">
     <value>No node could be found with that Id.</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1346,7 +1346,7 @@ You can always redownload the package.</value>
     <value>Installation cancelled due to custom node conflict.</value>
   </data>
   <data name="MessagePackageInstallRestartToCompleteCustomNodeReplace" xml:space="preserve">
-    <value>Restart Dynamo to remove the conflicting package and load this one.</value>
+    <value>Restart Dynamo to remove the conflicting package.</value>
   </data>
   <data name="MessageFailedToFindNodeById" xml:space="preserve">
     <value>No node could be found with that Id.</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -983,7 +983,7 @@ You can always redownload the package.</value>
     <value>Installation cancelled due to custom node conflict.</value>
   </data>
   <data name="MessagePackageInstallRestartToCompleteCustomNodeReplace" xml:space="preserve">
-    <value>Restart Dynamo to remove the conflicting package and load this one.</value>
+    <value>Restart Dynamo to remove the conflicting package.</value>
   </data>
   <data name="MessageFailedToDelete" xml:space="preserve">
     <value>{0} failed to delete the package.  You may need to delete the package's root directory manually.</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -980,7 +980,10 @@ You can always redownload the package.</value>
     <value>Failed to load an invalid package.</value>
   </data>
   <data name="MessagePackageInstallCancelledDueToCustomNodeConflict" xml:space="preserve">
-    <value>Package installation was cancelled because one or more custom nodes conflict with another installed package.</value>
+    <value>Installation cancelled due to custom node conflict.</value>
+  </data>
+  <data name="MessagePackageInstallRestartToCompleteCustomNodeReplace" xml:space="preserve">
+    <value>Restart Dynamo to remove the conflicting package and load this one.</value>
   </data>
   <data name="MessageFailedToDelete" xml:space="preserve">
     <value>{0} failed to delete the package.  You may need to delete the package's root directory manually.</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -979,6 +979,9 @@ You can always redownload the package.</value>
   <data name="MessageInvalidPackage" xml:space="preserve">
     <value>Failed to load an invalid package.</value>
   </data>
+  <data name="MessagePackageInstallCancelledDueToCustomNodeConflict" xml:space="preserve">
+    <value>Package installation was cancelled because one or more custom nodes conflict with another installed package.</value>
+  </data>
   <data name="MessageFailedToDelete" xml:space="preserve">
     <value>{0} failed to delete the package.  You may need to delete the package's root directory manually.</value>
   </data>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1141,18 +1141,65 @@ namespace Dynamo.ViewModels
         /// </summary>
         /// <param name="packageDownloadHandle">package download handle</param>
         /// <param name="downloadPath">package download path</param>
-        internal void SetPackageState(PackageDownloadHandle packageDownloadHandle, string downloadPath)
+        internal void SetPackageState(PackageDownloadHandle packageDownloadHandle, string packagesRootDirectory)
         {
-            Package dynPkg;
-            if (packageDownloadHandle.Extract(DynamoViewModel.Model, downloadPath, out dynPkg))
+            string stagingDirectory = null;
+            try
             {
+                if (!packageDownloadHandle.TryPrepareInstallation(DynamoViewModel.Model, out var dynPkg, out stagingDirectory))
+                {
+                    packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Error;
+                    packageDownloadHandle.Error(Resources.MessageInvalidPackage);
+                    return;
+                }
+
+                var packagesRoot = string.IsNullOrEmpty(packagesRootDirectory)
+                    ? DynamoViewModel.Model.PathManager.DefaultPackagesDirectory
+                    : packagesRootDirectory;
+
+                if (Directory.Exists(dynPkg.CustomNodeDirectory))
+                {
+                    var incomingInfo = new PackageInfo(dynPkg.Name, new Version(dynPkg.VersionName));
+                    if (DynamoViewModel.Model.CustomNodeManager.TryGetConflictingPackageCustomNodeInfo(
+                            dynPkg.CustomNodeDirectory,
+                            DynamoModel.IsTestMode,
+                            incomingInfo,
+                            out var conflictingExisting))
+                    {
+                        var existingDyfDir = Path.GetDirectoryName(conflictingExisting.Path);
+                        var installedPkg = PackageManagerExtension.PackageLoader.LocalPackages.FirstOrDefault(
+                            p => string.Equals(p.CustomNodeDirectory, existingDyfDir, StringComparison.OrdinalIgnoreCase));
+
+                        if (installedPkg == null)
+                        {
+                            packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Error;
+                            packageDownloadHandle.Error(Resources.MessagePackageInstallCancelledDueToCustomNodeConflict);
+                            return;
+                        }
+
+                        var userChoseReplace =
+                            PackageManagerExtension.PackageLoader.NotifyUserOfConflictingCustomNodePackage(installedPkg, dynPkg);
+
+                        if (!userChoseReplace)
+                        {
+                            packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Error;
+                            packageDownloadHandle.Error(Resources.MessagePackageInstallCancelledDueToCustomNodeConflict);
+                            return;
+                        }
+
+                        packageDownloadHandle.CompleteInstallation(dynPkg, stagingDirectory, packagesRoot);
+                        packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
+                        return;
+                    }
+                }
+
+                packageDownloadHandle.CompleteInstallation(dynPkg, stagingDirectory, packagesRoot);
                 PackageManagerExtension.PackageLoader.LoadPackages(new List<Package> { dynPkg });
                 packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
             }
-            else
+            finally
             {
-                packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Error;
-                packageDownloadHandle.Error(Resources.MessageInvalidPackage);
+                PackageDownloadHandle.DiscardStagingDirectory(stagingDirectory);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1184,14 +1184,14 @@ namespace Dynamo.ViewModels
                             return;
                         }
 
-                        packageDownloadHandle.CompleteInstallation(dynPkg, stagingDirectory, packagesRoot);
+                        PackageDownloadHandle.CompleteInstallation(dynPkg, stagingDirectory, packagesRoot);
                         packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
                         packageDownloadHandle.ErrorString = Resources.MessagePackageInstallRestartToCompleteCustomNodeReplace;
                         return;
                     }
                 }
 
-                packageDownloadHandle.CompleteInstallation(dynPkg, stagingDirectory, packagesRoot);
+                PackageDownloadHandle.CompleteInstallation(dynPkg, stagingDirectory, packagesRoot);
                 PackageManagerExtension.PackageLoader.LoadPackages(new List<Package> { dynPkg });
                 packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
             }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1141,21 +1141,20 @@ namespace Dynamo.ViewModels
         /// </summary>
         /// <param name="packageDownloadHandle">package download handle</param>
         /// <param name="downloadPath">package download path</param>
-        internal void SetPackageState(PackageDownloadHandle packageDownloadHandle, string packagesRootDirectory)
+        internal void SetPackageState(PackageDownloadHandle packageDownloadHandle, string downloadPath)
         {
             string stagingDirectory = null;
             try
             {
                 if (!packageDownloadHandle.TryPrepareInstallation(DynamoViewModel.Model, out var dynPkg, out stagingDirectory))
                 {
-                    packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Error;
                     packageDownloadHandle.Error(Resources.MessageInvalidPackage);
                     return;
                 }
 
-                var packagesRoot = string.IsNullOrEmpty(packagesRootDirectory)
+                var packagesRoot = string.IsNullOrEmpty(downloadPath)
                     ? DynamoViewModel.Model.PathManager.DefaultPackagesDirectory
-                    : packagesRootDirectory;
+                    : downloadPath;
 
                 if (Directory.Exists(dynPkg.CustomNodeDirectory))
                 {
@@ -1172,23 +1171,22 @@ namespace Dynamo.ViewModels
 
                         if (installedPkg == null)
                         {
-                            packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Error;
                             packageDownloadHandle.Error(Resources.MessagePackageInstallCancelledDueToCustomNodeConflict);
                             return;
                         }
 
                         var userChoseReplace =
-                            PackageManagerExtension.PackageLoader.NotifyUserOfConflictingCustomNodePackage(installedPkg, dynPkg);
+                            PackageManagerExtension.PackageLoader.OnConflictingPackageLoaded(installedPkg, dynPkg);
 
                         if (!userChoseReplace)
                         {
-                            packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Error;
                             packageDownloadHandle.Error(Resources.MessagePackageInstallCancelledDueToCustomNodeConflict);
                             return;
                         }
 
                         packageDownloadHandle.CompleteInstallation(dynPkg, stagingDirectory, packagesRoot);
                         packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
+                        packageDownloadHandle.ErrorString = Resources.MessagePackageInstallRestartToCompleteCustomNodeReplace;
                         return;
                     }
                 }
@@ -1199,7 +1197,7 @@ namespace Dynamo.ViewModels
             }
             finally
             {
-                PackageDownloadHandle.DiscardStagingDirectory(stagingDirectory);
+                PackageDownloadHandle.DiscardStagingDirectory(stagingDirectory, DynamoViewModel.Model.Logger);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -1639,7 +1639,7 @@ namespace Dynamo.PackageManager
         {
             SearchResults.CollectionChanged += SearchResultsOnCollectionChanged;
             PackageManagerClientViewModel.Downloads.CollectionChanged += DownloadsOnCollectionChanged;
-            PackageManagerClientViewModel.PackageManagerExtension.PackageLoader.ConflictingCustomNodePackageLoaded +=
+            PackageManagerClientViewModel.PackageManagerExtension.PackageLoader.ConflictingCustomNodePackageResolutionCallback +=
                 ConflictingCustomNodePackageLoaded;
         }
 
@@ -1647,7 +1647,7 @@ namespace Dynamo.PackageManager
         {
             SearchResults.CollectionChanged -= SearchResultsOnCollectionChanged;
             PackageManagerClientViewModel.Downloads.CollectionChanged -= DownloadsOnCollectionChanged;
-            PackageManagerClientViewModel.PackageManagerExtension.PackageLoader.ConflictingCustomNodePackageLoaded -=
+            PackageManagerClientViewModel.PackageManagerExtension.PackageLoader.ConflictingCustomNodePackageResolutionCallback -=
                 ConflictingCustomNodePackageLoaded;
         }
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -1486,8 +1486,13 @@ namespace Dynamo.PackageManager
             return String.Join("\r\n", packages.Select(x => x.Item1.name + " " + x.Item2.version));
         }
 
-        private void ConflictingCustomNodePackageLoaded(Package installed, Package conflicting)
+        private bool ConflictingCustomNodePackageLoaded(Package installed, Package conflicting)
         {
+            if (installed == null || conflicting == null)
+            {
+                return false;
+            }
+
             var message = string.Format(Resources.MessageUninstallCustomNodeToContinue,
                 installed.Name + " " + installed.VersionName, conflicting.Name + " " + conflicting.VersionName);
 
@@ -1500,7 +1505,10 @@ namespace Dynamo.PackageManager
                 // mark for uninstallation
                 var settings = PackageManagerClientViewModel.DynamoViewModel.Model.PreferenceSettings;
                 installed.MarkForUninstall(settings);
+                return true;
             }
+
+            return false;
         }
 
         private void DownloadsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -1489,9 +1489,7 @@ namespace Dynamo.PackageManager
         private bool ConflictingCustomNodePackageLoaded(Package installed, Package conflicting)
         {
             if (installed == null || conflicting == null)
-            {
                 return false;
-            }
 
             var message = string.Format(Resources.MessageUninstallCustomNodeToContinue,
                 installed.Name + " " + installed.VersionName, conflicting.Name + " " + conflicting.VersionName);

--- a/src/DynamoPackages/PackageDownloadHandle.cs
+++ b/src/DynamoPackages/PackageDownloadHandle.cs
@@ -97,6 +97,82 @@ namespace Dynamo.PackageManager
         }
 
         /// <summary>
+        /// Unzips the downloaded package to a staging directory and parses <c>pkg.json</c>.
+        /// The caller must delete <paramref name="stagingDirectory"/> with
+        /// <see cref="DiscardStagingDirectory"/> when installation is aborted or after
+        /// <see cref="CompleteInstallation"/> (which leaves the staging folder in place — discard afterward).
+        /// </summary>
+        public bool TryPrepareInstallation(DynamoModel dynamoModel, out Package pkg, out string stagingDirectory)
+        {
+            pkg = null;
+            stagingDirectory = null;
+            this.DownloadState = State.Installing;
+
+            var unzipPath = Greg.Utility.FileUtilities.UnZip(DownloadPath);
+            if (!Directory.Exists(unzipPath))
+            {
+                throw new Exception(Properties.Resources.PackageEmpty);
+            }
+
+            stagingDirectory = unzipPath;
+            pkg = Package.FromDirectory(unzipPath, dynamoModel.Logger);
+            return pkg != null;
+        }
+
+        /// <summary>
+        /// Copies a staged package into the Dynamo packages directory tree and sets <paramref name="pkg"/>.RootDirectory.
+        /// </summary>
+        /// <param name="pkg">Package metadata (initially rooted at the staging folder).</param>
+        /// <param name="stagingDirectory">Path returned from <see cref="TryPrepareInstallation"/>.</param>
+        /// <param name="packagesRootDirectory">Root packages folder (e.g. default or custom package path).</param>
+        public void CompleteInstallation(Package pkg, string stagingDirectory, string packagesRootDirectory)
+        {
+            if (pkg == null)
+            {
+                throw new ArgumentNullException(nameof(pkg));
+            }
+            if (string.IsNullOrEmpty(stagingDirectory))
+            {
+                throw new ArgumentException("Staging directory is required.", nameof(stagingDirectory));
+            }
+
+            var installedPath = BuildInstallDirectoryString(packagesRootDirectory, pkg.Name);
+            Directory.CreateDirectory(installedPath);
+
+            foreach (string dirPath in Directory.GetDirectories(stagingDirectory, "*", SearchOption.AllDirectories))
+            {
+                Directory.CreateDirectory(dirPath.Replace(stagingDirectory, installedPath));
+            }
+
+            foreach (string newPath in Directory.GetFiles(stagingDirectory, "*.*", SearchOption.AllDirectories))
+            {
+                File.Copy(newPath, newPath.Replace(stagingDirectory, installedPath));
+            }
+
+            pkg.RootDirectory = installedPath;
+        }
+
+        /// <summary>
+        /// Deletes a staging directory created by <see cref="TryPrepareInstallation"/>.
+        /// </summary>
+        public static void DiscardStagingDirectory(string stagingDirectory)
+        {
+            if (string.IsNullOrEmpty(stagingDirectory) || !Directory.Exists(stagingDirectory))
+            {
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(stagingDirectory, true);
+            }
+            catch
+            {
+                // Best-effort cleanup; avoid blocking package manager UX on locked files.
+            }
+        }
+
+        /// <summary>
         /// Extracts and parses the metadata of a downloaded package
         /// </summary>
         /// <param name="dynamoModel">Dynamo model</param>
@@ -105,41 +181,26 @@ namespace Dynamo.PackageManager
         /// <returns>Whether the operation succeeded or not</returns>
         public bool Extract(DynamoModel dynamoModel, string installDirectory, out Package pkg)
         {
-            this.DownloadState = State.Installing;
-
-            // unzip, place files
-            var unzipPath = Greg.Utility.FileUtilities.UnZip(DownloadPath);
-            if (!Directory.Exists(unzipPath))
+            string stagingDirectory = null;
+            try
             {
-                throw new Exception(Properties.Resources.PackageEmpty);
+                if (!TryPrepareInstallation(dynamoModel, out pkg, out stagingDirectory))
+                {
+                    return false;
+                }
+
+                if (String.IsNullOrEmpty(installDirectory))
+                {
+                    installDirectory = dynamoModel.PathManager.DefaultPackagesDirectory;
+                }
+
+                CompleteInstallation(pkg, stagingDirectory, installDirectory);
+                return true;
             }
-
-            // provide handle to installed package 
-            pkg = Package.FromDirectory(unzipPath, dynamoModel.Logger);
-
-            if (pkg == null)
+            finally
             {
-                return false;
+                DiscardStagingDirectory(stagingDirectory);
             }
-
-            if (String.IsNullOrEmpty(installDirectory))
-                installDirectory = dynamoModel.PathManager.DefaultPackagesDirectory;
-
-            var installedPath = BuildInstallDirectoryString(installDirectory, pkg.Name);
-            Directory.CreateDirectory(installedPath);
-
-            // Now create all of the directories
-            foreach (string dirPath in Directory.GetDirectories(unzipPath, "*", SearchOption.AllDirectories))
-                Directory.CreateDirectory(dirPath.Replace(unzipPath, installedPath));
-
-            // Copy all the files
-            foreach (string newPath in Directory.GetFiles(unzipPath, "*.*", SearchOption.AllDirectories))
-                File.Copy(newPath, newPath.Replace(unzipPath, installedPath));
-
-            // Update root directory to final path
-            pkg.RootDirectory = installedPath;
-
-            return true;
         }
 
         // cancel, install, redownload

--- a/src/DynamoPackages/PackageDownloadHandle.cs
+++ b/src/DynamoPackages/PackageDownloadHandle.cs
@@ -123,7 +123,7 @@ namespace Dynamo.PackageManager
         /// <param name="pkg">Package metadata (initially rooted at the staging folder).</param>
         /// <param name="stagingDirectory">Path returned from <see cref="TryPrepareInstallation"/>.</param>
         /// <param name="packagesRootDirectory">Root packages folder (e.g. default or custom package path).</param>
-        internal void CompleteInstallation(Package pkg, string stagingDirectory, string packagesRootDirectory)
+        internal static void CompleteInstallation(Package pkg, string stagingDirectory, string packagesRootDirectory)
         {
             if (pkg == null)
             {

--- a/src/DynamoPackages/PackageDownloadHandle.cs
+++ b/src/DynamoPackages/PackageDownloadHandle.cs
@@ -177,7 +177,7 @@ namespace Dynamo.PackageManager
         /// </summary>
         /// <param name="dynamoModel">Dynamo model</param>
         /// <param name="installDirectory">If specified, overrides Dynamo's default base folder for packages</param>
-        /// <param name="pkg">Metatda parsed from the package</param>
+        /// <param name="pkg">Metadata parsed from the package</param>
         /// <returns>Whether the operation succeeded or not</returns>
         public bool Extract(DynamoModel dynamoModel, string installDirectory, out Package pkg)
         {

--- a/src/DynamoPackages/PackageDownloadHandle.cs
+++ b/src/DynamoPackages/PackageDownloadHandle.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using Dynamo.Core;
+using Dynamo.Logging;
 using Dynamo.Models;
 
 using Greg.Responses;
@@ -98,11 +99,8 @@ namespace Dynamo.PackageManager
 
         /// <summary>
         /// Unzips the downloaded package to a staging directory and parses <c>pkg.json</c>.
-        /// The caller must delete <paramref name="stagingDirectory"/> with
-        /// <see cref="DiscardStagingDirectory"/> when installation is aborted or after
-        /// <see cref="CompleteInstallation"/> (which leaves the staging folder in place — discard afterward).
         /// </summary>
-        public bool TryPrepareInstallation(DynamoModel dynamoModel, out Package pkg, out string stagingDirectory)
+        internal bool TryPrepareInstallation(DynamoModel dynamoModel, out Package pkg, out string stagingDirectory)
         {
             pkg = null;
             stagingDirectory = null;
@@ -120,12 +118,12 @@ namespace Dynamo.PackageManager
         }
 
         /// <summary>
-        /// Copies a staged package into the Dynamo packages directory tree and sets <paramref name="pkg"/>.RootDirectory.
+        /// Copies a staged package into the Dynamo packages directory and sets <paramref name="pkg"/>.RootDirectory.
         /// </summary>
         /// <param name="pkg">Package metadata (initially rooted at the staging folder).</param>
         /// <param name="stagingDirectory">Path returned from <see cref="TryPrepareInstallation"/>.</param>
         /// <param name="packagesRootDirectory">Root packages folder (e.g. default or custom package path).</param>
-        public void CompleteInstallation(Package pkg, string stagingDirectory, string packagesRootDirectory)
+        internal void CompleteInstallation(Package pkg, string stagingDirectory, string packagesRootDirectory)
         {
             if (pkg == null)
             {
@@ -155,20 +153,22 @@ namespace Dynamo.PackageManager
         /// <summary>
         /// Deletes a staging directory created by <see cref="TryPrepareInstallation"/>.
         /// </summary>
-        public static void DiscardStagingDirectory(string stagingDirectory)
+        internal static void DiscardStagingDirectory(string stagingDirectory, ILogger logger)
         {
             if (string.IsNullOrEmpty(stagingDirectory) || !Directory.Exists(stagingDirectory))
-            {
                 return;
-            }
 
             try
             {
                 Directory.Delete(stagingDirectory, true);
             }
-            catch
+            catch (IOException ex)
             {
-                // Best-effort cleanup; avoid blocking package manager UX on locked files.
+                logger?.Log($"Failed to delete package directory {stagingDirectory}. {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                logger?.Log($"Failed to delete package directory {stagingDirectory}. {ex.Message}");
             }
         }
 
@@ -185,21 +185,17 @@ namespace Dynamo.PackageManager
             try
             {
                 if (!TryPrepareInstallation(dynamoModel, out pkg, out stagingDirectory))
-                {
                     return false;
-                }
 
                 if (String.IsNullOrEmpty(installDirectory))
-                {
                     installDirectory = dynamoModel.PathManager.DefaultPackagesDirectory;
-                }
 
                 CompleteInstallation(pkg, stagingDirectory, installDirectory);
                 return true;
             }
             finally
             {
-                DiscardStagingDirectory(stagingDirectory);
+                DiscardStagingDirectory(stagingDirectory, dynamoModel.Logger);
             }
         }
 

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -287,7 +287,7 @@ namespace Dynamo.PackageManager
             {
                 Package originalPackage =
                     localPackages.FirstOrDefault(x => x.CustomNodeDirectory == e.InstalledPath);
-                NotifyUserOfConflictingCustomNodePackage(originalPackage, package);
+                OnConflictingPackageLoaded(originalPackage, package);
 
                 package.LoadState.SetAsError(e.Message);
             }
@@ -311,13 +311,14 @@ namespace Dynamo.PackageManager
         /// </summary>
         public event Func<Package, Package, bool> ConflictingCustomNodePackageLoaded;
 
-        private bool OnConflictingPackageLoaded(Package installed, Package conflicting)
+        /// <summary>
+        /// Invokes <see cref="ConflictingCustomNodePackageLoaded"/> (e.g. conflict dialog). Does not change package load state.
+        /// </summary>
+        /// <returns>True if the user accepts replacing the installed package after restart.</returns>
+        internal bool OnConflictingPackageLoaded(Package installed, Package conflicting)
         {
             var handler = ConflictingCustomNodePackageLoaded;
-            if (handler == null)
-            {
-                return false;
-            }
+            if (handler == null) return false;
 
             var acceptReplace = false;
             foreach (Func<Package, Package, bool> del in handler.GetInvocationList())

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -287,7 +287,7 @@ namespace Dynamo.PackageManager
             {
                 Package originalPackage =
                     localPackages.FirstOrDefault(x => x.CustomNodeDirectory == e.InstalledPath);
-                OnConflictingPackageLoaded(originalPackage, package);
+                NotifyUserOfConflictingCustomNodePackage(originalPackage, package);
 
                 package.LoadState.SetAsError(e.Message);
             }
@@ -307,12 +307,37 @@ namespace Dynamo.PackageManager
         /// <summary>
         /// Event raised when a custom node package containing conflicting node definition
         /// with an existing package is tried to load.
+        /// Handlers return true if the user accepts replacing the installed package after restart (Yes).
         /// </summary>
-        public event Action<Package, Package> ConflictingCustomNodePackageLoaded;
-        private void OnConflictingPackageLoaded(Package installed, Package conflicting)
+        public event Func<Package, Package, bool> ConflictingCustomNodePackageLoaded;
+
+        private bool OnConflictingPackageLoaded(Package installed, Package conflicting)
         {
             var handler = ConflictingCustomNodePackageLoaded;
-            handler?.Invoke(installed, conflicting);
+            if (handler == null)
+            {
+                return false;
+            }
+
+            var acceptReplace = false;
+            foreach (Func<Package, Package, bool> del in handler.GetInvocationList())
+            {
+                if (del.Invoke(installed, conflicting))
+                {
+                    acceptReplace = true;
+                }
+            }
+
+            return acceptReplace;
+        }
+
+        /// <summary>
+        /// Runs the same conflict UI as a failed custom node load, without mutating package load state.
+        /// </summary>
+        /// <returns>True if the user chose to replace the installed package after restart.</returns>
+        public bool NotifyUserOfConflictingCustomNodePackage(Package installedPackage, Package conflictingPackage)
+        {
+            return OnConflictingPackageLoaded(installedPackage, conflictingPackage);
         }
 
         /// <summary>

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -307,38 +307,27 @@ namespace Dynamo.PackageManager
         /// <summary>
         /// Event raised when a custom node package containing conflicting node definition
         /// with an existing package is tried to load.
-        /// Handlers return true if the user accepts replacing the installed package after restart (Yes).
         /// </summary>
-        public event Func<Package, Package, bool> ConflictingCustomNodePackageLoaded;
+        public event Action<Package, Package> ConflictingCustomNodePackageLoaded;
 
         /// <summary>
-        /// Invokes <see cref="ConflictingCustomNodePackageLoaded"/> (e.g. conflict dialog). Does not change package load state.
+        /// Resolver wchich runs instead of only firing <see cref="ConflictingCustomNodePackageLoaded"/>
+        /// </summary>
+        public Func<Package, Package, bool> ConflictingCustomNodePackageResolutionCallback { get; set;  }
+
+        /// <summary>
+        /// Invokes conflict resolution / notification. Does not change package load state.
         /// </summary>
         /// <returns>True if the user accepts replacing the installed package after restart.</returns>
         internal bool OnConflictingPackageLoaded(Package installed, Package conflicting)
         {
-            var handler = ConflictingCustomNodePackageLoaded;
-            if (handler == null) return false;
-
-            var acceptReplace = false;
-            foreach (Func<Package, Package, bool> del in handler.GetInvocationList())
+            if (ConflictingCustomNodePackageResolutionCallback != null)
             {
-                if (del.Invoke(installed, conflicting))
-                {
-                    acceptReplace = true;
-                }
+                return ConflictingCustomNodePackageResolutionCallback(installed, conflicting);
             }
 
-            return acceptReplace;
-        }
-
-        /// <summary>
-        /// Runs the same conflict UI as a failed custom node load, without mutating package load state.
-        /// </summary>
-        /// <returns>True if the user chose to replace the installed package after restart.</returns>
-        public bool NotifyUserOfConflictingCustomNodePackage(Package installedPackage, Package conflictingPackage)
-        {
-            return OnConflictingPackageLoaded(installedPackage, conflictingPackage);
+            ConflictingCustomNodePackageLoaded?.Invoke(installed, conflicting);
+            return false;
         }
 
         /// <summary>

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -668,7 +668,7 @@ namespace Dynamo.PackageManager.Tests
             var zipFileControl = compressor.Zip(new RealDirectoryInfo(new DirectoryInfo(evenOdd2Source)));
             var downloadHandleControl = new PackageDownloadHandle { DownloadPath = zipFileControl.Name };
             Assert.IsTrue(downloadHandleControl.TryPrepareInstallation(CurrentDynamoModel, out var stagedPkgControl, out var stagingDirControl));
-            downloadHandleControl.CompleteInstallation(stagedPkgControl, stagingDirControl, packagesInstallRoot);
+            PackageDownloadHandle.CompleteInstallation(stagedPkgControl, stagingDirControl, packagesInstallRoot);
             PackageDownloadHandle.DiscardStagingDirectory(stagingDirControl, CurrentDynamoModel.Logger);
             Assert.IsTrue(Directory.Exists(committedPath));
             Assert.IsTrue(File.Exists(Path.Combine(committedPath, "pkg.json")));
@@ -728,7 +728,7 @@ namespace Dynamo.PackageManager.Tests
             // User chose Yes, same as ConflictingCustomNodePackageLoaded handler — mark existing for removal after restart
             evenOddInstalled.MarkForUninstall(prefs);
             // Commit to disk
-            downloadHandle.CompleteInstallation(stagedPkg, stagingDir, packagesInstallRoot);
+            PackageDownloadHandle.CompleteInstallation(stagedPkg, stagingDir, packagesInstallRoot);
             PackageDownloadHandle.DiscardStagingDirectory(stagingDir, CurrentDynamoModel.Logger);
 
             var committedPath = Path.Combine(packagesInstallRoot, "EvenOdd2");

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -608,6 +608,133 @@ namespace Dynamo.PackageManager.Tests
         }
 
         [Test]
+        public void DecliningStagedCustomNodeConflictPackageDoesNotCommitAndRemovesStaging()
+        {
+            // Load test packages - EvenOdd has a custom node that EvenOdd2 duplicates by GUID
+            var pathManager = new Mock<IPathManager>();
+            pathManager.SetupGet(x => x.PackagesDirectories).Returns(() => new List<string> { PackagesDirectory });
+
+            var loader = new PackageLoader(pathManager.Object);
+            var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
+
+            loader.PackagesLoaded += libraryLoader.LoadPackages;
+            loader.RequestLoadNodeLibrary += libraryLoader.LoadLibraryAndSuppressZTSearchImport;
+
+            Func<string, PackageInfo, IEnumerable<CustomNodeInfo>> reqLoadCNDelegate = (dir, pkgInfo) =>
+                CurrentDynamoModel.CustomNodeManager.AddUninitializedCustomNodesInPath(dir, isTestMode: false, packageInfo: pkgInfo);
+            loader.RequestLoadCustomNodeDirectory += reqLoadCNDelegate;
+
+            loader.LoadAll(new LoadPackageParams
+            {
+                Preferences = CurrentDynamoModel.PreferenceSettings,
+            });
+
+            var evenOddInstalled = loader.LocalPackages.FirstOrDefault(p => p.Name == "EvenOdd");
+            Assert.IsNotNull(evenOddInstalled);
+            var prefs = CurrentDynamoModel.PreferenceSettings;
+            var evenOddRoot = evenOddInstalled.RootDirectory;
+            var uninstallListedEvenOddBefore = prefs.PackageDirectoriesToUninstall.Contains(evenOddRoot);
+
+            // Simulate a downloaded package, zip EvenOdd2, then unzip like PackageDownloadHandle
+            var evenOdd2Source = Path.Combine(PackagesDirectory, "EvenOdd2");
+            var compressor = new MutatingFileCompressor();
+            var zipFile = compressor.Zip(new RealDirectoryInfo(new DirectoryInfo(evenOdd2Source)));
+            var downloadHandle = new PackageDownloadHandle { DownloadPath = zipFile.Name };
+
+            var packagesInstallRoot = Path.Combine(TempFolder, "decline_install_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(packagesInstallRoot);
+
+            Assert.IsTrue(downloadHandle.TryPrepareInstallation(CurrentDynamoModel, out var stagedPkg, out var stagingDir));
+            Assert.IsTrue(Directory.Exists(stagingDir));
+
+            // Precheck: same rule as PackageManagerClientViewModel before CompleteInstallation
+            var incomingInfo = new PackageInfo("EvenOdd2", new System.Version(1, 0, 0));
+            Assert.IsTrue(CurrentDynamoModel.CustomNodeManager.TryGetConflictingPackageCustomNodeInfo(
+                stagedPkg.CustomNodeDirectory,
+                false,
+                incomingInfo,
+                out var conflicting));
+            Assert.AreEqual("EvenOdd", conflicting.PackageInfo.Name);
+
+            // User chose No: do not commit, remove staging
+            PackageDownloadHandle.DiscardStagingDirectory(stagingDir, CurrentDynamoModel.Logger);
+
+            var committedPath = Path.Combine(packagesInstallRoot, "EvenOdd2");
+            Assert.IsFalse(Directory.Exists(committedPath));
+            Assert.IsFalse(Directory.Exists(stagingDir));
+            Assert.AreEqual(uninstallListedEvenOddBefore, prefs.PackageDirectoriesToUninstall.Contains(evenOddRoot));
+
+            loader.PackagesLoaded -= libraryLoader.LoadPackages;
+            loader.RequestLoadNodeLibrary -= libraryLoader.LoadLibraryAndSuppressZTSearchImport;
+            loader.RequestLoadCustomNodeDirectory -= reqLoadCNDelegate;
+        }
+
+        [Test]
+        public void AcceptingStagedCustomNodeConflictPackageCommitsAndMarksExistingForUninstall()
+        {
+            var pathManager = new Mock<IPathManager>();
+            pathManager.SetupGet(x => x.PackagesDirectories).Returns(() => new List<string> { PackagesDirectory });
+
+            var loader = new PackageLoader(pathManager.Object);
+            var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
+
+            loader.PackagesLoaded += libraryLoader.LoadPackages;
+            loader.RequestLoadNodeLibrary += libraryLoader.LoadLibraryAndSuppressZTSearchImport;
+
+            Func<string, PackageInfo, IEnumerable<CustomNodeInfo>> reqLoadCNDelegate = (dir, pkgInfo) =>
+                CurrentDynamoModel.CustomNodeManager.AddUninitializedCustomNodesInPath(dir, isTestMode: false, packageInfo: pkgInfo);
+            loader.RequestLoadCustomNodeDirectory += reqLoadCNDelegate;
+
+            loader.LoadAll(new LoadPackageParams
+            {
+                Preferences = CurrentDynamoModel.PreferenceSettings,
+            });
+
+            var evenOddInstalled = loader.LocalPackages.FirstOrDefault(p => p.Name == "EvenOdd");
+
+            Assert.IsNotNull(evenOddInstalled);
+
+            var prefs = CurrentDynamoModel.PreferenceSettings;
+            var evenOddRoot = evenOddInstalled.RootDirectory;
+
+            // Isolate uninstall-list assertion for this test
+            prefs.PackageDirectoriesToUninstall.RemoveAll(x => x.Equals(evenOddRoot));
+
+            var evenOdd2Source = Path.Combine(PackagesDirectory, "EvenOdd2");
+            var compressor = new MutatingFileCompressor();
+            var zipFile = compressor.Zip(new RealDirectoryInfo(new DirectoryInfo(evenOdd2Source)));
+            var downloadHandle = new PackageDownloadHandle { DownloadPath = zipFile.Name };
+
+            var packagesInstallRoot = Path.Combine(TempFolder, "accept_install_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(packagesInstallRoot);
+
+            Assert.IsTrue(downloadHandle.TryPrepareInstallation(CurrentDynamoModel, out var stagedPkg, out var stagingDir));
+            var incomingInfo = new PackageInfo("EvenOdd2", new System.Version(1, 0, 0));
+            Assert.IsTrue(CurrentDynamoModel.CustomNodeManager.TryGetConflictingPackageCustomNodeInfo(
+                stagedPkg.CustomNodeDirectory,
+                false,
+                incomingInfo,
+                out _));
+
+            // User chose Yes, same as ConflictingCustomNodePackageLoaded handler — mark existing for removal after restart
+            evenOddInstalled.MarkForUninstall(prefs);
+            // Commit to disk
+            downloadHandle.CompleteInstallation(stagedPkg, stagingDir, packagesInstallRoot);
+            PackageDownloadHandle.DiscardStagingDirectory(stagingDir, CurrentDynamoModel.Logger);
+
+            var committedPath = Path.Combine(packagesInstallRoot, "EvenOdd2");
+
+            Assert.IsTrue(Directory.Exists(committedPath));
+            Assert.IsTrue(File.Exists(Path.Combine(committedPath, "pkg.json")));
+            Assert.IsFalse(Directory.Exists(stagingDir));
+            Assert.IsTrue(prefs.PackageDirectoriesToUninstall.Contains(evenOddRoot));
+
+            loader.PackagesLoaded -= libraryLoader.LoadPackages;
+            loader.RequestLoadNodeLibrary -= libraryLoader.LoadLibraryAndSuppressZTSearchImport;
+            loader.RequestLoadCustomNodeDirectory -= reqLoadCNDelegate;
+        }
+
+        [Test]
         public void PlacingCustomNodeInstanceFromPackageRetainsCorrectPackageInfoState()
         {
             var loader = GetPackageLoader();

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -660,9 +660,18 @@ namespace Dynamo.PackageManager.Tests
             PackageDownloadHandle.DiscardStagingDirectory(stagingDir, CurrentDynamoModel.Logger);
 
             var committedPath = Path.Combine(packagesInstallRoot, "EvenOdd2");
-            Assert.IsFalse(Directory.Exists(committedPath));
             Assert.IsFalse(Directory.Exists(stagingDir));
             Assert.AreEqual(uninstallListedEvenOddBefore, prefs.PackageDirectoriesToUninstall.Contains(evenOddRoot));
+
+            // Without CompleteInstallation, EvenOdd2 would not appear under packagesInstallRoot
+            Assert.IsFalse(Directory.Exists(committedPath));
+            var zipFileControl = compressor.Zip(new RealDirectoryInfo(new DirectoryInfo(evenOdd2Source)));
+            var downloadHandleControl = new PackageDownloadHandle { DownloadPath = zipFileControl.Name };
+            Assert.IsTrue(downloadHandleControl.TryPrepareInstallation(CurrentDynamoModel, out var stagedPkgControl, out var stagingDirControl));
+            downloadHandleControl.CompleteInstallation(stagedPkgControl, stagingDirControl, packagesInstallRoot);
+            PackageDownloadHandle.DiscardStagingDirectory(stagingDirControl, CurrentDynamoModel.Logger);
+            Assert.IsTrue(Directory.Exists(committedPath));
+            Assert.IsTrue(File.Exists(Path.Combine(committedPath, "pkg.json")));
 
             loader.PackagesLoaded -= libraryLoader.LoadPackages;
             loader.RequestLoadNodeLibrary -= libraryLoader.LoadLibraryAndSuppressZTSearchImport;


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-7587](https://jira.autodesk.com/browse/DYN-7587).

It fixes the case where installing a package that conflicts on custom node (.dyf) GUIDs with an already installed package showed `Cannot Download Package`, but if the user chose `No`, the new package could already be copied into Dynamo’s packages folder.

Changes:
- Staged install: 
Custom-node conflicts are checked against already loaded package nodes before anything is copied from the temporary zip into the real packages directory.
- User chooses No:
Install is cancelled - no copy into the packages folder, staging is removed, and the existing package is not marked for uninstall. Download UI shows a short, specific message (Installation cancelled due to custom node conflict).
- User chooses Yes:
The existing package is marked for uninstall on next startup and the new package is committed to disk. The download handle shows text that installed files are present but a restart is required (Restart Dynamo to remove the conflicting package) so the old package can be removed.
- Tests
Package manager / loader tests cover decline (no commit, staging removed, uninstall list unchanged) and accept (commit, staging removed, existing package scheduled for uninstall).

<img width="480" height="325" alt="Screenshot 2026-05-07 122311" src="https://github.com/user-attachments/assets/fc709914-4f93-4611-83c5-faf202b45b08" />
<br>
<img width="1072" height="712" alt="Screenshot 2026-05-08 064757" src="https://github.com/user-attachments/assets/45dda79c-1288-4062-a846-6b099133df0f" />



### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixes the case where installing a package that conflicts on custom node (.dyf) GUIDs with an already installed package showed `Cannot Download Package`, but if the user chose `No`, the new package could already be copied into Dynamo’s packages folder.

### Reviewers

@DynamoDS/eidos
@jasonstratton
@zeusongit 

### FYIs

@dnenov
@johnpierson
