### PR TITLE
DynamoDS/DYN-10451: GLOB: LocRes integration: Dynamo TuneUp localized satellites not integrated in Revit - Translations not displaying

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2202,12 +2202,33 @@
   </ItemGroup>
  <Target Name="AfterBuildOps" AfterTargets="Build">
     <ItemGroup>
-      <ExternTuneUpPkg Include="$(SolutionDir)..\extern\TuneUp\**\*.*" />
 	  <DistribSamples Include="$(SolutionDir)..\extern\doc\distrib\Samples\**\*.*" />
     </ItemGroup>
     <MakeDir Directories="$(OutputPath)\viewExtensions\" />
-    <Copy SourceFiles="@(ExternTuneUpPkg)" DestinationFolder="$(OutputPath)\Built-In Packages\packages\TuneUp\%(RecursiveDir)" />
 	<Copy SourceFiles="@(DistribSamples)" DestinationFolder="$(OutputPath)\Samples" SkipUnchangedFiles="True" />
+  </Target>
+  <!--
+    Copies the pre-built TuneUp built-in package (binaries + 14 localized satellite
+    assemblies) from extern/TuneUp into the Dynamo build output. Pre-built satellites
+    arrive from DynamoDS/TuneUp via extern/TuneUp; .NET satellite probing requires
+    bin/<culture>/<name>.resources.dll beside TuneUp.dll, so the copy must preserve
+    the per-culture subdirectory layout. Downstream installer packaging (Sandbox,
+    DynamoRevit/RCPDYN) must likewise recurse into these subdirectories or localized
+    strings will silently disappear at runtime. The post-copy <Error> tasks assert
+    all 14 satellites landed in the output and fail the build if any are missing,
+    so a regression in extern/TuneUp, .gitignore, or the copy glob is caught at PR
+    time rather than at Revit-install time. See DYN-10451.
+  -->
+  <Target Name="CopyTuneUpBuiltInPackage" AfterTargets="Build">
+    <PropertyGroup>
+      <TuneUpCultures>cs-CZ;de-DE;en-GB;en-US;es-ES;fr-FR;it-IT;ja-JP;ko-KR;pl-PL;pt-BR;ru-RU;zh-CN;zh-TW</TuneUpCultures>
+    </PropertyGroup>
+    <ItemGroup>
+      <ExternTuneUpPkg Include="$(SolutionDir)..\extern\TuneUp\**\*.*" />
+      <ExpectedTuneUpSatellite Include="$(TuneUpCultures)" />
+    </ItemGroup>
+    <Copy SourceFiles="@(ExternTuneUpPkg)" DestinationFolder="$(OutputPath)\Built-In Packages\packages\TuneUp\%(RecursiveDir)" SkipUnchangedFiles="True" />
+    <Error Condition="!Exists('$(OutputPath)Built-In Packages\packages\TuneUp\bin\%(ExpectedTuneUpSatellite.Identity)\TuneUp.resources.dll')" Text="TuneUp satellite for culture '%(ExpectedTuneUpSatellite.Identity)' missing from build output. See DYN-10451." />
   </Target>
   <Target Name="CopyPMWizardHtmlFiles" AfterTargets="Build">
     <ItemGroup>


### PR DESCRIPTION
Closes https://autodesk.atlassian.net/browse/DYN-10451

h1. Integrate TuneUp Localized Satellites — Implementation Plan

h2. Overview

TuneUp's 14 localized satellite assemblies ({{cs-CZ}}, {{de-DE}}, …, {{zh-TW}}) ship in {{extern/TuneUp/bin/<culture>/TuneUp.resources.dll}} and an MSBuild target in {{DynamoCoreWpf.csproj}} already copies them into the Dynamo build output. The root cause of the bug is downstream (DynamoRevit/RCPDYN packaging dropping subdirectories) — not in this repo. The plan therefore:

# *In this repo:* Harden the existing copy target so the satellite delivery is explicit, verifiable, and a regression becomes a build failure rather than a silent installer drop.
# *Across repos:* File and drive a coordinated DynamoRevit fix so its packaging step recurses into the culture subdirectories.
# *End-to-end:* Verify on a localized (Czech) Revit install that {{Show TuneUp}} renders as {{Zobrazit TuneUp}}.

h2. Current State Analysis

h3. Key Discoveries

