### PR TITLE
DYN-9078: Node context menu chevron doesn't change color on hover

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -4114,7 +4114,11 @@
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="ContentPresenter" Property="TextBlock.Foreground" Value="White" />
+                            <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource GenericMouseOverBackgroundColorBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsSubmenuOpen" Value="True">
+                            <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="False">
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource NodeContextMenuBackground}" />
@@ -4211,7 +4215,11 @@
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="ContentPresenter" Property="TextBlock.Foreground" Value="White" />
+                            <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource GenericMouseOverBackgroundColorBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsSubmenuOpen" Value="True">
+                            <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="False">
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource GenericBorderBackgroundColorBrush}" />
@@ -4311,7 +4319,11 @@
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="ContentPresenter" Property="TextBlock.Foreground" Value="White" />
+                            <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource NodeContextMenuBackgroundHighlight}" />
+                        </Trigger>
+                        <Trigger Property="IsSubmenuOpen" Value="True">
+                            <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="False">
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource NodeContextMenuBackground}" />
@@ -5745,7 +5757,11 @@
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="ContentPresenter" Property="TextBlock.Foreground" Value="White" />
+                            <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource NodeContextMenuBackgroundHighlight}" />
+                        </Trigger>
+                        <Trigger Property="IsSubmenuOpen" Value="True">
+                            <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="False">
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource NodeContextMenuBackground}" />

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -2007,6 +2007,7 @@ namespace Dynamo.Nodes
                 Foreground = _blue300Brush,
                 VerticalAlignment = VerticalAlignment.Center,
                 HorizontalAlignment = HorizontalAlignment.Right,
+                RenderTransformOrigin = new Point(0.5, 0.5),
                 RenderTransform = new ScaleTransform(1, 1.5)
             };
 
@@ -2041,6 +2042,7 @@ namespace Dynamo.Nodes
                 popup.PlacementTarget = border;
                 popup.IsOpen = true;
                 border.Background = _nodeContextMenuBackgroundHighlight;
+                arrow.Foreground = Brushes.White;
             };
 
             border.MouseLeave += (s, e) =>
@@ -2050,6 +2052,7 @@ namespace Dynamo.Nodes
                 {
                     popup.IsOpen = false;
                     border.Background = Brushes.Transparent;
+                    arrow.Foreground = _blue300Brush;
                 }
             };
 

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -2387,13 +2387,6 @@ namespace Dynamo.Controls
             isMouseOverTrueTrigger.Setters.Add(new Setter(Control.ForegroundProperty, Brushes.White, "subMenuArrow"));
             isMouseOverTrueTrigger.Setters.Add(new Setter(DockPanel.BackgroundProperty, nodeContextMenuBackgroundHighlight, "dockPanel"));
 
-            var isSubmenuOpenTrigger = new Trigger
-            {
-                Property = MenuItem.IsSubmenuOpenProperty,
-                Value = true
-            };
-            isSubmenuOpenTrigger.Setters.Add(new Setter(Control.ForegroundProperty, Brushes.White, "subMenuArrow"));
-
             // Trigger for IsMouseOver property (false)
             var isMouseOverFalseTrigger = new Trigger
             {
@@ -2426,7 +2419,6 @@ namespace Dynamo.Controls
             menuItemTemplate.Triggers.Add(isMouseOverFalseTrigger);
             menuItemTemplate.Triggers.Add(dataTrigger);
             menuItemTemplate.Triggers.Add(isCheckedTrigger);
-            menuItemTemplate.Triggers.Add(isSubmenuOpenTrigger);
 
             menuItemStyle.Setters.Add(new Setter(MenuItem.TemplateProperty, menuItemTemplate));
            

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -2387,6 +2387,14 @@ namespace Dynamo.Controls
             isMouseOverTrueTrigger.Setters.Add(new Setter(Control.ForegroundProperty, Brushes.White, "subMenuArrow"));
             isMouseOverTrueTrigger.Setters.Add(new Setter(DockPanel.BackgroundProperty, nodeContextMenuBackgroundHighlight, "dockPanel"));
 
+            // Trigger for IsSubmenuOpen property
+            var isSubmenuOpenTrigger = new Trigger
+            {
+                Property = MenuItem.IsSubmenuOpenProperty,
+                Value = true
+            };
+            isSubmenuOpenTrigger.Setters.Add(new Setter(Control.ForegroundProperty, Brushes.White, "subMenuArrow"));
+
             // Trigger for IsMouseOver property (false)
             var isMouseOverFalseTrigger = new Trigger
             {
@@ -2416,6 +2424,7 @@ namespace Dynamo.Controls
             // Add the triggers to the ControlTemplate
             menuItemTemplate.Triggers.Add(isEnabledTrigger);
             menuItemTemplate.Triggers.Add(isMouseOverTrueTrigger);
+            menuItemTemplate.Triggers.Add(isSubmenuOpenTrigger);
             menuItemTemplate.Triggers.Add(isMouseOverFalseTrigger);
             menuItemTemplate.Triggers.Add(dataTrigger);
             menuItemTemplate.Triggers.Add(isCheckedTrigger);

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -2384,7 +2384,7 @@ namespace Dynamo.Controls
                 Value = true
             };
             isMouseOverTrueTrigger.Setters.Add(new Setter(TextBlock.ForegroundProperty, Brushes.White, "ContentPresenter"));
-            isMouseOverTrueTrigger.Setters.Add(new Setter(Label.ForegroundProperty, Brushes.White, "subMenuArrow"));
+            isMouseOverTrueTrigger.Setters.Add(new Setter(Control.ForegroundProperty, Brushes.White, "subMenuArrow"));
             isMouseOverTrueTrigger.Setters.Add(new Setter(DockPanel.BackgroundProperty, nodeContextMenuBackgroundHighlight, "dockPanel"));
 
             var isSubmenuOpenTrigger = new Trigger
@@ -2392,7 +2392,7 @@ namespace Dynamo.Controls
                 Property = MenuItem.IsSubmenuOpenProperty,
                 Value = true
             };
