### PR TITLE
DynamoDS/DYN-10149: As a Dynamo user, I want the home and end keys to navigate to notes as well.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -23,6 +23,7 @@ using Dynamo.Graph.Annotations;
 using Dynamo.Graph.Connectors;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.CustomNodes;
+using Dynamo.Graph.Notes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Interfaces;
 using Dynamo.Logging;
@@ -4521,6 +4522,21 @@ namespace Dynamo.ViewModels
         }
 
         #region "Home And End key press events in Canvas"
+
+        private readonly struct HomeEndCandidate
+        {
+            public HomeEndCandidate(double left, double right, IReadOnlyList<ISelectable> models)
+            {
+                Left = left;
+                Right = right;
+                Models = models;
+            }
+
+            public double Left { get; }
+            public double Right { get; }
+            public IReadOnlyList<ISelectable> Models { get; }
+        }
+
         /// <summary>
         /// Enable the shortcut key events when there is no selection.
         /// </summary>
@@ -4530,23 +4546,68 @@ namespace Dynamo.ViewModels
             return BackgroundPreviewViewModel != null &&
                     !CurrentSpaceViewModel.HasSelection;
         }
-        private void FitCanvasToSelectedNodes(List<NodeViewModel> nodes)
+
+        private IEnumerable<HomeEndCandidate> BuildHomeEndCandidates()
         {
-            var nodeSet = new HashSet<NodeModel>(nodes.Select(nvm => nvm.NodeModel));
-            var groups = CurrentSpaceViewModel.Annotations.Where(a => a.Nodes.Any(n => nodeSet.Contains(n)));
-            nodes.ForEach((ele) => DynamoSelection.Instance.Selection.Add(ele.NodeModel));
-            groups.ToList().ForEach((grp) => DynamoSelection.Instance.Selection.Add(grp.AnnotationModel));
+            var annotations = CurrentSpaceViewModel.Annotations;
+
+            foreach (var nvm in CurrentSpaceViewModel.Nodes)
+            {
+                var node = nvm.NodeModel;
+                var models = new List<ISelectable> { node };
+                foreach (var avm in annotations)
+                {
+                    if (avm.AnnotationModel.ContainsModel(node))
+                    {
+                        models.Add(avm.AnnotationModel);
+                    }
+                }
+                yield return new HomeEndCandidate(nvm.X, nvm.X + nvm.ActualWidth, models);
+            }
+
+            foreach (var noteVM in CurrentSpaceViewModel.Notes)
+            {
+                var noteModel = noteVM.Model;
+                if (annotations.Any(a => a.AnnotationModel.ContainsModel(noteModel)))
+                {
+                    continue;
+                }
+                yield return new HomeEndCandidate(noteVM.Left, noteVM.Left + noteModel.Width, new ISelectable[] { noteModel });
+            }
+
+            foreach (var avm in annotations)
+            {
+                var hasNodes = avm.Nodes.OfType<NodeModel>().Any();
+                var hasNotes = avm.Nodes.OfType<NoteModel>().Any();
+                if (hasNodes || !hasNotes)
+                {
+                    continue;
+                }
+                yield return new HomeEndCandidate(avm.Left, avm.Left + avm.Width, new ISelectable[] { avm.AnnotationModel });
+            }
+        }
+
+        private void FitCanvasToSelectedCandidates(IEnumerable<HomeEndCandidate> candidates)
+        {
+            foreach (var candidate in candidates)
+            {
+                foreach (var model in candidate.Models)
+                {
+                    DynamoSelection.Instance.Selection.Add(model);
+                }
+            }
             FitViewCommand.Execute(true);
             DynamoSelection.Instance.ClearSelection();
         }