* The 14 satellite DLLs are committed and tracked in {{extern/TuneUp/bin/<culture>/TuneUp.resources.dll}} (DYN-8378, {{b85ca993c4}}). Verified on disk: real PE32 .NET assemblies, not LFS pointers.
* {{src/DynamoCoreWpf/DynamoCoreWpf.csproj:2203-2211}} {{AfterBuildOps}} already copies the entire {{extern/TuneUp}} tree to {{$(OutputPath)\Built-In Packages\packages\TuneUp\}} with {{%(RecursiveDir)}} preserved — so the satellites are in the Dynamo build output.
* The runtime contract is {{src/DynamoCore/Configuration/PathManager.cs:154-180}} — {{Built-In Packages\Packages\TuneUp\bin\<culture>\TuneUp.resources.dll}}, located via .NET's standard satellite probing once {{TuneUp.dll}} is loaded.
* No file in this repo enumerates the downstream Revit-installer layout (the only WiX/Inno installer here targets standalone Sandbox); the Revit install is built by the separate {{DynamoDS/DynamoRevit}} repo and Autodesk's RCPDYN packaging pipeline.
* TuneUp arrives pre-signed (DYN-7832, {{2faabb6ce5}}); signing is not the gate, so {{tools/install/Extra/additional-files-to-sign.txt}} does not need changes.
* {{.github/scripts/check_file_version.ps1:68-69}} excludes {{TuneUp.dll}} and {{TuneUp.resources.dll}} from version check; no change needed there either.
* The recent precedent DYN-10440 ({{398369c09a}}) handled the opposite problem (analyzer satellites _leaking in_) — it does not provide a fix template for _delivering_ satellites; that path already works in this repo.

h2. Desired End State

* Building {{Dynamo.All.sln}} produces, in {{$(OutputPath)\Built-In Packages\packages\TuneUp\bin\<culture>\TuneUp.resources.dll}}, all 14 culture-specific satellite assemblies. Today: this already happens. After this work: a build-time check fails fast if any of the 14 satellites is missing, so a regression in the source drop, the gitignore, or the copy glob is caught at PR time rather than at Revit-install time.
* The downstream DynamoRevit packaging step recurses into culture subdirectories so the satellites land in {{...\AddIns\DynamoForRevit\Built-In packages\packages\TuneUp\bin\<culture>\TuneUp.resources.dll}} in the installed Revit build.
* In a localized Czech Revit (Build ≥ Ship_5_0_20260429), opening Dynamo → Extensions menu → {{Zobrazit TuneUp}} (not {{Show TuneUp}}) renders, and clicking it opens TuneUp with all of its UI strings translated.

h3. Verification

# Local PowerShell after {{msbuild src/Dynamo.All.sln /p:Configuration=Release}}:
{noformat}$cultures = 'cs-CZ','de-DE','en-GB','en-US','es-ES','fr-FR','it-IT','ja-JP','ko-KR','pl-PL','pt-BR','ru-RU','zh-CN','zh-TW'
$root = 'bin\AnyCPU\Release\Built-In Packages\packages\TuneUp\bin'
$missing = $cultures | Where-Object { -not (Test-Path "$root\$_\TuneUp.resources.dll") }
if ($missing) { throw "Missing TuneUp satellites: $($missing -join ', ')" } else { 'All 14 satellites present.' }{noformat}
Expected: {{All 14 satellites present.}}
# Same script run against the next localized-Revit storeroom build's RCPDYN.adix-mounted directory: expected to confirm satellites under {{Built-In packages\packages\TuneUp\bin\<culture>\}}. If still missing after DynamoRevit/RCPDYN fix lands, escalate.
# Manual verification on a Czech Revit install — Extensions menu shows {{Zobrazit TuneUp}}.

h2. What We're NOT Doing

