### PR TITLE
DYN-10517: Fix define data test

### DIFF
--- a/test/DynamoCoreTests/Nodes/DefineDataTests.cs
+++ b/test/DynamoCoreTests/Nodes/DefineDataTests.cs
@@ -10,6 +10,7 @@ namespace Dynamo.Tests.Nodes
     {
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
+            libraries.Add("DesignScriptBuiltin.dll");
             libraries.Add("DSCoreNodes.dll");
             base.GetLibrariesToPreload(libraries);
         }
@@ -37,6 +38,7 @@ namespace Dynamo.Tests.Nodes
         public void ValueTypeIdSafeWhenNoSelection()
         {
             var node = new DefineData();
+            node.SelectedIndex = -1;
             Assert.DoesNotThrow(() => { var _ = node.ValueTypeId; });
             Assert.AreEqual(node.SelectedString, node.ValueTypeId);
         }


### PR DESCRIPTION
### Purpose

Fixed a crash when running define Data–related automated tests.
Add `DesignScriptBuiltin.dll` and `DSCoreNodes.dll` to preload in `DefineDataTests`.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixed a crash when running define Data–related automated tests.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of