+
         internal void GoToLeftMostNode(object parameter)
         {
-            if (CurrentSpaceViewModel.Nodes.Count > 0)
-            {
-                double minX = CurrentSpaceViewModel.Nodes.Min(x => x.X);
-                var nodes = CurrentSpaceViewModel.Nodes.Where(x => x.X <= minX + tolerance).ToList();
-                FitCanvasToSelectedNodes(nodes);
-            }
+            var candidates = BuildHomeEndCandidates().ToList();
+            if (candidates.Count == 0) return;
+
+            double minX = candidates.Min(c => c.Left);
+            var winners = candidates.Where(c => c.Left <= minX + tolerance);
+            FitCanvasToSelectedCandidates(winners);
         }
         internal bool CanGoToLeftMostNode(object obj)
         {
@@ -4554,12 +4615,12 @@ namespace Dynamo.ViewModels
         }
         internal void GoToRightMostNode(object parameter)
         {
-            if (CurrentSpaceViewModel.Nodes.Count > 0)
-            {
-                double maxX = CurrentSpaceViewModel.Nodes.Max(x => x.X + x.ActualWidth);
-                var nodes = CurrentSpaceViewModel.Nodes.Where(x => x.X + x.ActualWidth >= maxX - tolerance).ToList();
-                FitCanvasToSelectedNodes(nodes);         
-            }
+            var candidates = BuildHomeEndCandidates().ToList();
+            if (candidates.Count == 0) return;
+
+            double maxRight = candidates.Max(c => c.Right);
+            var winners = candidates.Where(c => c.Right >= maxRight - tolerance);
+            FitCanvasToSelectedCandidates(winners);
         }
         internal bool CanGoToRightMostNode(object obj)
         {

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -12,9 +13,12 @@ using CoreNodeModels.Input;
 using Dynamo.Configuration;
 using Dynamo.Controls;
 using Dynamo.Extensions;
+using Dynamo.Graph;
+using Dynamo.Graph.Annotations;
 using Dynamo.Graph.Connectors;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
+using Dynamo.Graph.Notes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Linting.Interfaces;
 using Dynamo.Linting.Rules;
@@ -435,6 +439,280 @@ namespace DynamoCoreWpfTests
             // Create number node
             var numNode = new DoubleInput { X = 100, Y = 100 };
             ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(numNode, true);
+        }
+
+        #endregion
+
+        #region Home and End Key Navigation
+
+        private DoubleInput AddNodeAt(double x, double y)
+        {
+            var node = new DoubleInput { X = x, Y = y };
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(node, false);
+            return node;
+        }
+
+        private NoteModel AddNoteAt(double x, double y, double width = 100, double height = 50)
+        {
+            var note = ViewModel.Model.CurrentWorkspace.AddNote(
+                false, x, y, "n", Guid.NewGuid());
+            note.Width = width;
+            note.Height = height;
+            return note;
+        }
+
+        private AnnotationModel GroupAround(params ModelBase[] models)
+        {
+            DynamoSelection.Instance.ClearSelection();
+            foreach (var m in models)
+            {
+                DynamoSelection.Instance.Selection.Add(m);
+            }
+            ViewModel.AddAnnotationCommand.Execute(null);
+            var annotation = ViewModel.Model.CurrentWorkspace.Annotations.Last();
+            DynamoSelection.Instance.ClearSelection();
+            return annotation;
+        }
+
+        private List<ISelectable> CaptureSelectionDuring(Action action)
+        {
+            var captured = new List<ISelectable>();
+            NotifyCollectionChangedEventHandler handler = (s, e) =>
+            {
+                if (e.NewItems == null) return;
+                foreach (ISelectable item in e.NewItems)
+                {
+                    captured.Add(item);
+                }
+            };
+            DynamoSelection.Instance.Selection.CollectionChanged += handler;
+            try
+            {
+                action();
+            }
+            finally
+            {
+                DynamoSelection.Instance.Selection.CollectionChanged -= handler;
+            }
+            return captured;
+        }
+
+        [Test, Apartment(ApartmentState.STA)]
+        [Category("DynamoUI")]
+        public void WhenWorkspaceIsEmpty_HomeAndEndCommands_DoNothing()
+        {
+            // Arrange
+            var workspaceVM = ViewModel.CurrentSpaceViewModel;
+            var initZoom = workspaceVM.Zoom;
+            var initX = workspaceVM.X;
+            var initY = workspaceVM.Y;
+
+            // Act + Assert (does not throw, view unchanged)
+            Assert.DoesNotThrow(() => ViewModel.GoToLeftMostNodeCommand.Execute(null));
+            Assert.DoesNotThrow(() => ViewModel.GoToRightMostNodeCommand.Execute(null));
+
+            Assert.AreEqual(initZoom, workspaceVM.Zoom);
+            Assert.AreEqual(initX, workspaceVM.X);
+            Assert.AreEqual(initY, workspaceVM.Y);
+        }
+
+        [Test, Apartment(ApartmentState.STA)]
+        [Category("DynamoUI")]
+        public void WhenWorkspaceHasOnlyNodes_HomeSelectsLeftmostNodeAndFits()
+        {
+            // Arrange
+            var leftNode = AddNodeAt(100, 100);
+            var rightNode = AddNodeAt(500, 100);
+            var workspaceVM = ViewModel.CurrentSpaceViewModel;
+            var initZoom = workspaceVM.Zoom;
+
+            // Act
+            var selected = CaptureSelectionDuring(
+                () => ViewModel.GoToLeftMostNodeCommand.Execute(null));
+
+            // Assert
+            CollectionAssert.Contains(selected, leftNode);
+            CollectionAssert.DoesNotContain(selected, rightNode);
+            Assert.AreNotEqual(initZoom, workspaceVM.Zoom);
+            Assert.IsEmpty(DynamoSelection.Instance.Selection);
+        }
+
+        [Test, Apartment(ApartmentState.STA)]
+        [Category("DynamoUI")]
+        public void WhenWorkspaceHasOnlyNodes_EndSelectsRightmostNodeAndFits()
+        {
+            // Arrange
+            var leftNode = AddNodeAt(100, 100);
+            var rightNode = AddNodeAt(500, 100);
+            var workspaceVM = ViewModel.CurrentSpaceViewModel;
+            var initZoom = workspaceVM.Zoom;
+
+            // Act
+            var selected = CaptureSelectionDuring(
+                () => ViewModel.GoToRightMostNodeCommand.Execute(null));
+
+            // Assert
+            CollectionAssert.Contains(selected, rightNode);
+            CollectionAssert.DoesNotContain(selected, leftNode);
+            Assert.AreNotEqual(initZoom, workspaceVM.Zoom);
+            Assert.IsEmpty(DynamoSelection.Instance.Selection);
+        }
+
+        [Test, Apartment(ApartmentState.STA)]
+        [Category("DynamoUI")]
+        public void WhenWorkspaceContainsOrphanedNoteLeftOfNodes_HomeTargetsTheNote()
+        {
+            // Arrange
+            var node = AddNodeAt(500, 100);
+            var orphanNote = AddNoteAt(50, 100);
+
+            // Act
+            var selected = CaptureSelectionDuring(
+                () => ViewModel.GoToLeftMostNodeCommand.Execute(null));
+
+            // Assert
+            CollectionAssert.Contains(selected, orphanNote);
+            CollectionAssert.DoesNotContain(selected, node);
+        }
+
+        [Test, Apartment(ApartmentState.STA)]
+        [Category("DynamoUI")]
+        public void WhenWorkspaceContainsOrphanedNoteRightOfNodes_EndTargetsTheNote()
+        {
+            // Arrange
+            var node = AddNodeAt(50, 100);
+            var orphanNote = AddNoteAt(1000, 100);
+
+            // Act
+            var selected = CaptureSelectionDuring(
+                () => ViewModel.GoToRightMostNodeCommand.Execute(null));
+
+            // Assert
+            CollectionAssert.Contains(selected, orphanNote);
+            CollectionAssert.DoesNotContain(selected, node);
+        }
+
+        [Test, Apartment(ApartmentState.STA)]
+        [Category("DynamoUI")]
+        public void WhenWorkspaceContainsNoteInsideNodeContainingGroup_HomeIgnoresTheNote()
+        {
+            // Arrange: a group containing both a node and a note where note.X < node.X.
+            // The note rides along with its parent group via the node-candidate path;
+            // it should not contribute its own (smaller) X to the leftmost ranking.
+            var node = AddNodeAt(500, 100);
+            var noteInsideGroup = AddNoteAt(50, 100);
+            var group = GroupAround(node, noteInsideGroup);
+
+            // Act
+            var selected = CaptureSelectionDuring(
+                () => ViewModel.GoToLeftMostNodeCommand.Execute(null));
+
+            // Assert: the note is not the target. The group accompanies the node.
+            CollectionAssert.Contains(selected, node);
+            CollectionAssert.Contains(selected, group);
+            CollectionAssert.DoesNotContain(selected, noteInsideGroup);
+        }
+
+        [Test, Apartment(ApartmentState.STA)]
+        [Category("DynamoUI")]
+        public void WhenLeftmostItemIsNotesOnlyGroup_HomeTargetsTheGroup()
+        {
+            // Arrange
+            var node = AddNodeAt(800, 100);
+            var noteA = AddNoteAt(50, 100);
+            var noteB = AddNoteAt(120, 200);
+            var notesOnlyGroup = GroupAround(noteA, noteB);
+
+            // Act
+            var selected = CaptureSelectionDuring(
+                () => ViewModel.GoToLeftMostNodeCommand.Execute(null));
+
+            // Assert: the notes-only group is the leftmost candidate.
+            CollectionAssert.Contains(selected, notesOnlyGroup);
+            CollectionAssert.DoesNotContain(selected, node);
+        }
+
+        [Test, Apartment(ApartmentState.STA)]
+        [Category("DynamoUI")]
+        public void WhenRightmostItemIsNotesOnlyGroup_EndTargetsTheGroup()
+        {
+            // Arrange
+            var node = AddNodeAt(50, 100);
+            var noteA = AddNoteAt(800, 100);
+            var noteB = AddNoteAt(900, 200);
+            var notesOnlyGroup = GroupAround(noteA, noteB);
+
+            // Act
+            var selected = CaptureSelectionDuring(
+                () => ViewModel.GoToRightMostNodeCommand.Execute(null));
+
+            // Assert
+            CollectionAssert.Contains(selected, notesOnlyGroup);
+            CollectionAssert.DoesNotContain(selected, node);
+        }
+
+        [Test, Apartment(ApartmentState.STA)]
+        [Category("DynamoUI")]
+        public void WhenWorkspaceHasOnlyNotes_HomeAndEndStillNavigate()
+        {
+            // Arrange
+            var leftNote = AddNoteAt(50, 100);
+            var rightNote = AddNoteAt(800, 100);
+            var workspaceVM = ViewModel.CurrentSpaceViewModel;
+            var initZoom = workspaceVM.Zoom;
+
+            // Act + Assert: Home targets the left note
+            var leftSelected = CaptureSelectionDuring(
+                () => ViewModel.GoToLeftMostNodeCommand.Execute(null));
+            CollectionAssert.Contains(leftSelected, leftNote);
+            CollectionAssert.DoesNotContain(leftSelected, rightNote);
+            Assert.AreNotEqual(initZoom, workspaceVM.Zoom);
+
+            // Act + Assert: End targets the right note
+            var rightSelected = CaptureSelectionDuring(
+                () => ViewModel.GoToRightMostNodeCommand.Execute(null));
+            CollectionAssert.Contains(rightSelected, rightNote);
+            CollectionAssert.DoesNotContain(rightSelected, leftNote);
+        }
+
+        [Test, Apartment(ApartmentState.STA)]
+        [Category("DynamoUI")]
+        public void WhenSelectionContainsNode_CanGoToLeftMostNodeReturnsFalse()
+        {
+            var node = AddNodeAt(100, 100);
+            DynamoSelection.Instance.Selection.Add(node);
+
+            Assert.IsFalse(ViewModel.GoToLeftMostNodeCommand.CanExecute(null));
+            Assert.IsFalse(ViewModel.GoToRightMostNodeCommand.CanExecute(null));
+
+            DynamoSelection.Instance.ClearSelection();
+        }
+
+        [Test, Apartment(ApartmentState.STA)]
+        [Category("DynamoUI")]
+        public void WhenSelectionContainsNote_CanGoToLeftMostNodeReturnsFalse()
+        {
+            var note = AddNoteAt(100, 100);
+            DynamoSelection.Instance.Selection.Add(note);
+
+            Assert.IsFalse(ViewModel.GoToLeftMostNodeCommand.CanExecute(null));
+            Assert.IsFalse(ViewModel.GoToRightMostNodeCommand.CanExecute(null));
+
+            DynamoSelection.Instance.ClearSelection();
+        }
+
+        [Test, Apartment(ApartmentState.STA)]
+        [Category("DynamoUI")]
+        public void WhenSelectionContainsAnnotation_CanGoToLeftMostNodeReturnsFalse()
+        {
+            var node = AddNodeAt(100, 100);
+            var group = GroupAround(node);
+            DynamoSelection.Instance.Selection.Add(group);
+
+            Assert.IsFalse(ViewModel.GoToLeftMostNodeCommand.CanExecute(null));
+            Assert.IsFalse(ViewModel.GoToRightMostNodeCommand.CanExecute(null));
+
+            DynamoSelection.Instance.ClearSelection();
         }
 
         #endregion