* Not changing {{src/DynamoCore/Configuration/PathManager.cs}} or any Dynamo Core/CoreWpf source code. The runtime loader and .NET satellite probing already work; the bug is purely a packaging/delivery gap.
* Not modifying {{extern/TuneUp/}} contents. The satellites are correct as committed; the upstream {{DynamoDS/TuneUp}} pipeline owns them.
* Not adding TuneUp entries to {{tools/install/Extra/additional-files-to-sign.txt}}. TuneUp binaries arrive pre-signed; that file gates Dynamo's own signing pass, not the downstream Revit packaging.
* Not modifying the standalone Sandbox installer ({{tools/install/DynamoInstaller.iss}}, {{src/DynamoInstall/*.wxs}}). The reported bug is Revit-specific; the Sandbox path is unrelated.
* Not adding new public API surface; nothing in {{PublicAPI.Unshipped.txt}} changes.
* Not adding {{[NodeName]}}/{{[NodeCategory]}} or new view extensions; this is purely packaging work.
* Not introducing a NuGet PackageReference for TuneUp. The repo's existing model is the committed {{extern/TuneUp/}} drop, and changing it is out of scope for a bug fix.

h2. Implementation Approach

Minimal-blast-radius, defense-in-depth, in two repos:

* *In this repo:* Refactor the existing {{AfterBuildOps}} target so the TuneUp copy is its own named target with {{SkipUnchangedFiles="True"}} and add a follow-up {{Error}} task that asserts the 14 satellites exist after the copy. The behavior of the copy is unchanged; only the surface and the post-condition change.
* *In DynamoRevit:* File a coordinated ticket. The actual recursive-copy fix likely belongs in DynamoRevit's packaging logic (or Autodesk's RCPDYN packaging configuration) — outside this repo's reach.
* *Documentation:* A short paragraph in {{doc/integration_docs/4_builtinpackages.md}} clarifying that built-in-package satellites are delivered as {{package\bin\<culture>\*.resources.dll}} and that downstream installer packaging must recurse — for the next engineer who touches this area.

----

h3. TASK 1: Make the TuneUp satellite delivery explicit and verifiable in {{DynamoCoreWpf.csproj}} [HIGH PRIORITY]

*Status:* DONE
*Milestone:* Any future PR that breaks the satellite copy (gitignore change, glob change, accidental removal of a satellite from {{extern/TuneUp/bin/}}) fails the build on the {{Build DynamoAll.sln}} GitHub Actions check, instead of silently shipping a missing-translations Revit installer.

* [x] Split the TuneUp copy out of the catch-all {{AfterBuildOps}} target into a new MSBuild target {{CopyTuneUpBuiltInPackage}}, still wired {{AfterTargets="Build"}}. The {{DistribSamples}} copy and the {{viewExtensions\}} {{MakeDir}} stay in {{AfterBuildOps}}.
* [x] On the new TuneUp {{Copy}} task, set {{SkipUnchangedFiles="True"}} (parity with the adjacent {{DistribSamples}} copy at line 2210; reduces no-op incremental rebuild churn).
* [x] Add an {{<ItemGroup>}} enumerating the expected 14 satellite output paths via a {{Cultures}} property list ({{cs-CZ;de-DE;en-GB;en-US;es-ES;fr-FR;it-IT;ja-JP;ko-KR;pl-PL;pt-BR;ru-RU;zh-CN;zh-TW}}), and an {{<Error>}} task that fires if any expected satellite is missing after the copy: {{Condition="!Exists('$(OutputPath)Built-In Packages\packages\TuneUp\bin\%(ExpectedTuneUpSatellite.Identity)\TuneUp.resources.dll')" Text="TuneUp satellite for culture '%(ExpectedTuneUpSatellite.Identity)' missing from build output. See DYN-10451."}}.
* [x] Add one XML comment above the new target explaining the contract ("Pre-built satellites arrive from DynamoDS/TuneUp via extern/TuneUp; .NET satellite probing requires bin/<culture>/<name>.resources.dll beside TuneUp.dll; the downstream Revit installer must recurse into these subdirectories").

*Validation:*

* Local: {{msbuild src\Dynamo.All.sln /p:Configuration=Release}} succeeds. The PowerShell snippet from "Desired End State / Verification" prints {{All 14 satellites present.}}.
* Negative test (manual, do not commit): temporarily rename {{extern\TuneUp\bin\cs-CZ}} and rebuild — the build must fail with the {{<Error>}} message naming {{cs-CZ}}. Restore the directory.
* CI: the {{Build DynamoAll.sln}} workflow at {{.github/workflows/build_dynamo_all.yml}} passes on the PR.

*Requirements from spec:*

* Localized satellites must be integrated in the Revit installer (originating point: build output must reliably contain them).
* The 14-culture set must include cs-CZ specifically, since that is the reported case in this ticket.

*Files to Create:*

* (none)

*Files to Modify:*

* {{src/DynamoCoreWpf/DynamoCoreWpf.csproj}} (around lines 2203-2211) — split out the new target, add explicit enumeration + {{<Error>}} assertion + {{SkipUnchangedFiles}}.

*Implementation Details:*

* Keep the existing item {{ExternTuneUpPkg Include="$(SolutionDir)..\extern\TuneUp\**\*.*"}} and the {{%(RecursiveDir)}} destination — the copy logic itself is correct, only the surrounding affordances change.
* Use an {{<ItemGroup>}} {{ExpectedTuneUpSatellite}} populated from a semicolon-delimited property to avoid repeating culture codes 14 times.
* {{<Error>}} (not {{<Warning>}}) so the GitHub Actions {{Build DynamoAll.sln}} check at {{.github/workflows/build_dynamo_all.yml:31}} fails on regression.
* Confirm {{extern/.gitignore:5-6}} ({{!TuneUp/bin}}) keeps the satellites tracked — no change needed; just don't break it in this PR.

----

h3. TASK 2: File a DynamoRevit / RCPDYN ticket so the Revit installer recurses into culture subdirectories [HIGH PRIORITY]

*Status:* NOT STARTED
*Milestone:* A separate Jira ticket exists against DynamoDS/DynamoRevit (or the Autodesk RCPDYN packaging pipeline owner) requesting that the step which copies {{Built-In Packages\packages\TuneUp\bin\*.dll}} into the Revit install layout recurse into all subdirectories (i.e., switch any non-recursive {{Copy}} / {{xcopy}} / {{robocopy}} glob to one that picks up {{<culture>\*.resources.dll}}).

* [ ] Create a new Jira issue in the DYN project linked to DYN-10451 as {{is blocked by}} (or vice-versa depending on team convention), titled along the lines of: "DynamoRevit: recurse into culture subdirectories when packaging Built-In Packages\TuneUp into the Revit installer (blocks DYN-10451)".
* [ ] In the description, link to: (a) this ticket DYN-10451; (b) {{src/DynamoCoreWpf/DynamoCoreWpf.csproj:2203-2211}} showing the Dynamo build outputs {{Built-In Packages\packages\TuneUp\bin\<culture>\TuneUp.resources.dll}}; (c) the storeroom path from the bug report ({{...\RCPDYN.adix\VFS\...\Built-In packages\packages\TuneUp\bin\}}) which shows {{TuneUp.dll}} is being copied but the {{<culture>\}} subdirectories are not.
* [ ] Note that adding TuneUp to {{tools/install/Extra/additional-files-to-sign.txt}} is _not_ the fix and should not be requested — TuneUp arrives pre-signed.
* [ ] Once the downstream PR is merged and a localized Revit ship build is available, capture an updated storeroom path in this ticket's comments as proof of fix.

*Validation:*

* The next localized Revit Ship build's RCPDYN.adix at {{\\azw-storebox\builds\AEC\Revit\2026\px64\}} contains the satellite files at {{...\AddIns\DynamoForRevit\Built-In packages\packages\TuneUp\bin\<culture>\TuneUp.resources.dll}} for all 14 cultures.

*Requirements from spec:*

* "The localized satellites for TuneUp are not integrated in the installer" — fixed downstream once the packaging step recurses.

*Files to Create:*

* (none in this repo)

*Files to Modify:*

* (none in this repo; the fix lives in DynamoDS/DynamoRevit or Autodesk's RCPDYN packaging configuration)

*Implementation Details:*

* The most common shape of the underlying bug is a {{robocopy}} without {{/E}}, an {{xcopy}} without {{/S}}, a {{Copy}} MSBuild task without {{%(RecursiveDir)}}, or a WiX {{<File>}} ComponentGroup that enumerates only {{*.dll}} at one level. The DynamoRevit team should grep their packaging scripts for {{Built-In Packages\packages\TuneUp}} or {{\TuneUp\bin\}} and verify recursion.

----

h3. TASK 3: Update {{doc/integration_docs/4_builtinpackages.md}} to clarify the installer-recursion requirement [MEDIUM PRIORITY]

*Status:* NOT STARTED
*Milestone:* The next engineer who adds a localized built-in package or modifies a downstream installer reads the documented requirement and avoids re-introducing this bug class.

* [ ] Append one paragraph to the existing "Package Localization" section ({{doc/integration_docs/4_builtinpackages.md:31-58}}) noting: (a) satellite layout is {{package\bin\<culture>\<name>.resources.dll}}; (b) downstream installer packaging (Sandbox/Revit/integrator) MUST recurse into culture subdirectories or localized strings will not appear at runtime; (c) cite DYN-10451 as the precedent.
* [ ] Keep the addition under 10 lines; this is a guardrail note, not a tutorial.

*Validation:*

* A diff review by the Dynamo Loc / Build group confirms wording. No automated check.

*Requirements from spec:*

* Indirect — prevents recurrence of the same class of bug for other built-in packages with satellites.

*Files to Create:*

* (none)

*Files to Modify:*

* {{doc/integration_docs/4_builtinpackages.md}} (the WIP "Package Localization" section, lines 31-58).

*Implementation Details:*

* The file is already marked WIP; keep tone consistent with the rest of the doc (descriptive, no jargon beyond what's already in the file).

----

h3. TASK 4: Manual end-to-end verification on localized Revit [HIGH PRIORITY]

*Status:* NOT STARTED
*Milestone:* Reproduce the original failing scenario from the bug report on a build that includes both this PR (Task 1) AND the downstream DynamoRevit fix (Task 2) — confirm the bug is gone.

* [ ] Install a localized Czech Revit 2026 build that postdates both the merged Task 1 PR and the merged Task 2 PR.
* [ ] Walk through the exact steps from the ticket: launch Revit → Open Dynamo → Extensions menu.
* [ ] Confirm "Zobrazit TuneUp" (the CSY translation per LPU {{Button_ShowTuneUp}}) appears instead of "Show TuneUp".
* [ ] Confirm clicking the entry opens TuneUp and other TuneUp UI strings are also translated (sanity check that the satellite is fully loaded, not just one string).
* [ ] Repeat the spot-check on one additional non-en culture (e.g., de-DE or ja-JP) using a localized Revit of that language — verifies recursion is not just cs-CZ-specific.
* [ ] Post the storeroom path + screenshots to this ticket as resolution evidence.

*Validation:*

* Visual: "Zobrazit TuneUp" renders in the Extensions menu. TuneUp window strings are translated.
* Filesystem (sanity): {{\\azw-storebox\...\RCPDYN.adix\VFS\...\Built-In packages\packages\TuneUp\bin\cs-CZ\TuneUp.resources.dll}} exists.

*Requirements from spec:*

* The full "Actual" → "Expected" delta from the ticket is gone (string is translated).

*Files to Create:*

* (none; verification only)

*Files to Modify:*

* (none; verification only)

*Implementation Details:*

* If a Czech-locale Revit storeroom build is not yet available, postpone Task 4 until one is — but do not close this ticket without it.

----

h2. Testing Strategy

h3. Unit Tests

* No new unit tests. The fix is purely build-time / packaging. There is no Dynamo C# code path being added or changed.
* Existing tests that should continue passing without modification: {{test/DynamoCoreWpfTests/CrashReportingTests.cs:175}} (asserts TuneUp loads as a built-in package), {{test/DynamoCoreWpf2Tests/PackageManager/PackageManagerExtensionLoadingTests.cs:74}} (TuneUp in expected loaded extensions), {{test/DynamoCoreWpf2Tests/PackageManager/PackageManagerSearchElementViewModelTests.cs:852}}, {{test/Libraries/PackageManagerTests/PackageLoaderTests.cs:23}} (the {{Built-In Packages}} directory-name constant).

h3. Integration Tests

* The MSBuild {{<Error>}} assertion added in Task 1 acts as an in-band integration test: every {{Build DynamoAll.sln}} run is now an integration check on "do all 14 TuneUp satellites land in the build output?" Failure mode is a clear, actionable error message.

h3. Manual Testing Steps

# Run {{msbuild src\Dynamo.All.sln /p:Configuration=Release}} locally on Windows. Confirm build succeeds.
# Inspect {{bin\AnyCPU\Release\Built-In Packages\packages\TuneUp\bin\}} — confirm {{TuneUp.dll}} and all 14 {{<culture>\TuneUp.resources.dll}} subdirectories are present.
# Temporarily move {{extern\TuneUp\bin\cs-CZ}} out of the tree, re-run the build, and confirm the new {{<Error>}} task fires with a message naming {{cs-CZ}}. Restore.
# Once both PRs (Task 1 here + Task 2 in DynamoRevit) ship, install the localized Czech Revit build and execute the steps in Task 4.
# Repeat step 4 on one additional non-English locale (de-DE or ja-JP).

h2. Performance Considerations

None. Each per-build artifact is small (every {{TuneUp.resources.dll}} is on the order of single-digit KB), no new copies are introduced (only an {{Exists()}} check on 14 paths), and {{SkipUnchangedFiles="True"}} on the copy reduces incremental-rebuild churn slightly.

h2. Migration Notes

None. No persisted data, settings, or package format changes. The {{extern/TuneUp/}} directory layout and {{pkg.json}} are unchanged. Existing TuneUp installations continue to load with the same on-disk contract; this work only ensures the contract is delivered intact through the Revit installer.
