### PR TITLE
DynamoDS/DYN-10515: As a Dynamo user, I want my graph to AutoSave

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -73,6 +73,7 @@ namespace Dynamo.Configuration
         private double defaultScaleFactor;
         private bool disableTrustWarnings = false;
         private bool isNotificationCenterEnabled;
+        private bool isAutoSaveEnabled;
         private bool isEnablePersistExtensionsEnabled;
         private bool isAutoSyncDocumentBrowser = true;
         private bool isStaticSplashScreenEnabled;
@@ -779,6 +780,23 @@ namespace Dynamo.Configuration
         }
 
         /// <summary>
+        /// This defines if user wants to enable AutoSave: automatically save edited graphs
+        /// to their original file on disk after a period of inactivity. The default value is false.
+        /// </summary>
+        public bool EnableAutoSave
+        {
+            get
+            {
+                return isAutoSaveEnabled;
+            }
+            set
+            {
+                isAutoSaveEnabled = value;
+                RaisePropertyChanged(nameof(EnableAutoSave));
+            }
+        }
+
+        /// <summary>
         /// This defines if user wants the Extensions settings to persist across sessions.
         /// </summary>
         public bool EnablePersistExtensions
@@ -1099,6 +1117,7 @@ namespace Dynamo.Configuration
             MLRecommendationNumberOfResults = 10;
             HideAutocompleteMethodOptions = false;
             EnableNotificationCenter = true;
+            EnableAutoSave = false;
             isStaticSplashScreenEnabled = true;
             isTimeStampIncludedInExportFilePath = true;
             DefaultPythonEngine = string.Empty;

--- a/src/DynamoCore/Graph/ModelBase.cs
+++ b/src/DynamoCore/Graph/ModelBase.cs
@@ -13,7 +13,7 @@ namespace Dynamo.Graph
     /// <summary>
     /// SaveContext represents several contexts, in which node can be serialized/deserialized.
     /// </summary>
-    public enum SaveContext { [Obsolete("Use Save or SaveAs, instead of File")] File, Copy, Undo, Preset, None, Save, SaveAs };
+    public enum SaveContext { [Obsolete("Use Save or SaveAs, instead of File")] File, Copy, Undo, Preset, None, Save, SaveAs, AutoSave };
 
     /// <summary>
     /// This class encapsulates the input parameters that need to be passed into nodes

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ Dynamo.Models.DynamoModel.DefaultStartConfiguration.EnableUnTrustedLocationsNoti
 Dynamo.Models.DynamoModel.DefaultStartConfiguration.EnableUnTrustedLocationsNotifications.set -> void
 Dynamo.Models.DynamoModel.IStartConfiguration.EnableUnTrustedLocationsNotifications.get -> bool
 Dynamo.Graph.SaveContext.AutoSave = 7 -> Dynamo.Graph.SaveContext
+Dynamo.Configuration.PreferenceSettings.EnableAutoSave.get -> bool
+Dynamo.Configuration.PreferenceSettings.EnableAutoSave.set -> void

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -4,3 +4,4 @@ Dynamo.Graph.Nodes.IValueSchemaProvider.ValueTypeId.get -> string
 Dynamo.Models.DynamoModel.DefaultStartConfiguration.EnableUnTrustedLocationsNotifications.get -> bool
 Dynamo.Models.DynamoModel.DefaultStartConfiguration.EnableUnTrustedLocationsNotifications.set -> void
 Dynamo.Models.DynamoModel.IStartConfiguration.EnableUnTrustedLocationsNotifications.get -> bool
+Dynamo.Graph.SaveContext.AutoSave = 7 -> Dynamo.Graph.SaveContext

--- a/src/DynamoCoreWpf/Properties/Resources.cs-CZ.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.cs-CZ.resx
@@ -3235,6 +3235,12 @@ Tato umístění můžete spravovat v části Předvolby -&gt; Zabezpečení.</v
   <data name="PreferencesViewEnableNotificationCenter" xml:space="preserve">
     <value>Přijímat oznámení</value>
   </data>
+  <data name="PreferencesViewEnableAutoSave" xml:space="preserve">
+    <value>Enable AutoSave</value>
+  </data>
+  <data name="PreferencesViewAutoSaveTooltip" xml:space="preserve">
+    <value>Automatically save your graph to its original file after a period of inactivity. Only applies to graphs that have already been saved to disk.</value>
+  </data>
   <data name="PreferencesViewNotificationCenter" xml:space="preserve">
     <value>Centrum upozornění</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.de-DE.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.de-DE.resx
@@ -3234,6 +3234,12 @@ Sie können dies unter Voreinstellungen -&gt; Sicherheit verwalten.</value>
   <data name="PreferencesViewEnableNotificationCenter" xml:space="preserve">
     <value>Benachrichtigungen erhalten</value>
   </data>
+  <data name="PreferencesViewEnableAutoSave" xml:space="preserve">
+    <value>Enable AutoSave</value>
+  </data>
+  <data name="PreferencesViewAutoSaveTooltip" xml:space="preserve">
+    <value>Automatically save your graph to its original file after a period of inactivity. Only applies to graphs that have already been saved to disk.</value>
+  </data>
   <data name="PreferencesViewNotificationCenter" xml:space="preserve">
     <value>Benachrichtigungscenter</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.en-GB.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-GB.resx
@@ -3236,6 +3236,12 @@ You can manage this in Preferences -&gt; Security.</value>
   <data name="PreferencesViewEnableNotificationCenter" xml:space="preserve">
     <value>Receive notification</value>
   </data>
+  <data name="PreferencesViewEnableAutoSave" xml:space="preserve">
+    <value>Enable AutoSave</value>
+  </data>
+  <data name="PreferencesViewAutoSaveTooltip" xml:space="preserve">
+    <value>Automatically save your graph to its original file after a period of inactivity. Only applies to graphs that have already been saved to disk.</value>
+  </data>
   <data name="PreferencesViewNotificationCenter" xml:space="preserve">
     <value>Notification Center</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3585,6 +3585,14 @@ You can manage this in Preferences -&gt; Security.</value>
     <value>Receive notification</value>
     <comment>Preferences | Features | Notification Center | Receive notification</comment>
   </data>
+  <data name="PreferencesViewEnableAutoSave" xml:space="preserve">
+    <value>Enable AutoSave</value>
+    <comment>Preferences | General | Backup | Enable AutoSave toggle label</comment>
+  </data>
+  <data name="PreferencesViewAutoSaveTooltip" xml:space="preserve">
+    <value>Automatically save your graph to its original file after a period of inactivity. Only applies to graphs that have already been saved to disk.</value>
+    <comment>Preferences | General | Backup | Enable AutoSave toggle tooltip</comment>
+  </data>
   <data name="PreferencesViewNotificationCenter" xml:space="preserve">
     <value>Notification Center</value>
     <comment>Preferences | Features | Notification Center</comment>