### PR DESCRIPTION
Closes https://autodesk.atlassian.net/browse/DYN-10149

h1. Extend Home/End Navigation to Notes — Implementation Plan

h2. Overview

Extend the existing {{Home}}/{{End}} keyboard shortcuts (DYN-9637) so that, in addition to leftmost/rightmost *nodes*, they also navigate to *orphaned notes* and to *notes-only groups*. The change is localized to the {{"Home And End key press events in Canvas"}} region in {{DynamoViewModel.cs}}, plus new tests in {{CoreUITests.cs}}. No public API, XAML, or resource changes are required.

h2. Current State Analysis

h3. Key Discoveries

* Existing logic only iterates {{CurrentSpaceViewModel.Nodes}} — {{DynamoViewModel.cs:4542-4567}}.
* The selection model accepts {{NodeModel}}, {{NoteModel}}, and {{AnnotationModel}} interchangeably (all {{ISelectable}} via {{ModelBase}}), so the extension is purely about which items go into {{DynamoSelection.Instance.Selection}} before {{FitViewCommand.Execute(true)}} runs.
* {{tolerance = 2}} constant at {{DynamoViewModel.cs:79-80}} is reusable.
* {{NoteViewModel}} has {{Left}}/{{Top}} but no {{Width}} — use {{noteVM.Model.Width}} for the right-edge calculation.
* {{AnnotationViewModel}} already has {{Left}}/{{Width}} for bounding-box math, suitable for notes-only group ranking.
* Orphan check: {{!CurrentSpaceViewModel.Annotations.Any(a => a.AnnotationModel.ContainsModel(noteModel))}} (uses {{AnnotationModelExtensions.ContainsModel}}).
* Notes-only group check: {{!annotationVM.Nodes.OfType<NodeModel>().Any() && annotationVM.Nodes.OfType<NoteModel>().Any()}}.
* *Zero existing test coverage* for {{GoToLeftMostNodeCommand}} / {{GoToRightMostNodeCommand}} — verified via grep across {{test/}}.