-            isSubmenuOpenTrigger.Setters.Add(new Setter(Label.ForegroundProperty, Brushes.White, "subMenuArrow"));
+            isSubmenuOpenTrigger.Setters.Add(new Setter(Control.ForegroundProperty, Brushes.White, "subMenuArrow"));
 
             // Trigger for IsMouseOver property (false)
             var isMouseOverFalseTrigger = new Trigger
@@ -2426,6 +2426,7 @@ namespace Dynamo.Controls
             menuItemTemplate.Triggers.Add(isMouseOverFalseTrigger);
             menuItemTemplate.Triggers.Add(dataTrigger);
             menuItemTemplate.Triggers.Add(isCheckedTrigger);
+            menuItemTemplate.Triggers.Add(isSubmenuOpenTrigger);
 
             menuItemStyle.Setters.Add(new Setter(MenuItem.TemplateProperty, menuItemTemplate));
            

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -2384,7 +2384,15 @@ namespace Dynamo.Controls
                 Value = true
             };
             isMouseOverTrueTrigger.Setters.Add(new Setter(TextBlock.ForegroundProperty, Brushes.White, "ContentPresenter"));
+            isMouseOverTrueTrigger.Setters.Add(new Setter(Label.ForegroundProperty, Brushes.White, "subMenuArrow"));
             isMouseOverTrueTrigger.Setters.Add(new Setter(DockPanel.BackgroundProperty, nodeContextMenuBackgroundHighlight, "dockPanel"));
+
+            var isSubmenuOpenTrigger = new Trigger
+            {
+                Property = MenuItem.IsSubmenuOpenProperty,
+                Value = true
+            };
+            isSubmenuOpenTrigger.Setters.Add(new Setter(Label.ForegroundProperty, Brushes.White, "subMenuArrow"));
 
             // Trigger for IsMouseOver property (false)
             var isMouseOverFalseTrigger = new Trigger

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -2387,14 +2387,6 @@ namespace Dynamo.Controls
             isMouseOverTrueTrigger.Setters.Add(new Setter(Control.ForegroundProperty, Brushes.White, "subMenuArrow"));
             isMouseOverTrueTrigger.Setters.Add(new Setter(DockPanel.BackgroundProperty, nodeContextMenuBackgroundHighlight, "dockPanel"));
 
-            // Trigger for IsSubmenuOpen property
-            var isSubmenuOpenTrigger = new Trigger
-            {
-                Property = MenuItem.IsSubmenuOpenProperty,
-                Value = true
-            };
-            isSubmenuOpenTrigger.Setters.Add(new Setter(Control.ForegroundProperty, Brushes.White, "subMenuArrow"));
-
             // Trigger for IsMouseOver property (false)
             var isMouseOverFalseTrigger = new Trigger
             {
@@ -2424,7 +2416,6 @@ namespace Dynamo.Controls
             // Add the triggers to the ControlTemplate
             menuItemTemplate.Triggers.Add(isEnabledTrigger);
             menuItemTemplate.Triggers.Add(isMouseOverTrueTrigger);
-            menuItemTemplate.Triggers.Add(isSubmenuOpenTrigger);
             menuItemTemplate.Triggers.Add(isMouseOverFalseTrigger);
             menuItemTemplate.Triggers.Add(dataTrigger);
             menuItemTemplate.Triggers.Add(isCheckedTrigger);

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -507,7 +507,11 @@
                                     </Trigger>
                                     <Trigger Property="IsMouseOver" Value="True">
                                         <Setter TargetName="ContentPresenter" Property="TextBlock.Foreground" Value="White" />
+                                        <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                                         <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource NodeContextMenuBackgroundHighlight}" />
+                                    </Trigger>
+                                    <Trigger Property="IsSubmenuOpen" Value="True">
+                                        <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                                     </Trigger>
                                     <Trigger Property="IsMouseOver" Value="False">
                                         <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource NodeContextMenuBackground}" />


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-9078](https://autodesk.atlassian.net/browse/DYN-9078?atlOrigin=eyJpIjoiZGZjZWQ3NmJlNGEyNGYyOWE3OGE1MGE3NDE0ZDg0ZDEiLCJwIjoiaiJ9).

In node, workspace, and group context menus, items that open a submenu show a small blue > on the right. When you hover those items or open the submenu the arrow stayed blue. 

This PR updates the styling so the arrow turns white in the same situations. It also fixes the same behavior for group context menus, and aligns the group menu chevron vertically without making the rows taller.

<img width="800" height="450" alt="DYN-9078" src="https://github.com/user-attachments/assets/3c692448-378c-498e-bad9-cd028a36f05d" />

<br><br>
Before:  
<img width="424" height="372" alt="Screenshot 2026-05-28 110719" src="https://github.com/user-attachments/assets/5b45d950-5623-4d97-a94b-41fb2928eb0d" />

<br><br>
After:
<img width="422" height="374" alt="Screenshot 2026-05-28 113918" src="https://github.com/user-attachments/assets/d5f4a342-e6dd-4972-9cf9-1c8f342a1bb2" />


### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Context menu items with submenus now show a white chevron when hovered or expanded, matching the menu label. Group context menus are included.

### Reviewers

@DynamoDS/eidos
@jasonstratton 
@zeusongit 

### FYIs

@dnenov 
@johnpierson 
