### PR TITLE
DYN-10491: Fix template open for legacy XML .dyn files

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2207,21 +2207,35 @@ namespace Dynamo.Models
 
         /// <summary>
         /// Opens a Dynamo workspace from a path to a template on disk.
+        /// Supports JSON workspaces and legacy XML-format graphs
         /// </summary>
         /// <param name="filePath">Path to file</param>
         /// <param name="forceManualExecutionMode">Set this to true to discard
         /// execution mode specified in the file and set manual mode</param>
         public void OpenTemplateFromPath(string filePath, bool forceManualExecutionMode = false)
         {
-
-            if (DynamoUtilities.PathHelper.isValidJson(filePath, out string fileContents, out Exception ex))
+            Exception ex;
+            string fileContents;
+            if (DynamoUtilities.PathHelper.isValidJson(filePath, out fileContents, out ex))
             {
                 OpenJsonFileFromPath(fileContents, filePath, forceManualExecutionMode, true);
+                return;
             }
             else
             {
-                // These kind of exceptions indicate that file is not accessible
-                if (ex is IOException || ex is UnauthorizedAccessException || ex is JsonReaderException)
+                if (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    throw ex;
+                }
+
+                XmlDocument xmlDoc;
+
+                if (ex is JsonReaderException && DynamoUtilities.PathHelper.isValidXML(filePath, out xmlDoc, out ex))
+                {
+                    OpenXmlFileFromPath(xmlDoc, filePath, forceManualExecutionMode, isTemplate: true);
+                    return;
+                }
+                else
                 {
                     throw ex;
                 }
@@ -2374,8 +2388,9 @@ namespace Dynamo.Models
         /// <param name="filePath">Path to file</param>
         /// <param name="forceManualExecutionMode">Set this to true to discard
         /// execution mode specified in the file and set manual mode</param>
+        /// <param name="isTemplate">When true, marks the opened workspace as a template (for example when opened via <see cref="OpenTemplateFromPath"/>).</param>
         /// <returns>True if workspace was opened successfully</returns>
-        private bool OpenXmlFileFromPath(XmlDocument xmlDoc, string filePath, bool forceManualExecutionMode)
+        private bool OpenXmlFileFromPath(XmlDocument xmlDoc, string filePath, bool forceManualExecutionMode, bool isTemplate = false)
         {
             try
             {
@@ -2397,6 +2412,7 @@ namespace Dynamo.Models
                         WorkspaceModel ws;
                         if (OpenXmlFile(workspaceInfo, xmlDoc, out ws))
                         {
+                            ws.IsTemplate = isTemplate;
                             OpenWorkspace(ws);
 
                             // Set up workspace cameras here

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2255,7 +2255,6 @@ namespace Dynamo.Models
             if (DynamoUtilities.PathHelper.isValidJson(filePath, out fileContents, out ex))
             {
                 InsertJsonFileFromPath(fileContents, filePath, forceManualExecutionMode);
-                return;
             }
             else
             {
@@ -2271,7 +2270,6 @@ namespace Dynamo.Models
                     if (DynamoUtilities.PathHelper.isValidXML(filePath, out xmlDoc, out ex))
                     {
                         InsertXmlFileFromPath(xmlDoc, filePath, forceManualExecutionMode);
-                        return;
                     }
                 }
                 else
@@ -2314,8 +2312,7 @@ namespace Dynamo.Models
         /// <param name="forceManualExecutionMode">Set this to true to discard
         /// execution mode specified in the file and set manual mode</param>
         /// <param name="isTemplate">Set this to true to indicate that the file is a template</param>
-        /// <returns>True if workspace was opened successfully</returns>
-        internal bool OpenJsonFileFromPath(string fileContents, string filePath, bool forceManualExecutionMode, bool isTemplate = false)
+        internal void OpenJsonFileFromPath(string fileContents, string filePath, bool forceManualExecutionMode, bool isTemplate = false)
         {
             try
             {
@@ -2337,7 +2334,6 @@ namespace Dynamo.Models
                         }
                     }
                 }
-                return true;
             }
             catch (Exception e)
             {

--- a/test/DynamoCoreWpf3Tests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpf3Tests/WorkspaceSaving.cs
@@ -573,6 +573,19 @@ namespace Dynamo.Tests
             Assert.AreEqual("dummy description", ViewModel.Model.CurrentWorkspace.Description);
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void CanOpenLegacyXmlTemplateAsNewWorkspace()
+        {
+            var templatePath = Path.Combine(TestDirectory, @"core\math", "Round.dyn");
+
+            ViewModel.Model.OpenTemplateFromPath(templatePath);
+
+            Assert.IsTrue(!string.IsNullOrEmpty(ViewModel.Model.CurrentWorkspace.FileName));
+            Assert.IsTrue(ViewModel.Model.CurrentWorkspace.IsTemplate);
+            Assert.AreEqual(3, ViewModel.Model.CurrentWorkspace.Nodes.Count());
+        }
+
         /// <summary>
         /// This test validates that when a template is opened as a new workspace, it does not save the template (replacing it with new changes)
         /// The Business Rule says that we should not allow the user to modify templates and save them in the defined templates folder.


### PR DESCRIPTION
### Purpose

This PR addresses DYN-10491 https://jira.autodesk.com/browse/DYN-10491 The changes in the code aim to fix misleading "corrupted file" error for valid old XML workspaces opened from File- New - From template
This issue was discovered while testing the new workflow ( File- New - From template  https://jira.autodesk.com/browse/DYN-10228 ) But this behaviour already existed in previous File - Open -Template workflow


Changes : 

OpenTemplateFromPath now matches OpenFileFromPath: try JSON, then fall back to XML when JSON parsing fails. OpenXmlFileFromPath accepts an optional isTemplate flag so XML graphs opened from File > New > From Template set WorkspaceModel.IsTemplate like JSON template opens.


**Issue :** 

<img width="1280" height="720" alt="Issue gif" src="https://github.com/user-attachments/assets/3b9fd661-eab8-4994-8b7f-a6046b7211b4" />

**Fix :** 

<img width="1280" height="720" alt="Fix gif" src="https://github.com/user-attachments/assets/0ddfe3c2-e364-4927-8238-534c48300042" />



### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Align OpenTemplateFromPath with OpenFileFromPath JSON-then-XML load.
Set IsTemplate on XML-opened workspaces for the template flow.

### Reviewers
@zeusongit
@DynamoDS/eidos

### FYIs
@dnenov
@johnpierson
@jnealb 