h2. Desired End State

* Pressing {{Home}} selects the leftmost workspace item — be it a node, an orphaned note, or a notes-only group — plus any group containing a winning node, and fits the view to that selection. Selection is cleared afterward.
* Pressing {{End}} does the symmetric operation on the rightmost item, using right edge ({{X + Width}}).
* Notes that live inside a group also containing nodes still ride along with their parent group (the existing path); they do *not* contribute to leftmost/rightmost ranking on their own.
* A workspace with only notes still responds to {{Home}}/{{End}}.
* {{IsHomeAndEndKeyEnabled}} continues to disable both shortcuts when anything is selected.
* New NUnit tests pass and explicitly cover both legacy and new behavior.

*Verification*: Run {{dotnet test test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj --filter "Name~GoToLeftMost|Name~GoToRightMost"}} — all new tests pass; manual smoke test in Dynamo Sandbox with a graph that has nodes, orphaned notes, and notes-only groups confirms the camera centers on the expected element.

h2. What We're NOT Doing

* Renaming {{GoToLeftMostNode}} / {{GoToRightMostNode}} (and their {{Command}} properties) to {{GoToLeftMostElement}} / {{GoToRightMostElement}}. They are listed in {{PublicAPI.Unshipped.txt}} so a rename is technically free, but the ticket does not request it and a rename would touch unrelated files. Defer.
* Including notes that live inside a mixed (node + note) group in the leftmost/rightmost ranking. The ticket scope is {{notes in groups alone}} and {{orphaned notes}}; pinned-label notes are intentionally excluded so the camera does not jump off the node they label.
* Adding any new public API.
* Changing keybindings, key gestures, or XAML.
* Splitting {{GoToLeftMostNodeCommand}} / {{GoToRightMostNodeCommand}} into separate node and note commands. One command per direction, smarter target selection.
* Backward-compatibility shims or feature flags. The behavior change is purely additive and the methods are {{internal}}.

