### PR TITLE
DYN-9663 fix missing parameter DataType in NodeDocumentationMarkdownGenerator

### DIFF
--- a/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
+++ b/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
@@ -268,7 +268,7 @@ namespace Dynamo.DocumentationBrowser
             {
                 sb.AppendLine("<tr class=\"table--border\">");
                 sb.AppendLine($"<td class=\"table--border\">{e.InputNames.ElementAt(i)}</td>");
-                sb.AppendLine($"<td class=\"table--border\">{GetTypeFromDescription(e.InputDescriptions.ElementAt(i))}</td>");
+                sb.AppendLine($"<td class=\"table--border\">{e.InputTypes.ElementAt(i)}</td>");
                 sb.AppendLine($"<td class=\"table--border\">{GetNthRowFromStringSplit(e.InputDescriptions.ElementAt(i), 0)}</td>");
                 sb.AppendLine($"<td class=\"table--border broken\">{GetDefaultValueFromDescription(e.InputDescriptions.ElementAt(i))}</td>");
                 sb.AppendLine(@"</tr>");
@@ -292,7 +292,7 @@ namespace Dynamo.DocumentationBrowser
                 sb.AppendLine(" <tr class=\"table--border\">");
                 sb.AppendLine($"<td class=\"table--border\">{e.OutputNames.ElementAt(i)}</td>");
                 sb.AppendLine($"<td class=\"table--border\">{GetNthRowFromStringSplit(e.OutputDescriptions.ElementAt(i), 0)}</td>");
-                sb.AppendLine($"<td class=\"table--border\">{GetTypeFromDescription(e.OutputDescriptions.ElementAt(i))}</td>");
+                sb.AppendLine($"<td class=\"table--border\">{e.OutputTypes.ElementAt(i)}</td>");
                 sb.AppendLine(@"</tr>");
             }
 
@@ -302,13 +302,6 @@ namespace Dynamo.DocumentationBrowser
 
             return sb.ToString();
         }
-
-         private static string GetTypeFromDescription(string element)
-         {
-             var stringArr = element.Split(new string[] {"\r\n", "\r", "\n"}, StringSplitOptions.None);
-             if(stringArr.Length > 2) return stringArr[2];
-             return string.Empty;
-         }
 
          private static string GetDefaultValueFromDescription(string element)
          {

--- a/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
+++ b/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
@@ -292,6 +292,7 @@ namespace Dynamo.DocumentationBrowser
                 sb.AppendLine(" <tr class=\"table--border\">");
                 sb.AppendLine($"<td class=\"table--border\">{e.OutputNames.ElementAt(i)}</td>");
                 sb.AppendLine($"<td class=\"table--border\">{GetNthRowFromStringSplit(e.OutputDescriptions.ElementAt(i), 0)}</td>");
+                sb.AppendLine($"<td class=\"table--border\">{GetTypeFromDescription(e.OutputDescriptions.ElementAt(i))}</td>");
                 sb.AppendLine(@"</tr>");
             }
 

--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -515,12 +515,23 @@ namespace Dynamo.Graph.Nodes
 
                 try
                 {
-                    return inPortAttribute?.PortTypes.ElementAt(Index);
+                    var attrType = inPortAttribute?.PortTypes.ElementAt(Index);
+                    if (attrType != null) return attrType;
                 }
                 catch (Exception e)
                 {
                     Log(e.Message);
                 }
+
+                // Fallback: infer from the port's default value node type.
+                return DefaultValue switch
+                {
+                    IntNode     _ => "int",
+                    DoubleNode  _ => "double",
+                    BooleanNode _ => "bool",
+                    StringNode  _ => "string",
+                    _ => null
+                };
             }
             return null;
         }

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -26,6 +26,8 @@ Dynamo.ViewModels.DynamoViewModel.PythonEngineUpgradeToastRequested -> System.Ac
 Dynamo.ViewModels.DynamoViewModel.ToastManager.get -> Dynamo.Wpf.UI.ToastManager
 Dynamo.ViewModels.DynamoViewModel.ToastManager.set -> void
 Dynamo.ViewModels.DynamoViewModel.ShowPythonEngineUpgradeCanvasToast(string message, bool stayOpen = true, string filePath = null) -> void
+Dynamo.ViewModels.OpenNodeAnnotationEventArgs.InputTypes.get -> System.Collections.Generic.IEnumerable<string>
+Dynamo.ViewModels.OpenNodeAnnotationEventArgs.OutputTypes.get -> System.Collections.Generic.IEnumerable<string>
 Dynamo.ViewModels.PreferencesViewModel.AutoSyncDocumentBrowserIsChecked.get -> bool
 Dynamo.ViewModels.PreferencesViewModel.AutoSyncDocumentBrowserIsChecked.set -> void
 Dynamo.ViewModels.PreferencesViewModel.ShowPythonAutoMigrationNotificationIsChecked.get -> bool

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelEventArgs.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelEventArgs.cs
@@ -217,6 +217,14 @@ namespace Dynamo.ViewModels
         /// </summary>
         public IEnumerable<string> OutputDescriptions { get; private set; }
         /// <summary>
+        /// Collection of the nodes input port types.
+        /// </summary>
+        public IEnumerable<string> InputTypes { get; private set; }
+        /// <summary>
+        /// Collection of the nodes output port types.
+        /// </summary>
+        public IEnumerable<string> OutputTypes { get; private set; }
+        /// <summary>
         /// Collection of the nodes collection of warnings/errors/infos.
         /// </summary>
         public IEnumerable<Info> NodeInfos { get; private set; }
