### PR TITLE
DYN-10493: Fix crash in Getting Started guided tour

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
@@ -697,9 +697,12 @@ namespace Dynamo.Wpf.UI.GuidedTour
             //Once we have the ItemsControl we get the ContentPresenter
             var inputViewModel = inPorts.FirstOrDefault(x => x.PortName == (string)uiAutomationData.Parameters[3]);
             var dependencyObject = itemsControlPort.ItemContainerGenerator.ContainerFromItem(inputViewModel);
-
-
             Grid mainGrid = dependencyObject.ChildOfType<Grid>();
+
+            // ContainerFromItem returns null when the ItemsControl hasn't generated the
+            // container yet (e.g. timing race during guided-tour initialization). Skip the
+            // highlight rather than crash — the tour can continue without it.
+            if (mainGrid == null) return;
 
             if (enableFunction)
             {


### PR DESCRIPTION
### Purpose

Fixes [DYN-10493](https://jira.autodesk.com/browse/DYN-10493): Dynamo crashes when clicking "Start Tour" on the Getting Started guided tour (Learning tab). The crash occurs on the transition from the Welcome popup to step 2 ("nodes").

**Root cause:** `GuidesValidationMethods.HighlightPort` calls `ItemContainerGenerator.ContainerFromItem` to locate the WPF container for a port, then passes the result to `CreateRectangle`. `ContainerFromItem` can return `null` when the `ItemsControl` hasn't generated containers yet. This is a timing race exposed by PR #16883 (DYN-7760, Feb 17 2026), which added synchronous WebView2 extension-closing before tour startup — shifting the dispatcher queue state enough to delay container generation past the point where `HighlightPort` reads it. The resulting `null` reached `NameScope.SetNameScope` inside `CreateRectangle`, which throws `ArgumentNullException("dependencyObject")`.

Key changes:
- Added a null guard on `mainGrid` in `HighlightPort` (`GuidesValidationMethods.cs`) — skips the port highlight rather than crashing if the container isn't ready. The tour continues without the visual effect.

**Regression introduced in:** PR #16883 (DYN-7760, Feb 17 2026)
**Not reproducible in:** 4.0.2 and older
**Fix targets:** `master`, cherry-pick to `4.1.1`

Full investigation: [DYN-10493 DynaNote](https://git.autodesk.com/strattj/DynaNotes/blob/master/DYN-10493/README.md) _(Autodesk internal)_

### Declarations

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixed a crash that occurred when clicking "Start Tour" on the Getting Started guided tour (Learning tab).

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)