h2. Implementation Approach

Refactor {{FitCanvasToSelectedNodes}} into a shape that accepts a heterogeneous candidate list (each candidate knows its left edge, right edge, and which {{ISelectable}}s to add — possibly including a containing group). {{GoToLeftMostNode}} / {{GoToRightMostNode}} build that list from three sources (nodes, orphaned notes, notes-only groups), pick the winners by {{X}} or {{X + Width}} within {{tolerance}}, and delegate selection + {{FitView}} to the shared helper. Relax the guard from {{Nodes.Count > 0}} to "candidate list is non-empty".

The simplest concrete shape: introduce a private nested struct/record (e.g. {{HomeEndCandidate}}) capturing {{Left}}, {{Right}}, and an {{IEnumerable<ISelectable> Selection}}. This stays internal, requires no allocations beyond the existing per-call ones, and keeps the diff readable.

----

h3. TASK 1: Extend Home/End logic in {{DynamoViewModel}} [HIGH PRIORITY]

*Status:* DONE
*Milestone:* {{Home}}/{{End}} shortcuts in a running sandbox correctly target orphaned notes and notes-only groups in addition to nodes; no regression in existing node-only behavior.

* [x] In {{DynamoViewModel.cs}} inside the {{"Home And End key press events in Canvas"}} region, introduce a private nested type {{HomeEndCandidate}} with fields {{double Left}}, {{double Right}}, {{IReadOnlyList<ISelectable> Models}} (the items to add to {{DynamoSelection}}).
* [x] Add a private helper {{IEnumerable<HomeEndCandidate> BuildHomeEndCandidates()}} that yields:
** One candidate per {{NodeViewModel}} in {{CurrentSpaceViewModel.Nodes}}: {{Left = nvm.X}}, {{Right = nvm.X + nvm.ActualWidth}}, {{Models = [nvm.NodeModel, ...any AnnotationModel that contains nvm.NodeModel]}}.
** One candidate per *orphaned* {{NoteViewModel}} (where no {{AnnotationModel}} in the workspace contains its {{Model}}): {{Left = noteVM.Model.X}}, {{Right = noteVM.Model.X + noteVM.Model.Width}}, {{Models = [noteVM.Model]}}.
** One candidate per *notes-only* {{AnnotationViewModel}} (where {{.Nodes.OfType<NodeModel>().Any() == false}} AND {{.Nodes.OfType<NoteModel>().Any()}}): {{Left = avm.Left}}, {{Right = avm.Left + avm.Width}}, {{Models = [avm.AnnotationModel]}}.
* [x] Replace {{FitCanvasToSelectedNodes(List<NodeViewModel>)}} with {{FitCanvasToSelectedCandidates(IEnumerable<HomeEndCandidate>)}}: union all {{Models}} from the candidates into {{DynamoSelection.Instance.Selection}}, invoke {{FitViewCommand.Execute(true)}}, then {{ClearSelection()}}.
* [x] Update {{GoToLeftMostNode}} to: build candidates → if empty, return → compute {{minX = candidates.Min(c => c.Left)}} → take candidates within {{tolerance}} ({{c.Left <= minX + tolerance}}) → call {{FitCanvasToSelectedCandidates}}.
* [x] Update {{GoToRightMostNode}} symmetrically using {{c.Right}} and {{maxRight - tolerance}}.
* [x] Leave {{IsHomeAndEndKeyEnabled}}, {{CanGoToLeftMostNode}}, {{CanGoToRightMostNode}} unchanged — the {{!HasSelection}} gate already accounts for notes and groups.
* [x] Confirm via build that no other caller of the now-renamed {{FitCanvasToSelectedNodes}} exists ({{grep}} should show zero hits — it is private).