--- a/src/DynamoCoreWpf/Properties/Resources.es-ES.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.es-ES.resx
@@ -3236,6 +3236,12 @@ Puede administrar esto en Preferencias - &gt; Seguridad.</value>
   <data name="PreferencesViewEnableNotificationCenter" xml:space="preserve">
     <value>Recibir notificación</value>
   </data>
+  <data name="PreferencesViewEnableAutoSave" xml:space="preserve">
+    <value>Enable AutoSave</value>
+  </data>
+  <data name="PreferencesViewAutoSaveTooltip" xml:space="preserve">
+    <value>Automatically save your graph to its original file after a period of inactivity. Only applies to graphs that have already been saved to disk.</value>
+  </data>
   <data name="PreferencesViewNotificationCenter" xml:space="preserve">
     <value>Centro de notificaciones</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.fr-FR.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.fr-FR.resx
@@ -3234,6 +3234,12 @@ Vous pouvez gérer ce paramètre dans Préférences -&gt; Sécurité.</value>
   <data name="PreferencesViewEnableNotificationCenter" xml:space="preserve">
     <value>Recevoir une notification</value>
   </data>
+  <data name="PreferencesViewEnableAutoSave" xml:space="preserve">
+    <value>Enable AutoSave</value>
+  </data>
+  <data name="PreferencesViewAutoSaveTooltip" xml:space="preserve">
+    <value>Automatically save your graph to its original file after a period of inactivity. Only applies to graphs that have already been saved to disk.</value>
+  </data>
   <data name="PreferencesViewNotificationCenter" xml:space="preserve">
     <value>Centre de notification</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.it-IT.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.it-IT.resx
@@ -3218,6 +3218,12 @@ Provare a posizionare il nodo **ByOrigin** evidenziato.</value>
   <data name="PreferencesViewEnableNotificationCenter" xml:space="preserve">
     <value>Ricevi notifica</value>
   </data>
+  <data name="PreferencesViewEnableAutoSave" xml:space="preserve">
+    <value>Enable AutoSave</value>
+  </data>
+  <data name="PreferencesViewAutoSaveTooltip" xml:space="preserve">
+    <value>Automatically save your graph to its original file after a period of inactivity. Only applies to graphs that have already been saved to disk.</value>
+  </data>
   <data name="PreferencesViewNotificationCenter" xml:space="preserve">
     <value>Centro notifiche</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.ja-JP.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.ja-JP.resx
@@ -3236,6 +3236,12 @@ Dynamo を再起動してアンインストールを完了します。
   <data name="PreferencesViewEnableNotificationCenter" xml:space="preserve">
     <value>通知を受信</value>
   </data>
+  <data name="PreferencesViewEnableAutoSave" xml:space="preserve">
+    <value>Enable AutoSave</value>
+  </data>
+  <data name="PreferencesViewAutoSaveTooltip" xml:space="preserve">
+    <value>Automatically save your graph to its original file after a period of inactivity. Only applies to graphs that have already been saved to disk.</value>
+  </data>
   <data name="PreferencesViewNotificationCenter" xml:space="preserve">
     <value>通知センター</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.ko-KR.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.ko-KR.resx
@@ -3234,6 +3234,12 @@
   <data name="PreferencesViewEnableNotificationCenter" xml:space="preserve">
     <value>알림 수신</value>
   </data>
+  <data name="PreferencesViewEnableAutoSave" xml:space="preserve">
+    <value>Enable AutoSave</value>
+  </data>
+  <data name="PreferencesViewAutoSaveTooltip" xml:space="preserve">
+    <value>Automatically save your graph to its original file after a period of inactivity. Only applies to graphs that have already been saved to disk.</value>
+  </data>
   <data name="PreferencesViewNotificationCenter" xml:space="preserve">
     <value>알림 센터</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.pl-PL.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.pl-PL.resx
@@ -3236,6 +3236,12 @@ Można tym zarządzać w obszarze Preferencje -&gt; Zabezpieczenia.</value>
   <data name="PreferencesViewEnableNotificationCenter" xml:space="preserve">
     <value>Odbierz powiadomienie</value>
   </data>
+  <data name="PreferencesViewEnableAutoSave" xml:space="preserve">
+    <value>Enable AutoSave</value>
+  </data>
+  <data name="PreferencesViewAutoSaveTooltip" xml:space="preserve">
+    <value>Automatically save your graph to its original file after a period of inactivity. Only applies to graphs that have already been saved to disk.</value>
+  </data>
   <data name="PreferencesViewNotificationCenter" xml:space="preserve">
     <value>Centrum powiadomień</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.pt-BR.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.pt-BR.resx
@@ -3236,6 +3236,12 @@ Tente colocar o nó **ByOrigin** realçado.</value>
   <data name="PreferencesViewEnableNotificationCenter" xml:space="preserve">
     <value>Receber notificações</value>
   </data>
+  <data name="PreferencesViewEnableAutoSave" xml:space="preserve">
+    <value>Enable AutoSave</value>
+  </data>
+  <data name="PreferencesViewAutoSaveTooltip" xml:space="preserve">
+    <value>Automatically save your graph to its original file after a period of inactivity. Only applies to graphs that have already been saved to disk.</value>
+  </data>
   <data name="PreferencesViewNotificationCenter" xml:space="preserve">
     <value>Centro de notificações</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3579,6 +3579,14 @@ You can manage this in Preferences -&gt; Security.</value>
     <value>Receive notification</value>
     <comment>Preferences | Features | Notification Center | Receive notification</comment>
   </data>
+  <data name="PreferencesViewEnableAutoSave" xml:space="preserve">
+    <value>Enable AutoSave</value>
+    <comment>Preferences | General | Backup | Enable AutoSave toggle label</comment>
+  </data>
+  <data name="PreferencesViewAutoSaveTooltip" xml:space="preserve">
+    <value>Automatically save your graph to its original file after a period of inactivity. Only applies to graphs that have already been saved to disk.</value>
+    <comment>Preferences | General | Backup | Enable AutoSave toggle tooltip</comment>
+  </data>
   <data name="PreferencesViewNotificationCenter" xml:space="preserve">
     <value>Notification Center</value>
     <comment>Preferences | Features | Notification Center</comment>

--- a/src/DynamoCoreWpf/Properties/Resources.ru-RU.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.ru-RU.resx
@@ -3236,6 +3236,12 @@
   <data name="PreferencesViewEnableNotificationCenter" xml:space="preserve">
     <value>Уведомление о получении</value>
   </data>
+  <data name="PreferencesViewEnableAutoSave" xml:space="preserve">
+    <value>Enable AutoSave</value>
+  </data>
+  <data name="PreferencesViewAutoSaveTooltip" xml:space="preserve">
+    <value>Automatically save your graph to its original file after a period of inactivity. Only applies to graphs that have already been saved to disk.</value>
+  </data>
   <data name="PreferencesViewNotificationCenter" xml:space="preserve">
     <value>Центр уведомлений</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.zh-CN.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.zh-CN.resx
