### PR TITLE
DYN-10509: Update copyright year to 2026

### DIFF
--- a/ABOUT.txt
+++ b/ABOUT.txt
@@ -1,4 +1,4 @@
-@DYNAMO v.4.2.0 © 2025 Autodesk, Inc.  All rights reserved.
+@DYNAMO v.4.2.0 © 2026 Autodesk, Inc.  All rights reserved.
 
 Dynamo License
 
@@ -8,7 +8,7 @@ Copyright 2017 Ian Keough
 
 Those portions created by Autodesk employees are provided with the following copyright:
 
-Copyright 2025 Autodesk, Inc.
+Copyright 2026 Autodesk, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 

--- a/doc/distrib/License.rtf
+++ b/doc/distrib/License.rtf
@@ -47,7 +47,7 @@ Normal;}{\*\cs10 \additive \ssemihidden \sunhideused \spriority1 Default Paragra
 \fs24\lang1033\langfe1033\kerning2\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\f4\fs22\cf19\lang2057\langfe1033\kerning0\langnp2057\insrsid16600302 \hich\af4\dbch\af31505\loch\f4 
 @DYNAMO v.}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\f4\fs22\cf19\lang2057\langfe1033\kerning0\langnp2057\insrsid9531066 \hich\af4\dbch\af31505\loch\f4 4}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 
 \b\f4\fs22\cf19\lang2057\langfe1033\kerning0\langnp2057\insrsid16600302 .}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\f4\fs22\cf19\lang2057\langfe1033\kerning0\langnp2057\insrsid12870815 \hich\af4\dbch\af31505\loch\f4 2}{\rtlch\fcs1 \ab\af4\afs22 
-\ltrch\fcs0 \b\f4\fs22\cf19\lang2057\langfe1033\kerning0\langnp2057\insrsid16600302 \hich\af4\dbch\af31505\loch\f4 \hich\f4 .0 \'a9\loch\f4  2025 Autodesk, Inc. All rights reserved.
+\ltrch\fcs0 \b\f4\fs22\cf19\lang2057\langfe1033\kerning0\langnp2057\insrsid16600302 \hich\af4\dbch\af31505\loch\f4 \hich\f4 .0 \'a9\loch\f4  2026 Autodesk, Inc. All rights reserved.
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \f4\fs22\cf19\kerning0\insrsid16600302 
 \par \hich\af4\dbch\af31505\loch\f4 This Offering is subject to the Autodesk Terms of Use found\~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \f4\fs22\cf19\kerning0\insrsid16600302 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://www.autodesk.com/company/terms-of-use/en/general-terms"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \f4\fs22\cf19\kerning0\insrsid9531066 {\*\datafield 

--- a/extern/TuneUp/pkg.json
+++ b/extern/TuneUp/pkg.json
@@ -20,5 +20,5 @@
   "contains_binaries": true,
   "node_libraries": [],
   "copyright_holder": "DynamoTeam",
-  "copyright_year": "2025"
+  "copyright_year": "2026"
 }

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyCompany("Autodesk, Inc")]
 [assembly: AssemblyProduct("Dynamo")]
-[assembly: AssemblyCopyright("Copyright © Autodesk, Inc 2025")]
+[assembly: AssemblyCopyright("Copyright © Autodesk, Inc 2026")]
 [assembly: AssemblyTrademark("")]
 
 //In order to begin building localizable applications, set
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("4.2.0.2940")]
+[assembly: AssemblyVersion("4.2.0.5034")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("4.2.0.2940")]
+[assembly: AssemblyFileVersion("4.2.0.5034")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyCompany("Autodesk, Inc")]
 [assembly: AssemblyProduct("Dynamo")]
-[assembly: AssemblyCopyright("Copyright © Autodesk, Inc 2025")]
+[assembly: AssemblyCopyright("Copyright © Autodesk, Inc 2026")]
 [assembly: AssemblyTrademark("")]
 
 //In order to begin building localizable applications, set


### PR DESCRIPTION
### Purpose

Update Autodesk copyright year from 2025 to 2026.

Fixes [DYN-10509](https://jira.autodesk.com/browse/DYN-10509)  
[DYN-10509 DynaNote](https://git.autodesk.com/strattj/DynaNotes/blob/master/DYN-10509/README.md) _(Autodesk internal)_

**Files changed:**
- `ABOUT.txt` — updates the About box copyright header and Dynamo license attribution
- `src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt` — updates the T4 template that generates `AssemblyCopyright` for all Dynamo assemblies at build time

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Update Autodesk copyright year from 2025 to 2026 in the About box and assembly metadata.

### Reviewers

(FILL ME IN)

### FYIs

N/A