*Validation:*

* {{dotnet restore src/DynamoCore.sln --runtime=win-x64 -p:Configuration=Release -p:DotNet=net10.0 && msbuild src/DynamoCore.sln /p:Configuration=Release}} succeeds.
* {{msbuild src/Dynamo.All.sln /p:Configuration=Release}} succeeds.
* No new entries in {{PublicAPI.Unshipped.txt}}.

*Requirements from spec:*

* {{Home}} and {{End}} work with notes in groups alone.
* {{Home}} and {{End}} work with orphaned notes.
* DYN-9637 behavior preserved for nodes and node-containing groups.

*Files to Modify:*

* {{src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs}} — replace the region body at lines 4523-4568 with the candidate-based implementation.

*Implementation Details:*

* Use {{using Dynamo.Graph.Annotations;}} to bring in {{AnnotationModelExtensions.ContainsModel}} (file: {{src/DynamoCore/Graph/Annotations/AnnotationModelExtensions.cs}}). The {{using}} is almost certainly already present; verify before adding.
* Candidate construction order does not matter — we re-rank by {{Left}} / {{Right}} anyway.
* Be careful with the {{nodes-only}} containing-group lookup: a node candidate's {{Models}} collection may include zero, one, or several {{AnnotationModel}}s (a node can in theory be in one group; nested groups carry their own membership). Mirror the existing line {{CurrentSpaceViewModel.Annotations.Where(a => a.Nodes.Any(n => nodeSet.Contains(n)))}} semantics — but per-candidate rather than per-batch.
* Do not change the {{private readonly int tolerance = 2;}} constant.