@@ -247,33 +255,38 @@ namespace Dynamo.ViewModels
         {
             var outputNames = new List<string>();
             var outputDescriptions = new List<string>();
+            var outputTypes = new List<string>();
 
             var outputs = nodeModel.OutPorts;
             foreach (var output in outputs)
             {
                 outputNames.Add(output.Name);
                 outputDescriptions.Add(output.ToolTip);
+                outputTypes.Add(output.GetOutPortType() ?? string.Empty);
             }
 
             OutputNames = outputNames;
             OutputDescriptions = outputDescriptions;
+            OutputTypes = outputTypes;
         }
 
         private void SetInputs(NodeModel nodeModel)
         {
             var inputNames = new List<string>();
             var inputDescriptions = new List<string>();
+            var inputTypes = new List<string>();
 
             var inputs = nodeModel.InPorts;
             foreach (var input in inputs)
             {
                 inputNames.Add(input.Name);
                 inputDescriptions.Add(input.ToolTip);
+                inputTypes.Add(input.GetInputPortType() ?? string.Empty);
             }
 
             InputNames = inputNames;
             InputDescriptions = inputDescriptions;
-
+            InputTypes = inputTypes;
         }
     }
 

--- a/src/Tools/NodeDocumentationMarkdownGenerator/AssemblyHandler.cs
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/AssemblyHandler.cs
@@ -422,7 +422,7 @@ namespace NodeDocumentationMarkdownGenerator
                     }
                 }
 
-                typeParams.Add(new TypedParameter(name));
+                typeParams.Add(new TypedParameter(name, arg.ArgumentType));
             }
 
             return typeParams;

--- a/test/DynamoCoreWpf3Tests/NodeViewTests.cs
+++ b/test/DynamoCoreWpf3Tests/NodeViewTests.cs
@@ -9,6 +9,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using Dynamo.Controls;
 using Dynamo.Graph;
+using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
 using Dynamo.Selection;
@@ -16,12 +17,24 @@ using Dynamo.UI.Prompts;
 using Dynamo.ViewModels;
 using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
+using ProtoCore.AST.AssociativeAST;
 
 namespace DynamoCoreWpfTests
 {
     public class NodeViewTests : DynamoTestUIBase
     {
         // adapted from: http://stackoverflow.com/questions/9336165/correct-method-for-using-the-wpf-dispatcher-in-unit-tests
+        private class DefaultValueInputTypeNode : NodeModel
+        {
+            internal DefaultValueInputTypeNode()
+            {
+                InPorts.Add(new PortModel(PortType.Input, this, new PortData("integer", "integer", AstFactory.BuildIntNode(1))));
+                InPorts.Add(new PortModel(PortType.Input, this, new PortData("number", "number", AstFactory.BuildDoubleNode(1.0))));
+                InPorts.Add(new PortModel(PortType.Input, this, new PortData("boolean", "boolean", AstFactory.BuildBooleanNode(true))));
+                InPorts.Add(new PortModel(PortType.Input, this, new PortData("text", "text", AstFactory.BuildStringNode("value"))));
+                RegisterAllPorts();
+            }
+        }
 
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
@@ -359,6 +372,16 @@ namespace DynamoCoreWpfTests
             var port = inPorts[0].PortModel;
             var type = port.GetInputPortType();
             Assert.AreEqual("System.Drawing.Bitmap", type);
+        }
+
+        [Test]
+        public void InputPortType_NodeModelNodeWithoutInPortTypes_FallsBackToDefaultValueType()
+        {
+            var node = new DefaultValueInputTypeNode();
+
+            CollectionAssert.AreEqual(
+                new[] { "int", "double", "bool", "string" },
+                node.InPorts.Select(port => port.GetInputPortType()));
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

Fixes missing DataType in the node documentation browser for input and output ports. Tracked in [DYN-9663](https://autodesk.atlassian.net/browse/DYN-9663).

Three root causes addressed:

1. **`NodeDocumentationMarkdownGenerator` dropped parameter types** — `BuildParameters` in `AssemblyHandler.cs` constructed `TypedParameter` objects with only the name, ignoring `arg.ArgumentType`. One-line fix to pass the `ProtoCore.Type` through.

2. **Doc browser parsed type from a fragile multi-line string** — `GetTypeFromDescription` tried to extract type from a tooltip description string, which only worked when a parameter had a non-empty XML doc Summary. Added `InputTypes`/`OutputTypes` collections to `OpenNodeAnnotationEventArgs`, populated directly from `PortModel.GetInputPortType()`/`GetOutPortType()`, which already handle ZeroTouch, DesignScript, custom node, and `[InPortTypes]`/`[OutPortTypes]` attribute paths correctly.

3. **Output DataType cell was never emitted** — Output table had 3 column headers (Name, Description, DataType) but only 2 `<td>` cells per row. Added the missing cell.

4. **NodeModel nodes without `[InPortTypes]` always returned null** — Added a fallback in `GetInputPortType()` to infer the type string from the port's `DefaultValue` AST node (`IntNode`→`int`, `DoubleNode`→`double`, `BooleanNode`→`bool`, `StringNode`→`string`). NodeModel nodes without typed defaults or `[InPortTypes]` attributes will still show empty — those require separate annotation work.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fix missing DataType column in the node documentation browser. Input and output port types now display correctly for ZeroTouch, DesignScript, and NodeModel nodes. NodeModel nodes with typed default values (e.g. `Range`, `Sequence`) will show inferred types even without explicit `[InPortTypes]` attributes.

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)