### PR TITLE
Update pr_description_check.yml

### DIFF
--- a/.github/workflows/pr_description_check.yml
+++ b/.github/workflows/pr_description_check.yml
@@ -29,29 +29,29 @@ jobs:
         cat release_notes.txt
       
     - name: Validate Release Notes
-      id: validate_notes
-      run: |
-        release_notes=$(cat release_notes.txt)
-        if [[ "$release_notes" == *"(FILL ME IN)"* ]]; then
-          echo "Error: Release notes must be filled in."
-          echo "Author: Please check if the text in Release Notes is the default text."
-          exit 1
-        elif [[ "$release_notes" == *"N/A"* ]]; then
-          echo "Release notes are not applicable for this pull request."
-          echo "Reviewer: Please check if this pull request have non-applicable Release notes."
-          exit 0
-        else
-          word_count=$(wc -w <<< "$release_notes")
-          if [ $word_count -ge 6 ]; then
-            echo "Release notes have at least 6 words."
-            exit 0
-          else
-            echo "Error: Release notes must have at least 6 words."
-            echo "Author: Please add more context of your changes."
-            echo "Extracted release notes (word count: $word_count):"
-            echo "---"
-            echo "$release_notes"
-            echo "---"
-            exit 1
-          fi
-        fi
+  id: validate_notes
+  run: |
+    release_notes=$(cat release_notes.txt)
+    if [[ "$release_notes" == *"(FILL ME IN)"* ]]; then
+      echo "Error: Release notes must be filled in."
+      echo "Author: Please check if the text in Release Notes is the default text."
+      exit 1
+    elif [[ "$release_notes" == *"N/A"* ]]; then
+      echo "Release notes are not applicable for this pull request."
+      echo "Reviewer: Please check if this pull request have non-applicable Release notes."
+      exit 0
+    else
+      word_count=$(echo "$release_notes" | wc -w)
+      if [ "$word_count" -ge 6 ]; then
+        echo "Release notes have at least 6 words."
+        exit 0
+      else
+        echo "Error: Release notes must have at least 6 words."
+        echo "Author: Please add more context of your changes."
+        echo "Extracted release notes (word count: $word_count):"
+        echo "---"
+        echo "$release_notes"
+        echo "---"
+        exit 1
+      fi
+    fi


### PR DESCRIPTION
### Purpose

This PR updates the release notes validation GitHub Action to use a more portable word count command when checking PR descriptions.

### Declarations

Check these if you believe they are true

* [ ] Is documented according to the [[standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
* [x] The level of testing this PR includes is appropriate
* [ ] Changes to the API follow [[Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions)](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [[API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes)](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Improved PR release notes validation by updating the word count logic used by the GitHub Action.

### Reviewers

(FILL ME IN) Reviewer 1

Please verify that the PR description checker still correctly fails on default or too-short release notes and passes on valid release notes or `N/A`.

### FYIs

N/A