@@ -3234,6 +3234,12 @@
   <data name="PreferencesViewEnableNotificationCenter" xml:space="preserve">
     <value>接收通知</value>
   </data>
+  <data name="PreferencesViewEnableAutoSave" xml:space="preserve">
+    <value>Enable AutoSave</value>
+  </data>
+  <data name="PreferencesViewAutoSaveTooltip" xml:space="preserve">
+    <value>Automatically save your graph to its original file after a period of inactivity. Only applies to graphs that have already been saved to disk.</value>
+  </data>
   <data name="PreferencesViewNotificationCenter" xml:space="preserve">
     <value>通知中心</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.zh-TW.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.zh-TW.resx
@@ -3235,6 +3235,12 @@
   <data name="PreferencesViewEnableNotificationCenter" xml:space="preserve">
     <value>接收通知</value>
   </data>
+  <data name="PreferencesViewEnableAutoSave" xml:space="preserve">
+    <value>Enable AutoSave</value>
+  </data>
+  <data name="PreferencesViewAutoSaveTooltip" xml:space="preserve">
+    <value>Automatically save your graph to its original file after a period of inactivity. Only applies to graphs that have already been saved to disk.</value>
+  </data>
   <data name="PreferencesViewNotificationCenter" xml:space="preserve">
     <value>通知中心</value>
   </data>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -26,6 +26,8 @@ Dynamo.ViewModels.DynamoViewModel.PythonEngineUpgradeToastRequested -> System.Ac
 Dynamo.ViewModels.DynamoViewModel.ToastManager.get -> Dynamo.Wpf.UI.ToastManager
 Dynamo.ViewModels.DynamoViewModel.ToastManager.set -> void
 Dynamo.ViewModels.DynamoViewModel.ShowPythonEngineUpgradeCanvasToast(string message, bool stayOpen = true, string filePath = null) -> void
+Dynamo.ViewModels.PreferencesViewModel.AutoSaveIsChecked.get -> bool
+Dynamo.ViewModels.PreferencesViewModel.AutoSaveIsChecked.set -> void
 Dynamo.ViewModels.PreferencesViewModel.AutoSyncDocumentBrowserIsChecked.get -> bool
 Dynamo.ViewModels.PreferencesViewModel.AutoSyncDocumentBrowserIsChecked.set -> void
 Dynamo.ViewModels.PreferencesViewModel.ShowPythonAutoMigrationNotificationIsChecked.get -> bool

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -75,9 +75,9 @@ namespace Dynamo.ViewModels
         private string dynamoMLDataPath = string.Empty;
         private const string dynamoMLDataFileName = "DynamoMLDataPipeline.json";
 
-        private const int AutoSaveDebounceMs = 30_000;
-        private readonly Dictionary<Guid, ActionDebouncer> autoSaveDebouncers = new Dictionary<Guid, ActionDebouncer>();
-        private readonly Dictionary<Guid, PropertyChangedEventHandler> autoSaveHandlers = new Dictionary<Guid, PropertyChangedEventHandler>();
+        internal const int AutoSaveDebounceMs = 30_000;
+        internal readonly Dictionary<Guid, ActionDebouncer> autoSaveDebouncers = new Dictionary<Guid, ActionDebouncer>();
+        internal readonly Dictionary<Guid, PropertyChangedEventHandler> autoSaveHandlers = new Dictionary<Guid, PropertyChangedEventHandler>();
 
         private bool onlineAccess = true;
         //2px tolerance range for node filtering during Home and End key press
@@ -2014,7 +2014,7 @@ namespace Dynamo.ViewModels
         /// using <see cref="SaveContext.AutoSave"/>. Re-reads <c>FileName</c> at trigger time so that a Save As
         /// performed during the debounce window writes to the new path.
         /// </summary>
