### PR TITLE
DYN-10536: Command injection in issue_type_predicter.yml GitHub Actions workflow

### DIFF
--- a/.github/scripts/get_issue_json_body.ps1
+++ b/.github/scripts/get_issue_json_body.ps1
@@ -11,7 +11,5 @@ $json_object = @{
 
 $json_string = ConvertTo-Json -Compress $json_object
 
-$json_string = $json_string -replace '"', '\"'
-
 Write-Output $json_string
 

--- a/.github/workflows/issue_type_predicter.yml
+++ b/.github/workflows/issue_type_predicter.yml
@@ -54,7 +54,7 @@ jobs:
           ISSUE_BODY_PARSED: ${{ github.event.issue.body }}
         run: |
           parsed=$(pwsh ./.github/scripts/issue_body_cleaner.ps1)
-          # issue_body_cleaner.ps1 emits one line per parsed section — always multi-line.
+          # issue_body_cleaner.ps1 emits one line per parsed section, so the output can be multi-line.
           delimiter="GHA_EOF_$(openssl rand -hex 16)"
           {
             printf 'parsed_issue_body<<%s\n' "$delimiter"

--- a/.github/workflows/issue_type_predicter.yml
+++ b/.github/workflows/issue_type_predicter.yml
@@ -40,7 +40,12 @@ jobs:
           ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
           response=$(pwsh ./.github/scripts/issue_analyzer.ps1 "${{ env.template }}" "${{ env.acceptable_missing_info }}")
-          echo "analysis_response=$response" >> "$GITHUB_ENV"
+          delimiter="GHA_EOF_$(openssl rand -hex 16)"
+          {
+            printf 'analysis_response<<%s\n' "$delimiter"
+            printf '%s\n' "$response"
+            printf '%s\n' "$delimiter"
+          } >> "$GITHUB_ENV"
 
       # Remove sections in the issue body like "Dynamo version", "Stack Trace" because won't be used to predict the issue type
       - name: Clean Issue Body
@@ -49,7 +54,13 @@ jobs:
           ISSUE_BODY_PARSED: ${{ github.event.issue.body }}
         run: |
           parsed=$(pwsh ./.github/scripts/issue_body_cleaner.ps1)
-          echo "parsed_issue_body=$parsed" >> "$GITHUB_ENV"
+          # issue_body_cleaner.ps1 emits one line per parsed section — always multi-line.
+          delimiter="GHA_EOF_$(openssl rand -hex 16)"
+          {
+            printf 'parsed_issue_body<<%s\n' "$delimiter"
+            printf '%s\n' "$parsed"
+            printf '%s\n' "$delimiter"
+          } >> "$GITHUB_ENV"
 
       # Create json string from the issue body
       - name: Create Issue JSON String
@@ -59,7 +70,12 @@ jobs:
           ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
           json=$(pwsh ./.github/scripts/get_issue_json_body.ps1 "$ISSUE_NUMBER")
-          echo "issue_json_string=$json" >> "$GITHUB_ENV"
+          delimiter="GHA_EOF_$(openssl rand -hex 16)"
+          {
+            printf 'issue_json_string<<%s\n' "$delimiter"
+            printf '%s\n' "$json"
+            printf '%s\n' "$delimiter"
+          } >> "$GITHUB_ENV"
 
       # Checkout the IssuesTypePredicter repo (https://github.com/DynamoDS/IssuesTypePredicter)
       - name: Checkout IssuesTypePredicter Repo
@@ -89,7 +105,12 @@ jobs:
           ISSUE_JSON: ${{ env.issue_json_string }}
         run: |
           result=$(dotnet run --project ./IssuesTypePredicter/IssuesTypePredicterML.ConsoleApp/IssuesTypePredicterML.ConsoleApp.csproj -v q "$ISSUE_JSON")
-          echo "is_wish_list=$result" >> "$GITHUB_ENV"
+          delimiter="GHA_EOF_$(openssl rand -hex 16)"
+          {
+            printf 'is_wish_list<<%s\n' "$delimiter"
+            printf '%s\n' "$result"
+            printf '%s\n' "$delimiter"
+          } >> "$GITHUB_ENV"
 
       #  If the is_wish_list variable contains 1, label the issue as "Wishlist"
       - name: Label issue as 'Wishlist'

--- a/.github/workflows/issue_type_predicter.yml
+++ b/.github/workflows/issue_type_predicter.yml
@@ -5,6 +5,11 @@ on:
   issues:
     types: [opened, edited]
 
+# Least-privilege token scope: we only need to read repo contents and label issues.
+permissions:
+  issues: write
+  contents: read
+
 jobs:
   issue_type_Predicter:
     name: Issue Type Predicter
@@ -29,40 +34,32 @@ jobs:
       - name: Checkout Dynamo Repo
         uses: actions/checkout@v6
 
-      # Removes quotes before using the issue content as a script parameter
-      - name: Remove Quotes
-        id: remove_quotes
-        uses: frabert/replace-string-action@v2.5
-        env:
-          ISSUE_BODY: ${{ github.event.issue.body }}
-        with:
-          pattern: "\""
-          string: ${{ env.ISSUE_BODY }}
-          replace-with: '-'
-
       # Analyze for missing information inside the issue content
       - name: Analyze Issue Body
         env:
-          ISSUE_BODY: ${{ steps.remove_quotes.outputs.replaced }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          echo "analysis_response=$(pwsh .\\.github\\scripts\\issue_analyzer.ps1 "${{ env.template }}" "${{ env.acceptable_missing_info }}")" >> $GITHUB_ENV
+          response=$(pwsh ./.github/scripts/issue_analyzer.ps1 "${{ env.template }}" "${{ env.acceptable_missing_info }}")
+          echo "analysis_response=$response" >> "$GITHUB_ENV"
 
       # Remove sections in the issue body like "Dynamo version", "Stack Trace" because won't be used to predict the issue type
       - name: Clean Issue Body
         if: env.analysis_response == 'Valid'
         env:
-          ISSUE_BODY_PARSED: ${{ steps.remove_quotes.outputs.replaced }}
+          ISSUE_BODY_PARSED: ${{ github.event.issue.body }}
         run: |
-          echo "parsed_issue_body="$(pwsh .\\.github\\scripts\\issue_body_cleaner.ps1 )"" >> $GITHUB_ENV
+          parsed=$(pwsh ./.github/scripts/issue_body_cleaner.ps1)
+          echo "parsed_issue_body=$parsed" >> "$GITHUB_ENV"
 
       # Create json string from the issue body
       - name: Create Issue JSON String
         if: env.analysis_response == 'Valid'
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_TITLE:  ${{ github.event.issue.title }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
-          echo "issue_json_string="$(pwsh .\\.github\\scripts\\get_issue_json_body.ps1 "$ISSUE_NUMBER")"" >> $GITHUB_ENV
+          json=$(pwsh ./.github/scripts/get_issue_json_body.ps1 "$ISSUE_NUMBER")
+          echo "issue_json_string=$json" >> "$GITHUB_ENV"
 
       # Checkout the IssuesTypePredicter repo (https://github.com/DynamoDS/IssuesTypePredicter)
       - name: Checkout IssuesTypePredicter Repo
@@ -88,21 +85,28 @@ jobs:
       # Execute the IssuesTypePredicter program and pass 'issue_json_string' as a parameter
       - name: Run Issues Type Predicter
         if: env.analysis_response == 'Valid'
+        env:
+          ISSUE_JSON: ${{ env.issue_json_string }}
         run: |
-          echo "is_wish_list="$(dotnet run --project ./IssuesTypePredicter/IssuesTypePredicterML.ConsoleApp/IssuesTypePredicterML.ConsoleApp.csproj -v q "${{ env.issue_json_string }}")"" >> $GITHUB_ENV
+          result=$(dotnet run --project ./IssuesTypePredicter/IssuesTypePredicterML.ConsoleApp/IssuesTypePredicterML.ConsoleApp.csproj -v q "$ISSUE_JSON")
+          echo "is_wish_list=$result" >> "$GITHUB_ENV"
 
       #  If the is_wish_list variable contains 1, label the issue as "Wishlist"
       - name: Label issue as 'Wishlist'
         if: env.analysis_response == 'Valid' && contains(env.is_wish_list, 'IsWishlist:1')
         env:
           GH_TOKEN: ${{ secrets.DYNAMO_ISSUES_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
         run: |
-          gh issue edit ${{ github.event.issue.number }} --add-label "Wishlist" --repo ${{ github.repository }}
+          gh issue edit "$ISSUE_NUMBER" --add-label "Wishlist" --repo "$REPO"
 
       #  If the issue is missing important information (don't follow the template structure), label the issue as "NotMLEvaluated"
       - name: Label issue as 'NotMLEvaluated'
         if: env.analysis_response != 'Valid' || env.issue_json_string == ''
         env:
           GH_TOKEN: ${{ secrets.DYNAMO_ISSUES_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
         run: |
-          gh issue edit ${{ github.event.issue.number }} --add-label "NotMLEvaluated" --repo ${{ github.repository }}
+          gh issue edit "$ISSUE_NUMBER" --add-label "NotMLEvaluated" --repo "$REPO"


### PR DESCRIPTION
### Purpose

Received an external security vulnerability report via **Autodesk PSIRT**, about the #issue_type_predicter.yml GitHub Actions workflow, specifically a command injection risk. This issue highlights that the workflow's current implementation allows untrusted input to be passed directly into shell commands without proper sanitization, potentially enabling attackers to execute arbitrary commands. The ticket emphasizes the need to validate and sanitize all inputs used in shell commands to mitigate this risk. It recommends updating the workflow to use safer practices, such as leveraging parameterized commands or escaping inputs, to ensure the security of the CI/CD pipeline.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

### Summary of changes to [issue_type_predicter.yml](.github/workflows/issue_type_predicter.yml)

| # | Change | Why |
|---|--------|-----|
| 1 | Added top-level `permissions:` block (`issues: write`, `contents: read`). | Shrinks `GITHUB_TOKEN` blast radius if injection is ever reintroduced. |
| 2 | **Deleted the `Remove Quotes` step** and dropped the `frabert/replace-string-action@v2.5` dependency. | The action was an insufficient sanitizer (only stripped `"`, only from body, never from title). Unnecessary once values flow via `env:`. |
| 3 | **`Run Issues Type Predicter`** — the actual CVE fix: `${{ env.issue_json_string }}` moved into a step-level `env: ISSUE_JSON:` and the bash script reads `"$ISSUE_JSON"`. | Closes CWE-78 in the vulnerable step. |
| 4 | **`Analyze Issue Body`** / **`Clean Issue Body`** — `ISSUE_BODY` / `ISSUE_BODY_PARSED` now read from `github.event.issue.body` directly (no longer routed through the deleted `Remove Quotes` step). | Helper PowerShell scripts already read `$env:ISSUE_BODY` / `$env:ISSUE_BODY_PARSED`, so bash never sees the value. Safe by construction. |
| 7 | Quoted `"$GITHUB_ENV"` in `echo ... >> "$GITHUB_ENV"` calls. | Shell hygiene; the prior `echo "var="$(...)""` triple-quote concatenation was fragile. |
| 8 | Backslash paths (`.\\.github\\scripts\\...`) → forward slashes (`./.github/scripts/...`). | Runner is `ubuntu-latest`; forward slashes are unambiguous in bash. |

### Reviewers

@jasonstratton @RobertGlobant20 

### FYIs

@eamiri 