----

h3. TASK 2: Add NUnit coverage for legacy and new behavior [HIGH PRIORITY]

*Status:* DONE
*Milestone:* All Home/End behavior is exercised by automated tests; future regressions are caught locally and in CI.

* [x] Open {{test/DynamoCoreWpfTests/CoreUITests.cs}}. Add a new {{#region Home and End Key Navigation}} after the existing {{#region Fit to View}} (line 287). Tests use the same {{[Test, Apartment(ApartmentState.STA)]}} + {{[Category("DynamoUI")]}} attributes already established in the file.
* [x] Test 1 — {{WhenWorkspaceIsEmpty_HomeAndEndCommands_DoNothing}}: Empty {{CurrentSpaceViewModel}}. Capture {{Zoom}}/{{X}}/{{Y}}, invoke both commands, assert unchanged.
* [x] Test 2 — {{WhenWorkspaceHasOnlyNodes_HomeSelectsLeftmostNodeAndFits}}: Place two {{CodeBlockNodeModel}}s at distinct X coordinates, invoke {{GoToLeftMostNodeCommand.Execute(null)}}, assert {{FitView}} ran (zoom/position changed in a way consistent with the leftmost node's bounds).
* [x] Test 3 — {{WhenWorkspaceHasOnlyNodes_EndSelectsRightmostNodeAndFits}}: Symmetric of Test 2 using {{GoToRightMostNodeCommand}}.
* [x] Test 4 — {{WhenWorkspaceContainsOrphanedNoteLeftOfNodes_HomeTargetsTheNote}}: One node and one orphaned {{NoteModel}} placed further left than the node. Invoke {{GoToLeftMostNodeCommand}}, assert the view fits to the note's bounds.
* [x] Test 5 — {{WhenWorkspaceContainsNoteInsideNodeContainingGroup_HomeIgnoresTheNote}}: A group with one node and one note; the note's {{X}} is smaller than the node's {{X}} but the group's overall {{X}} matches the node. Confirm the camera lands on the group/node, not the note.
* [x] Test 6 — {{WhenLeftmostItemIsNotesOnlyGroup_HomeTargetsTheGroup}}: Place a group whose contents are exclusively notes to the left of any node, invoke {{GoToLeftMostNodeCommand}}, assert the view fits to the group's bounds.
* [x] Test 7 — {{WhenWorkspaceHasOnlyNotes_HomeAndEndStillNavigate}}: No nodes at all, only orphaned notes. Assert both commands fit the view (i.e. the relaxed guard works).
* [x] Test 8 — {{WhenSelectionIsNonEmpty_CanGoToLeftMostNodeReturnsFalse}}: Select a {{NoteModel}}, assert {{CanGoToLeftMostNode(null)}} returns {{false}}. Repeat for {{NodeModel}} and {{AnnotationModel}}. Confirms {{IsHomeAndEndKeyEnabled}} gate covers notes/groups.
* [x] Test 9 (End equivalents): Add the matching {{End}}-direction tests for Tests 4, 6, 7 to keep coverage symmetric.
* [x] All tests must follow {{WhenConditionThenExpectedBehavior}} naming and use Arrange-Act-Assert. One behavior per test.

*Validation:*

* {{dotnet test test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj --filter "Name~HomeAndEnd|Name~GoToLeftMost|Name~GoToRightMost"}} — all new tests pass; no existing tests regress.
* {{dotnet test test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj --filter "Category=DynamoUI"}} for full UI category sanity check.

*Requirements from spec:*

* Coverage for orphaned notes and notes-only groups (new behavior).
* Coverage retroactively added for DYN-9637 node-only behavior.
* Gate test confirms {{IsHomeAndEndKeyEnabled}} rejects every selectable type.

*Files to Modify:*

* {{test/DynamoCoreWpfTests/CoreUITests.cs}} — add the new {{#region Home and End Key Navigation}} block with the tests above.

*Implementation Details:*

* For asserting "the view moved to roughly here", reuse the pattern in {{FitViewWithNoNodes}}/{{CanFitView}} (line 289+): capture {{workspaceVM.Zoom}}/{{X}}/{{Y}} before, compare after. Where exact coordinates are unstable across screen DPI, assert directionality (e.g. {{Assert.AreNotEqual(initZoom, workspaceVM.Zoom)}} plus a check that the resulting visible rectangle contains the target item's bounds).
* Create notes via the existing {{WorkspaceModel.AddNote(...)}} / {{DynamoModel.ExecuteCommand(new DynamoModel.CreateNoteCommand(...))}} flow — search {{CoreUITests.cs}} or {{WorkspaceTests.cs}} for an existing example before inventing a new helper.
* Create groups via {{DynamoModel.AddAnnotation(...)}} after selecting the target models. The pattern is established in {{AnnotationModelTests}} in the core test project; replicate the smallest possible setup here.
* Always {{DynamoSelection.Instance.ClearSelection()}} in test teardown / after assertions to avoid bleed between tests in the same fixture.

----

h2. Testing Strategy

h3. Unit Tests

* New tests in {{test/DynamoCoreWpfTests/CoreUITests.cs}} (see TASK 2). Exercise all branches of {{BuildHomeEndCandidates}} (node, orphan note, notes-only group) and both {{Home}} and {{End}} directions.
* Verify the {{IsHomeAndEndKeyEnabled}} gate disables both shortcuts when any of {{NodeModel}}, {{NoteModel}}, or {{AnnotationModel}} is selected.
* Empty-workspace, notes-only-workspace, nodes-only-workspace, and mixed-workspace permutations.

h3. Integration Tests

* Run {{dotnet test src/DynamoCore.sln}} to confirm no regressions in core graph logic from the candidate-set refactor.
* Run {{dotnet test test/DynamoCoreWpfTests}} to confirm UI tests pass end-to-end.

h3. Manual Testing Steps

# Launch {{DynamoSandbox}} ({{msbuild src/Dynamo.All.sln /p:Configuration=Release}} then run the sandbox exe).
# Open an empty graph. Press {{Home}}, then {{End}} — view should not change, no exception.
# Add one node, three orphaned notes (one to the far left, one to the far right, one centered). Press {{Home}} — view fits to the leftmost note. Press {{End}} — view fits to the rightmost note.
# Add a group containing only two notes, place it to the left of all nodes. Press {{Home}} — view fits to that group.
# Add a group containing one node and one note where the note's X < the node's X but the group's overall bounding box matches the node. Press {{Home}} — view fits to the group/node, not the note.
# Select any item (node, note, or group) and press {{Home}}/{{End}} — the camera should not move (gate disables the shortcut).
# Verify symmetry: repeat steps 3-6 with {{End}} in place of {{Home}}.

h2. Performance Considerations

* {{BuildHomeEndCandidates}} is O(N) in workspace items per keypress. {{Home}}/{{End}} are user-driven events at human cadence (not redrawn per frame), so the additional traversal of {{Notes}} and {{Annotations}} adds no measurable cost even for large graphs (≤ thousands of items). The existing {{Nodes}} traversal already runs on every press.
* The orphan check costs O(notes × annotations) in the worst case. For pathological graphs this is still well under millisecond-scale and runs only on keypress; no optimization needed. If profiling later shows this on a hot path, precompute a {{HashSet<NoteModel>}} of group-contained notes once per call and use it as the orphan filter.

h2. Migration Notes

None. The change is purely additive: existing behavior for nodes is preserved exactly, and no persisted state, file format, or public API surface is affected. No upgrade path needed for existing graphs.