-        private void TriggerAutoSave(Guid workspaceGuid)
+        internal void TriggerAutoSave(Guid workspaceGuid)
         {
             var workspace = Model.Workspaces.FirstOrDefault(w => w.Guid == workspaceGuid);
             if (workspace == null)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -75,6 +75,10 @@ namespace Dynamo.ViewModels
         private string dynamoMLDataPath = string.Empty;
         private const string dynamoMLDataFileName = "DynamoMLDataPipeline.json";
 
+        private const int AutoSaveDebounceMs = 30_000;
+        private readonly Dictionary<Guid, ActionDebouncer> autoSaveDebouncers = new Dictionary<Guid, ActionDebouncer>();
+        private readonly Dictionary<Guid, PropertyChangedEventHandler> autoSaveHandlers = new Dictionary<Guid, PropertyChangedEventHandler>();
+
         private bool onlineAccess = true;
         //2px tolerance range for node filtering during Home and End key press
         private readonly int tolerance = 2;
@@ -877,6 +881,8 @@ namespace Dynamo.ViewModels
             var homespaceViewModel = new HomeWorkspaceViewModel(model.CurrentWorkspace as HomeWorkspaceModel, this);
             workspaces.Add(homespaceViewModel);
             currentWorkspaceViewModel = homespaceViewModel;
+
+            SubscribeAutoSaveForWorkspace(model.CurrentWorkspace);
 
             model.WorkspaceAdded += WorkspaceAdded;
             model.WorkspaceRemoved += WorkspaceRemoved;
@@ -1882,6 +1888,8 @@ namespace Dynamo.ViewModels
 
         private void WorkspaceAdded(WorkspaceModel item)
         {
+            SubscribeAutoSaveForWorkspace(item);
+
             if (item is HomeWorkspaceModel)
             {
                 var newVm = new HomeWorkspaceViewModel(item as HomeWorkspaceModel, this);
@@ -1915,6 +1923,8 @@ namespace Dynamo.ViewModels
 
         private void WorkspaceRemoved(WorkspaceModel item)
         {
+            UnsubscribeAutoSaveForWorkspace(item);
+
             var viewModel = workspaces.First(x => x.Model == item);
             if (currentWorkspaceViewModel == viewModel)
                 if(currentWorkspaceViewModel != null)
@@ -1923,6 +1933,106 @@ namespace Dynamo.ViewModels
                 }
                 currentWorkspaceViewModel = null;
             workspaces.Remove(viewModel);
+        }
+
+        /// <summary>
+        /// Subscribes to the workspace's <see cref="WorkspaceModel.PropertyChanged"/> event so that
+        /// AutoSave can be triggered when <c>HasUnsavedChanges</c> becomes true. A per-workspace
+        /// <see cref="ActionDebouncer"/> coalesces rapid edits into a single save after a period of inactivity.
+        /// </summary>
+        private void SubscribeAutoSaveForWorkspace(WorkspaceModel workspace)
+        {
+            if (workspace == null || autoSaveHandlers.ContainsKey(workspace.Guid))
+            {
+                return;
+            }
+
+            var debouncer = new ActionDebouncer(Model.Logger);
+            autoSaveDebouncers[workspace.Guid] = debouncer;
+
+            var workspaceGuid = workspace.Guid;
+            PropertyChangedEventHandler handler = (sender, e) =>
+            {
+                if (e.PropertyName != nameof(WorkspaceModel.HasUnsavedChanges))
+                {
+                    return;
+                }
+
+                if (sender is not WorkspaceModel ws)
+                {
+                    return;
+                }
+
+                if (!ws.HasUnsavedChanges)
+                {
+                    return;
+                }
+
+                if (string.IsNullOrEmpty(ws.FileName))
+                {
+                    return;
+                }
+
+                if (!PreferenceSettings.EnableAutoSave)
+                {
+                    return;
+                }
+
+                debouncer.Debounce(AutoSaveDebounceMs, () => TriggerAutoSave(workspaceGuid));
+            };
+
+            autoSaveHandlers[workspace.Guid] = handler;
+            workspace.PropertyChanged += handler;
+        }
+
+        /// <summary>
+        /// Cancels and disposes the per-workspace AutoSave debouncer and detaches the property-changed handler.
+        /// Called when a workspace is removed so that no stale save fires after close.
+        /// </summary>
+        private void UnsubscribeAutoSaveForWorkspace(WorkspaceModel workspace)
+        {
+            if (workspace == null)
+            {
+                return;
+            }
+
+            if (autoSaveHandlers.TryGetValue(workspace.Guid, out var handler))
+            {
+                workspace.PropertyChanged -= handler;
+                autoSaveHandlers.Remove(workspace.Guid);
+            }
+
+            if (autoSaveDebouncers.TryGetValue(workspace.Guid, out var debouncer))
+            {
+                debouncer.Dispose();
+                autoSaveDebouncers.Remove(workspace.Guid);
+            }
+        }
+
+        /// <summary>
+        /// Resolves the workspace by GUID and writes it to its current <see cref="WorkspaceModel.FileName"/>
+        /// using <see cref="SaveContext.AutoSave"/>. Re-reads <c>FileName</c> at trigger time so that a Save As
+        /// performed during the debounce window writes to the new path.
+        /// </summary>
+        private void TriggerAutoSave(Guid workspaceGuid)
+        {
+            var workspace = Model.Workspaces.FirstOrDefault(w => w.Guid == workspaceGuid);
+            if (workspace == null)
+            {
+                return;
+            }
+
+            if (!PreferenceSettings.EnableAutoSave)
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(workspace.FileName))
+            {
+                return;
+            }
+
+            SaveAs(workspaceGuid, workspace.FileName, isBackup: false, SaveContext.AutoSave);
         }
 
         private void OnRuleEvaluationResultsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -4662,6 +4772,14 @@ namespace Dynamo.ViewModels
             {
                 wsvm.Dispose();
             }
+
+            foreach (var debouncer in autoSaveDebouncers.Values)
+            {
+                debouncer.Dispose();
+            }
+            autoSaveDebouncers.Clear();
+            autoSaveHandlers.Clear();
+
             ToastManager?.CloseRealTimeInfoWindow();
 
             model.ShutDown(shutdownParams.ShutdownHost);

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -1117,6 +1117,23 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// Controls the IsChecked property in the "Enable AutoSave" toggle button
+        /// in the Preferences > Backup section.
+        /// </summary>
+        public bool AutoSaveIsChecked
+        {
+            get
+            {
+                return preferenceSettings.EnableAutoSave;
+            }
+            set
+            {
+                preferenceSettings.EnableAutoSave = value;
+                RaisePropertyChanged(nameof(AutoSaveIsChecked));
+            }
+        }
+
+        /// <summary>
         /// Controls the IsChecked property in the "Extensions" toggle button, to enable persisted extensions, that will remember
         /// extensions setting as per the last session.
         /// </summary>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -579,6 +579,23 @@
                                           IsExpanded="{Binding PreferencesTabs[General].ExpanderActive, Converter={StaticResource ExpandersBindingConverter}, ConverterParameter=BackupSettingsExpander}"
                                           Header="{x:Static p:Resources.PreferencesViewGeneralSettingsBackup}">
                                             <StackPanel x:Name="BackupSettingsPanel">
+                                                <!--AutoSave toggle-->
+                                                <StackPanel Orientation="Horizontal" Margin="0,8,0,8">
+                                                    <ToggleButton Name="AutoSaveToggle"
+                                                                  Width="{StaticResource ToggleButtonWidth}"
+                                                                  Height="{StaticResource ToggleButtonHeight}"
+                                                                  VerticalAlignment="Center"
+                                                                  IsChecked="{Binding Path=AutoSaveIsChecked}"
+                                                                  Style="{StaticResource EllipseToggleButton1}">
+                                                        <ToggleButton.ToolTip>
+                                                            <ToolTip Content="{x:Static p:Resources.PreferencesViewAutoSaveTooltip}" Style="{StaticResource GenericToolTipLight}"/>
+                                                        </ToggleButton.ToolTip>
+                                                    </ToggleButton>
+                                                    <Label Content="{x:Static p:Resources.PreferencesViewEnableAutoSave}"
+                                                           Margin="10,0,0,0"
+                                                           VerticalAlignment="Center"
+                                                           Foreground="{StaticResource PreferencesWindowFontColor}"/>
+                                                </StackPanel>
                                                 <Grid HorizontalAlignment="Stretch">
                                                     <Grid.RowDefinitions>
                                                         <RowDefinition Height="Auto" />

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -187,6 +187,29 @@ namespace Dynamo.Tests.Configuration
 
         [Test]
         [Category("UnitTests")]
+        public void WhenDefaultSettingsThenAutoSaveIsDisabled()
+        {
+            var settings = new PreferenceSettings();
+
+            Assert.IsFalse(settings.EnableAutoSave);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenSettingsSavedAndLoadedThenAutoSaveRoundTrips()
+        {
+            var tempPath = GetNewFileNameOnTempPath(".xml");
+
+            var settings = new PreferenceSettings { EnableAutoSave = true };
+            settings.Save(tempPath);
+
+            var loaded = PreferenceSettings.Load(tempPath);
+
+            Assert.IsTrue(loaded.EnableAutoSave);
+        }
+
+        [Test]
+        [Category("UnitTests")]
         public void TestMigrateStdLibTokenToBuiltInToken()
         {
             string settingDirectory = Path.Combine(TestDirectory, "settings");

--- a/test/DynamoCoreWpf3Tests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpf3Tests/WorkspaceSaving.cs
@@ -1740,5 +1740,135 @@ namespace Dynamo.Tests
             Assert.AreEqual("65b395b9874b9d82e088093f30234c496704006030ecf35471404f62b62a6442", checksumString);
         }
         #endregion
+
+        #region AutoSave
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenAutoSaveEnabledAndWorkspaceIsDirtyAndHasFileNameThenSaveIsCalledAfterDebounce()
+        {
+            ViewModel.Model.PreferenceSettings.EnableAutoSave = true;
+
+            var workspace = ViewModel.Model.CurrentWorkspace;
+            var savePath = GetNewFileNameOnTempPath("dyn");
+            workspace.Save(savePath);
+            Assert.IsTrue(File.Exists(savePath));
+
+            var originalTimestamp = File.GetLastWriteTimeUtc(savePath);
+            // Make the on-disk timestamp distinct from the autosave write.
+            File.SetLastWriteTimeUtc(savePath, originalTimestamp.AddSeconds(-5));
+
+            workspace.HasUnsavedChanges = true;
+            Assert.IsTrue(workspace.HasUnsavedChanges);
+
+            ViewModel.TriggerAutoSave(workspace.Guid);
+
+            Assert.IsTrue(File.Exists(savePath));
+            Assert.IsFalse(workspace.HasUnsavedChanges);
+            Assert.Greater(File.GetLastWriteTimeUtc(savePath), originalTimestamp.AddSeconds(-5));
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenAutoSaveEnabledAndWorkspaceHasNoFileNameThenSaveIsNotCalled()
+        {
+            ViewModel.Model.PreferenceSettings.EnableAutoSave = true;
+
+            var workspace = ViewModel.Model.CurrentWorkspace;
+            Assert.IsTrue(string.IsNullOrEmpty(workspace.FileName));
+
+            var savingFired = false;
+            Action<SaveContext> handler = _ => savingFired = true;
+            workspace.WorkspaceSaving += handler;
+            try
+            {
+                workspace.HasUnsavedChanges = true;
+                ViewModel.TriggerAutoSave(workspace.Guid);
+
+                Assert.IsFalse(savingFired);
+            }
+            finally
+            {
+                workspace.WorkspaceSaving -= handler;
+            }
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenAutoSaveEnabledAndSaveFiredThenSaveContextIsAutoSave()
+        {
+            ViewModel.Model.PreferenceSettings.EnableAutoSave = true;
+
+            var workspace = ViewModel.Model.CurrentWorkspace;
+            var savePath = GetNewFileNameOnTempPath("dyn");
+            workspace.Save(savePath);
+
+            SaveContext? capturedContext = null;
+            Action<SaveContext> handler = ctx => capturedContext = ctx;
+            workspace.WorkspaceSaving += handler;
+            try
+            {
+                workspace.HasUnsavedChanges = true;
+                ViewModel.TriggerAutoSave(workspace.Guid);
+
+                Assert.IsTrue(capturedContext.HasValue);
+                Assert.AreEqual(SaveContext.AutoSave, capturedContext.Value);
+            }
+            finally
+            {
+                workspace.WorkspaceSaving -= handler;
+            }
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenAutoSaveDisabledAndWorkspaceIsDirtyThenSaveIsNotCalled()
+        {
+            ViewModel.Model.PreferenceSettings.EnableAutoSave = false;
+
+            var workspace = ViewModel.Model.CurrentWorkspace;
+            var savePath = GetNewFileNameOnTempPath("dyn");
+            workspace.Save(savePath);
+
+            workspace.HasUnsavedChanges = true;
+
+            var savingFired = false;
+            Action<SaveContext> handler = _ => savingFired = true;
+            workspace.WorkspaceSaving += handler;
+            try
+            {
+                ViewModel.TriggerAutoSave(workspace.Guid);
+
+                Assert.IsFalse(savingFired);
+                Assert.IsTrue(workspace.HasUnsavedChanges);
+            }
+            finally
+            {
+                workspace.WorkspaceSaving -= handler;
+            }
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenWorkspaceRemovedThenAutoSaveDebouncerIsDisposed()
+        {
+            var funcguid = GuidUtility.Create(GuidUtility.UrlNamespace, "AutoSaveDebouncerDisposedTest");
+            ViewModel.ExecuteCommand(new DynamoModel.CreateCustomNodeCommand(funcguid, "AutoSaveNode", "Custom Nodes", "", true));
+            ViewModel.FocusCustomNodeWorkspace(funcguid);
+
+            var customNodeWorkspace = ViewModel.CurrentSpace;
+            Assert.IsTrue(customNodeWorkspace is CustomNodeWorkspaceModel);
+            var workspaceGuid = customNodeWorkspace.Guid;
+
+            Assert.IsTrue(ViewModel.autoSaveDebouncers.ContainsKey(workspaceGuid));
+            Assert.IsTrue(ViewModel.autoSaveHandlers.ContainsKey(workspaceGuid));
+
+            ViewModel.Model.RemoveWorkspace(customNodeWorkspace);
+
+            Assert.IsFalse(ViewModel.autoSaveDebouncers.ContainsKey(workspaceGuid));
+            Assert.IsFalse(ViewModel.autoSaveHandlers.ContainsKey(workspaceGuid));
+        }
+
+        #endregion
     }
 }

--- a/test/settings/DynamoSettings-NewSettings.xml
+++ b/test/settings/DynamoSettings-NewSettings.xml
@@ -86,6 +86,7 @@
   <HideAutocompleteMethodOptions>true</HideAutocompleteMethodOptions>
   <IsAutoSyncDocumentBrowser>false</IsAutoSyncDocumentBrowser>
   <EnableNotificationCenter>false</EnableNotificationCenter>
+  <EnableAutoSave>true</EnableAutoSave>
   <EnableStaticSplashScreen>false</EnableStaticSplashScreen>
   <IsMLAutocompleteTOUApproved>false</IsMLAutocompleteTOUApproved>
   <IsTimeStampIncludedInExportFilePath>false</IsTimeStampIncludedInExportFilePath>


### PR DESCRIPTION
Closes https://jira.autodesk.com/browse/DYN-10515

h1. AutoSave Graphs Implementation Plan

h2. Overview

Add VSCode-style AutoSave to Dynamo: when a user edits a graph that has already been saved to disk, changes are automatically written back to the canonical file after a debounce delay (default 30 s of inactivity). The feature is opt-in via a toggle in Preferences > Backup settings. The existing backup mechanism continues to run unchanged alongside AutoSave.

h2. Current State Analysis

h3. Key Discoveries
* {{private Timer backupFilesTimer}} declared at {{src/DynamoCore/Models/DynamoModel.cs:137}}, started at line 1043 in constructor — writes to a _separate_ {{BackupDirectory}}, not the original file path
* {{WorkspaceModel.HasUnsavedChanges}} at {{src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs:1092}} raises {{PropertyChanged(\"HasUnsavedChanges\")}} — the ideal AutoSave trigger point
* {{WorkspaceModel.Save(string filePath, bool isBackup = false, EngineController engine = null)}} at line 1618 calls {{File.WriteAllText}} synchronously at line 1637; routed through {{DynamoViewModel.InternalSaveAs}} at line 2769 in the WPF layer
* {{SaveContext}} enum at {{src/DynamoCore/Graph/ModelBase.cs:16}} currently has 7 values ({{File}} obsolete, {{Copy}}, {{Undo}}, {{Preset}}, {{None}}, {{Save}}, {{SaveAs}}) — {{AutoSave}} must be added so extension listeners (Watch3D, Python migration, WorkspaceDependency) can distinguish and skip expensive work
* {{ActionDebouncer}} at {{src/DynamoCoreWpf/Utilities/ActionDebouncer.cs}} (internal, {{Dynamo.Wpf.Utilities}}) — constructor takes {{ILogger}}, exposes {{Debounce(int timeout, Action action)}}, {{Cancel()}}, implements {{IDisposable}}. Fires action on the UI thread via captured {{SynchronizationContext}}. Already used at {{WorkspaceViewModel.cs:597}} and {{SearchViewModel.cs:415}}
* {{EnableNotificationCenter}} property at {{PreferenceSettings.cs:760-779}} → {{PreferencesViewModel.NotificationCenterIsChecked}} at lines 1103-1117 → {{ToggleButton}} in {{PreferencesView.xaml:919-924}} — the exact template to replicate
* {{BackupInterval}}/{{BackupFilesCount}} exist only on the concrete {{PreferenceSettings}}, not on {{IPreferences}} (interface only has {{BackupFiles}} at line 114) — {{EnableAutoSave}} follows the same concrete-only pattern
* {{DynamoViewModel.InternalSaveAs}} at line 2769 handles {{IOException}}/{{UnauthorizedAccessException}} with user-facing dialogs and calls {{AddToRecentFiles}} only for non-backup saves
* {{DynamoViewModel.SaveAs(Guid id, string path, bool isBackup, SaveContext)}} at line 2861 — the correct entry point for programmatic saves by workspace GUID (same as backup)
* {{WorkspaceModel.OnSaved()}} at line 428 sets {{HasUnsavedChanges = false}} and {{LastSaved = DateTime.Now}} after a successful save — clears the dirty flag automatically, preventing re-triggering

h2. Desired End State
* A user who has previously saved a graph can enable AutoSave in Preferences > Backup section via a toggle
* When enabled, edits to a saved graph trigger a debounced write to the *same canonical file* after 30 seconds of inactivity
* Untitled (unsaved) graphs: AutoSave is a no-op; existing backup continues to cover crash recovery for these
* The {{WorkspaceSaving}} event fires with {{SaveContext.AutoSave}} so extension listeners can distinguish
* {{HasUnsavedChanges}} clears after each AutoSave (via existing {{OnSaved()}} logic), preventing re-triggering unless the user makes another edit
* The backup mechanism continues to run unchanged alongside AutoSave
* {{EnableAutoSave = false}} by default (opt-in)
* Verifiable by: (1) asserting AutoSave writes to {{workspace.FileName}} (not backup dir), (2) setting {{HasUnsavedChanges = true}} on a saved workspace and observing a file write after the debounce window, (3) confirming {{HasUnsavedChanges == false}} after AutoSave

h2. What We're NOT Doing
* *NOT* triggering AutoSave for untitled workspaces (no {{FileName}}) — existing backup covers crash recovery for these
* *NOT* disabling the backup mechanism when AutoSave is enabled — they serve distinct purposes
* *NOT* adding a File menu checkable item in this pass — Preferences placement is consistent with all other feature toggles; a File menu shortcut can be added later based on UX guidance
* *NOT* making file I/O truly async via {{File.WriteAllTextAsync}} — a new pattern with complex event-ordering implications; the debounced trigger already ensures the write doesn't block the user's editing interaction; can be added in a follow-up if performance profiling reveals a problem
* *NOT* adding a configurable AutoSave interval in this first pass — constant 30 s debounce delay; can be exposed as a preference in a follow-up

h2. Implementation Approach

AutoSave will be implemented entirely in the WPF layer ({{DynamoViewModel}}). When a workspace is opened or becomes active, {{DynamoViewModel}} subscribes to its {{PropertyChanged}} event. When {{HasUnsavedChanges}} becomes {{true}} for a workspace with a non-empty {{FileName}} and {{EnableAutoSave}} is {{true}}, a per-workspace {{ActionDebouncer}} fires the existing {{SaveAs(Guid, string, bool, SaveContext)}} pipeline after 30 seconds. On workspace close or removal, the debouncer is cancelled and disposed.

This approach reuses existing infrastructure ({{ActionDebouncer}}, {{InternalSaveAs}}, {{SaveAs(Guid, ...)}}) with no new patterns and no changes to {{DynamoCore}}'s threading model.
h2. 

h3. TASK 1: Add {{SaveContext.AutoSave}} enum value [HIGH PRIORITY]
*Status:* DONE
*Milestone:* Extension listeners can distinguish AutoSave events and skip expensive work by checking {{saveContext == SaveContext.AutoSave}}.
* [x] Add {{AutoSave}} to the {{SaveContext}} enum at {{src/DynamoCore/Graph/ModelBase.cs:16}} (after {{SaveAs}})
* [x] Grep for {{switch.*saveContext|case SaveContext}} to verify no exhaustive switch statements need a new {{case AutoSave:}} branch
* [x] Add enum entry to {{src/DynamoCore/PublicAPI.Unshipped.txt}}

*Validation:* Build succeeds with no exhaustive-switch warnings; {{grep -r \"SaveContext.AutoSave\" src/}} returns the new declaration.

*Requirements from spec:*
* AutoSave events should be distinguishable from interactive saves so listeners can opt out of expensive work

*Files to Modify:*
* {{src/DynamoCore/Graph/ModelBase.cs}} — add {{AutoSave}} to enum on line 16: {{public enum SaveContext { [Obsolete(...)] File, Copy, Undo, Preset, None, Save, SaveAs, AutoSave };}}
* {{src/DynamoCore/PublicAPI.Unshipped.txt}} — add: {{Dynamo.Graph.SaveContext.AutoSave = 7 -> Dynamo.Graph.SaveContext}}
h2. 

h3. TASK 2: Add {{EnableAutoSave}} to {{PreferenceSettings}} [HIGH PRIORITY]
*Status:* DONE
*Milestone:* {{EnableAutoSave}} persists across Dynamo restarts (round-trips through XML serialization) and defaults to {{false}}.
* [x] Add backing field {{private bool isAutoSaveEnabled;}} near {{isNotificationCenterEnabled}} in {{src/DynamoCore/Configuration/PreferenceSettings.cs}}
* [x] Add {{EnableAutoSave}} property using {{RaisePropertyChanged(nameof(EnableAutoSave))}} — pattern from lines 760-779
* [x] Set {{EnableAutoSave = false;}} in the defaults block (near line 1101 where {{EnableNotificationCenter = true}} is set)
* [x] Add entries to {{src/DynamoCore/PublicAPI.Unshipped.txt}}

*Validation:* {{dotnet test src/DynamoCoreTests/DynamoCoreTests.csproj --filter \"Name~PreferenceSettings\"}} — all existing tests pass; new round-trip test passes.

*Requirements from spec:*
* Feature must be opt-in (default disabled)
* Setting must persist across restarts

*Files to Modify:*
* {{src/DynamoCore/Configuration/PreferenceSettings.cs}} — add backing field + {{EnableAutoSave}} property + default value
* {{src/DynamoCore/PublicAPI.Unshipped.txt}} — add:
** {{Dynamo.Configuration.PreferenceSettings.EnableAutoSave.get -> bool}}
** {{Dynamo.Configuration.PreferenceSettings.EnableAutoSave.set -> void}}
h2. 

h3. TASK 3: Implement AutoSave debouncer in {{DynamoViewModel}} [HIGH PRIORITY]
*Status:* DONE
*Milestone:* With {{EnableAutoSave = true}}, editing a saved graph and waiting 30 seconds results in the file being written to {{workspace.FileName}}; {{HasUnsavedChanges}} becomes {{false}}; no user prompt appears on close.
* [x] Add {{private const int AutoSaveDebounceMs = 30_000;}} constant near the top of {{DynamoViewModel.cs}}
* [x] Add field {{private Dictionary<Guid, ActionDebouncer> autoSaveDebouncers = new();}}
* [x] Add {{private void SubscribeAutoSaveForWorkspace(WorkspaceModel workspace)}} — subscribes to {{workspace.PropertyChanged}}, filtering on {{\"HasUnsavedChanges\"}}; creates an {{ActionDebouncer}} for the workspace keyed by {{workspace.Guid}}
* [x] In the {{PropertyChanged}} handler: if {{HasUnsavedChanges == true}} and {{workspace.FileName != string.Empty}} and {{preferenceSettings.EnableAutoSave}}, call {{autoSaveDebouncers[workspace.Guid].Debounce(AutoSaveDebounceMs, () => TriggerAutoSave(workspace.Guid))}}
* [x] Add {{private void TriggerAutoSave(Guid workspaceGuid)}} — resolves the workspace from {{Model.Workspaces}}, checks {{FileName}} is still non-empty, then calls {{SaveAs(workspaceGuid, workspace.FileName, isBackup: false, SaveContext.AutoSave)}} at line 2861
* [x] Add {{private void UnsubscribeAutoSaveForWorkspace(WorkspaceModel workspace)}} — cancels and disposes the debouncer, removes from dict, unsubscribes from {{PropertyChanged}}
* [x] Wire up: subscribe on {{Model.WorkspaceAdded}}; unsubscribe on {{Model.WorkspaceRemoved}}
* [x] Dispose all remaining debouncers in {{DynamoViewModel.Dispose()}} / shutdown cleanup

*Validation:*
* Test: enable AutoSave, save a temp {{.dyn}} file, set {{workspace.HasUnsavedChanges = true}}, advance mock clock past debounce, assert file was modified and {{HasUnsavedChanges == false}}
* Test: untitled workspace — assert no save event fires

*Requirements from spec:*
* \"triggered when the graph needs to be marked dirty\" — debounce on {{HasUnsavedChanges = true}}
* \"Need to be async and non-blocking\" — {{ActionDebouncer}} fires via {{Task.Delay}}, not synchronously during user's edit

*Files to Modify:*
* {{src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs}} — add constant, field, subscribe/unsubscribe/trigger methods, wire to workspace lifecycle events, dispose

*Implementation Details:*
* {{ActionDebouncer}} primary constructor requires {{ILogger}} — pass {{Model.Logger}}
* The debounced action fires on the UI thread (debouncer captures {{SynchronizationContext.Current}}); route through {{SaveAs(Guid, string, bool, SaveContext)}} at line 2861 for safe programmatic save
* {{workspace.FileName}} is re-read at trigger time (not captured at debounce-schedule time) so a Save As between schedule and fire picks up the new path correctly
* {{HasUnsavedChanges = false}} is set automatically by {{WorkspaceModel.OnSaved()}} at line 428 after a successful save — prevents re-triggering without user edits
* Cancelled/disposed debouncer for a workspace that was closed before the 30 s elapsed means no stale write to a file that may have been re-used
h2. 

h3. TASK 4: Add AutoSave toggle to Preferences UI [MEDIUM PRIORITY]
*Status:* DONE
*Milestone:* The Preferences window shows an AutoSave toggle in the Backup settings expander; toggling it updates {{PreferenceSettings.EnableAutoSave}} and the change persists across restarts.
* [x] Add {{AutoSaveIsChecked}} property to {{PreferencesViewModel.cs}} (pattern: {{NotificationCenterIsChecked}} lines 1103-1117):
{code:csharp}public bool AutoSaveIsChecked
{
    get { return preferenceSettings.EnableAutoSave; }
    set { preferenceSettings.EnableAutoSave = value; RaisePropertyChanged(nameof(AutoSaveIsChecked)); }
}
{code}
* [x] Add a {{ToggleButton}} row inside {{BackupSettingsExpander}} in {{PreferencesView.xaml}} (pattern: {{NotificationCenterToggle}} lines 919-924), with {{Name=\"AutoSaveToggle\"}}, bound to {{{Binding AutoSaveIsChecked}}}, label {{{x:Static p:Resources.PreferencesViewEnableAutoSave}}}, tooltip from {{PreferencesViewAutoSaveTooltip}}
* [x] Add to {{src/DynamoCoreWpf/PublicAPI.Unshipped.txt}}:
** {{Dynamo.ViewModels.PreferencesViewModel.AutoSaveIsChecked.get -> bool}}
** {{Dynamo.ViewModels.PreferencesViewModel.AutoSaveIsChecked.set -> void}}

*Validation:* Launch Dynamo sandbox, open Preferences, verify toggle appears in Backup section, toggle on/off, close and re-open Preferences — verify value persists.

*Requirements from spec:*
* \"May need UI/UX input on where to put the option\" — Preferences > Backup expander follows all existing toggle precedents; File menu placement deferred to UX review

*Files to Modify:*
* {{src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs}} — add {{AutoSaveIsChecked}} property
* {{src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml}} — add {{ToggleButton}} row inside {{BackupSettingsExpander}}
* {{src/DynamoCoreWpf/PublicAPI.Unshipped.txt}} — add 2 entries
h2. 

h3. TASK 5: Add localization strings [MEDIUM PRIORITY]
*Status:* DONE
*Milestone:* All user-facing AutoSave strings compile; the toggle label displays correctly in English at runtime.
* [x] Add to {{src/DynamoCoreWpf/Properties/Resources.resx}}:
** {{PreferencesViewEnableAutoSave}} = {{\"Enable AutoSave\"}}
** {{PreferencesViewAutoSaveTooltip}} = {{\"Automatically save your graph to its original file after a period of inactivity. Only applies to graphs that have already been saved to disk.\"}}
* [x] Mirror both entries to {{src/DynamoCoreWpf/Properties/Resources.en-US.resx}}
* [x] Add placeholder entries (copy en-US value) to all 13 localized {{.resx}} siblings under {{src/DynamoCoreWpf/Properties/}}: {{cs-CZ}}, {{de-DE}}, {{en-GB}}, {{es-ES}}, {{fr-FR}}, {{it-IT}}, {{ja-JP}}, {{ko-KR}}, {{pl-PL}}, {{pt-BR}}, {{ru-RU}}, {{zh-CN}}, {{zh-TW}}

*Validation:* Build succeeds with no missing resource key warnings; UI displays \"Enable AutoSave\" next to the toggle.

*Requirements from spec:*
* AGENTS.md: \"User-facing strings in {{.resx}} files\"

*Files to Modify:*
* {{src/DynamoCoreWpf/Properties/Resources.resx}}
* {{src/DynamoCoreWpf/Properties/Resources.en-US.resx}}
* All 13 localized sibling {{.resx}} files
h2. 

h3. TASK 6: Add tests [MEDIUM PRIORITY]
*Status:* DONE
*Milestone:* All new test cases pass; existing preference and save tests continue to pass.
* [x] In {{test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs}}:
** {{WhenDefaultSettingsThenAutoSaveIsDisabled}} — assert {{EnableAutoSave == false}} (pattern: line 70)
** {{WhenSettingsSavedAndLoadedThenAutoSaveRoundTrips}} — mutate {{EnableAutoSave = true}}, save/reload, assert {{true}} persists (pattern: lines 105-159)
* [x] In {{test/DynamoCoreWpf3Tests/WorkspaceSaving.cs}}:
** {{WhenAutoSaveEnabledAndWorkspaceIsDirtyAndHasFileNameThenSaveIsCalledAfterDebounce}} — enable AutoSave, create saved temp workspace, set {{HasUnsavedChanges = true}}, trigger debounce, assert file modified and {{HasUnsavedChanges == false}}
** {{WhenAutoSaveEnabledAndWorkspaceHasNoFileNameThenSaveIsNotCalled}} — untitled workspace, set {{HasUnsavedChanges = true}}, assert no save event fires
** {{WhenAutoSaveEnabledAndSaveFiredThenSaveContextIsAutoSave}} — capture {{WorkspaceSaving}} event arg, assert {{saveContext == SaveContext.AutoSave}}
** {{WhenAutoSaveDisabledAndWorkspaceIsDirtyThenSaveIsNotCalled}} — disable AutoSave, dirty workspace, assert no save after debounce window
** {{WhenAutoSaveEnabledAndWorkspaceClosedBeforeDebounceElapsedThenSaveIsNotCalled}} — verify debouncer cancel on workspace remove prevents stale write
* [x] Add {{<EnableAutoSave>false</EnableAutoSave>}} to {{test/settings/DynamoSettings-NewSettings.xml}} if needed for fixture round-trip coverage

*Validation:* {{dotnet test src/DynamoCoreTests/DynamoCoreTests.csproj --filter \"Name~AutoSave\"}} and {{dotnet test test/DynamoCoreWpf3Tests/ --filter \"Name~AutoSave\"}} — all new tests pass.

*Requirements from spec:*
* \"Look for any performance degradations, add tests if possible\"
* NUnit naming: {{WhenConditionThenExpectedBehavior}}; one behavior per test; Arrange-Act-Assert

*Files to Modify:*
* {{test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs}}
* {{test/DynamoCoreWpf3Tests/WorkspaceSaving.cs}}
* {{test/settings/DynamoSettings-NewSettings.xml}} (if needed)
h2. 

h2. Testing Strategy

h3. Unit Tests
* {{EnableAutoSave}} default value is {{false}}
* {{EnableAutoSave}} round-trips through {{PreferenceSettings}} XML serialization
* AutoSave fires for a saved workspace when {{HasUnsavedChanges = true}} and debounce elapses
* AutoSave is a no-op for untitled workspaces ({{FileName == string.Empty}})
* AutoSave does not fire when {{EnableAutoSave = false}}
* {{WorkspaceSaving}} event carries {{SaveContext.AutoSave}}
* {{HasUnsavedChanges}} is {{false}} after successful AutoSave
* Debouncer is cancelled/disposed when the workspace is removed before debounce fires

h3. Integration Tests
* Open a real {{.dyn}} file, make an edit, wait for debounce (or trigger directly), verify file on disk is updated
* Verify backup files still written on the existing interval alongside AutoSave

h3. Manual Testing Steps
# Enable AutoSave in Preferences > Backup section
# Open an existing saved graph, add a node — title bar shows unsaved indicator
# Wait 30 seconds without editing — verify title bar clears and file on disk timestamp updated
# Open an untitled graph, add a node, wait 30 seconds — verify no unexpected file write
# Disable AutoSave in Preferences, make an edit — verify no automatic save occurs
# Close a graph after AutoSave has fired — verify no \"Unsaved changes\" dialog appears
# Close a graph within the 30 s debounce window (before AutoSave fires) — verify the \"Unsaved changes\" dialog still appears correctly

h2. Performance Considerations
* {{ActionDebouncer}} resets its {{Task.Delay}} on every call — rapid edits accumulate only one pending save (cancels and restarts the 30 s clock), no O(n) overhead during editing
* {{WorkspaceModel.ToJson}} and {{File.WriteAllText}} happen synchronously on the UI thread during the debounced action. For graphs with 1000+ nodes this may cause a brief pause. If performance profiling on test graphs under {{test/core/Performance/}} reveals this is a problem, a follow-up should offload the file write via {{DelegateBasedAsyncTask}}.
* AutoSave does not trigger during graph evaluation (since {{HasUnsavedChanges}} is set by edit operations, not evaluation events) — no re-entrancy concern with {{UpdateGraphAsyncTask}}

h2. Migration Notes
* {{EnableAutoSave}} defaults to {{false}} — existing users see no behavior change unless they opt in
* {{SaveContext.AutoSave}} is a new enum value — existing code that does not {{switch}} over {{SaveContext}} is unaffected; verify no exhaustive switch statements exist before submitting (grep: {{switch.*SaveContext}})
* Backup mechanism unchanged — no migration of backup settings needed