### PR TITLE
DynamoDS/DYN-8957: Add tooltips describing PM is disabled in no-network mode

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -10248,7 +10248,16 @@ namespace Dynamo.Wpf.Properties {
                 return ResourceManager.GetString("SignInOfflineButtonContentToolTip", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Enable Network Mode to be able to use Package Manager..
+        /// </summary>
+        public static string PackageManagerNoNetworkModeToolTip {
+            get {
+                return ResourceManager.GetString("PackageManagerNoNetworkModeToolTip", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Signing out of Dynamo will sign you out of all Autodesk desktop products..
         /// </summary>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -154,6 +154,9 @@
   <data name="SignInOfflineButtonContentToolTip" xml:space="preserve">
     <value>Enable Network Mode to be able to sign in.</value>
   </data>
+  <data name="PackageManagerNoNetworkModeToolTip" xml:space="preserve">
+    <value>Enable Network Mode to be able to use Package Manager.</value>
+  </data>
   <data name="Autodesk360SignInButtonTitleToolTip" xml:space="preserve">
     <value>Autodesk A360</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2147,6 +2147,9 @@ Do you want to install the latest Dynamo update?</value>
   <data name="SignInOfflineButtonContentToolTip" xml:space="preserve">
     <value>Enable Network Mode to be able to sign in.</value>
   </data>
+  <data name="PackageManagerNoNetworkModeToolTip" xml:space="preserve">
+    <value>Enable Network Mode to be able to use Package Manager.</value>
+  </data>
   <data name="Autodesk360SignInButtonTitleToolTip" xml:space="preserve">
     <value>Autodesk A360</value>
   </data>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -615,13 +615,64 @@
                               IsEnabled="True">
                         <MenuItem Name="publishSelected"
                                   Command="{Binding Path=DataContext.PublishSelectedNodesCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
-                                  Header="{x:Static p:Resources.DynamoViewPackageMenuPublishNodes}" />
+                                  Header="{x:Static p:Resources.DynamoViewPackageMenuPublishNodes}"
+                                  ToolTipService.ShowOnDisabled="True">
+                            <MenuItem.ToolTip>
+                                <ToolTip>
+                                    <ToolTip.Style>
+                                        <Style TargetType="ToolTip" BasedOn="{StaticResource GenericToolTipLight}">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding PlacementTarget.IsEnabled, RelativeSource={RelativeSource Self}}" Value="False">
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                    <Setter Property="Content" Value="{x:Static p:Resources.PackageManagerNoNetworkModeToolTip}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </ToolTip.Style>
+                                </ToolTip>
+                            </MenuItem.ToolTip>
+                        </MenuItem>
                         <MenuItem Name="publishCurrent"
                                   Command="{Binding Path=DataContext.PublishCurrentWorkspaceCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
-                                  Header="{x:Static p:Resources.DynamoViewPackageMenuPublishWorkspace}" />
+                                  Header="{x:Static p:Resources.DynamoViewPackageMenuPublishWorkspace}"
+                                  ToolTipService.ShowOnDisabled="True">
+                            <MenuItem.ToolTip>
+                                <ToolTip>
+                                    <ToolTip.Style>
+                                        <Style TargetType="ToolTip" BasedOn="{StaticResource GenericToolTipLight}">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding PlacementTarget.IsEnabled, RelativeSource={RelativeSource Self}}" Value="False">
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                    <Setter Property="Content" Value="{x:Static p:Resources.PackageManagerNoNetworkModeToolTip}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </ToolTip.Style>
+                                </ToolTip>
+                            </MenuItem.ToolTip>
+                        </MenuItem>
                         <MenuItem Name="showPM"
                                   Command="{Binding Path=DataContext.ShowPackageManagerCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
-                                  Header="{x:Static p:Resources.DynamoViewPackageMenuPackageManager}" />
+                                  Header="{x:Static p:Resources.DynamoViewPackageMenuPackageManager}"
+                                  ToolTipService.ShowOnDisabled="True">
+                            <MenuItem.ToolTip>
+                                <ToolTip>
+                                    <ToolTip.Style>
+                                        <Style TargetType="ToolTip" BasedOn="{StaticResource GenericToolTipLight}">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding PlacementTarget.IsEnabled, RelativeSource={RelativeSource Self}}" Value="False">
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                    <Setter Property="Content" Value="{x:Static p:Resources.PackageManagerNoNetworkModeToolTip}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </ToolTip.Style>
+                                </ToolTip>
+                            </MenuItem.ToolTip>
+                        </MenuItem>
                     </MenuItem>
 
                     <MenuItem Name="HelpMenu"

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -755,7 +755,24 @@
                     <MenuItem Name="Publish"
                               Command="{Binding DynamoViewModel.PublishCurrentWorkspaceCommand}"
                               Header="{x:Static p:Resources.ContextMenuPublishCustomNode}"
-                              Visibility="{Binding Path=IsHomeSpace, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}" />
+                              Visibility="{Binding Path=IsHomeSpace, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}"
+                              ToolTipService.ShowOnDisabled="True">
+                        <MenuItem.ToolTip>
+                            <ToolTip>
+                                <ToolTip.Style>
+                                    <Style TargetType="ToolTip" BasedOn="{StaticResource GenericToolTipLight}">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding PlacementTarget.IsEnabled, RelativeSource={RelativeSource Self}}" Value="False">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                                <Setter Property="Content" Value="{x:Static p:Resources.PackageManagerNoNetworkModeToolTip}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </ToolTip.Style>
+                            </ToolTip>
+                        </MenuItem.ToolTip>
+                    </MenuItem>
 
                     <Separator />
 

--- a/src/WorkspaceDependencyViewExtension/Properties/Resources.Designer.cs
+++ b/src/WorkspaceDependencyViewExtension/Properties/Resources.Designer.cs
@@ -209,7 +209,16 @@ namespace Dynamo.WorkspaceDependency.Properties {
                 return ResourceManager.GetString("InstallButtonText", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Enable Network Mode to be able to install packages..
+        /// </summary>
+        public static string InstallButtonNoNetworkModeToolTip {
+            get {
+                return ResourceManager.GetString("InstallButtonNoNetworkModeToolTip", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>

--- a/src/WorkspaceDependencyViewExtension/Properties/Resources.en-US.resx
+++ b/src/WorkspaceDependencyViewExtension/Properties/Resources.en-US.resx
@@ -225,6 +225,9 @@
   <data name="InstallButtonText" xml:space="preserve">
     <value>Install Specified Version</value>
   </data>
+  <data name="InstallButtonNoNetworkModeToolTip" xml:space="preserve">
+    <value>Enable Network Mode to be able to install packages.</value>
+  </data>
   <data name="JsonIcon" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL

--- a/src/WorkspaceDependencyViewExtension/Properties/Resources.resx
+++ b/src/WorkspaceDependencyViewExtension/Properties/Resources.resx
@@ -225,6 +225,9 @@
   <data name="InstallButtonText" xml:space="preserve">
     <value>Install Specified Version</value>
   </data>
+  <data name="InstallButtonNoNetworkModeToolTip" xml:space="preserve">
+    <value>Enable Network Mode to be able to install packages.</value>
+  </data>
   <data name="JsonIcon" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml
@@ -247,12 +247,37 @@
                                 FontSize="11">
                             </TextBlock>
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                <Button Style="{StaticResource SmallTextButton}"
-                                    Visibility="{Binding Path=ShowDownloadButton, Converter={StaticResource BoolToVis}}"
+                                <Button Visibility="{Binding Path=ShowDownloadButton, Converter={StaticResource BoolToVis}}"
                                     Name="DownloadPackageButton"
                                     Click="DownloadPackage"
                                     Margin="10"
-                                    Content="{x:Static w:Resources.InstallButtonText}"/>
+                                    Content="{x:Static w:Resources.InstallButtonText}"
+                                    ToolTipService.ShowOnDisabled="True">
+                                    <Button.Style>
+                                        <Style TargetType="Button" BasedOn="{StaticResource SmallTextButton}">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding NoNetworkMode, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}" Value="True">
+                                                    <Setter Property="IsEnabled" Value="False" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Button.Style>
+                                    <Button.ToolTip>
+                                        <ToolTip>
+                                            <ToolTip.Style>
+                                                <Style TargetType="ToolTip" BasedOn="{StaticResource GenericToolTipLight}">
+                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding PlacementTarget.IsEnabled, RelativeSource={RelativeSource Self}}" Value="False">
+                                                            <Setter Property="Visibility" Value="Visible" />
+                                                            <Setter Property="Content" Value="{x:Static w:Resources.InstallButtonNoNetworkModeToolTip}" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </ToolTip.Style>
+                                        </ToolTip>
+                                    </Button.ToolTip>
+                                </Button>
                                 <Button Style="{StaticResource SmallTextButton}"
                                     Visibility="{Binding Path=ShowKeepLocalButton, Converter={StaticResource BoolToVis}}"
                                     Name="KeepLocalPackageButton"

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -39,6 +39,12 @@ namespace Dynamo.WorkspaceDependency
         private Boolean hasDependencyIssue = false;
 
         /// <summary>
+        /// True when Dynamo started in no-network mode. Bound to the Install button's
+        /// IsEnabled trigger so users see the disabled state and tooltip.
+        /// </summary>
+        public bool NoNetworkMode { get; private set; }
+
+        /// <summary>
         /// Property to raise to author's attention, if the Dynamo active workspace has any missing dependencies.
         /// This determines if the package dep viewer will be injected into right panel.
         /// </summary>
@@ -149,6 +155,7 @@ namespace Dynamo.WorkspaceDependency
             currentWorkspace.PropertyChanged += OnWorkspacePropertyChanged;
             loadedParams = p;
             packageInstaller = p.PackageInstaller;
+            NoNetworkMode = p.StartupParams.NoNetworkMode;
             dependencyViewExtension = viewExtension;
             HomeWorkspaceModel.WorkspaceClosed += this.CloseExtensionTab;
         }

--- a/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUnitTests.cs
+++ b/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUnitTests.cs
@@ -1,5 +1,6 @@
 ﻿using Dynamo;
 using Dynamo.PackageManager;
+using Dynamo.Wpf.Properties;
 using NUnit.Framework;
 
 namespace DynamoCoreWpfTests.PackageManager
@@ -33,6 +34,14 @@ namespace DynamoCoreWpfTests.PackageManager
             var message = "Unknown error";
             var actual = PublishPackageViewModel.TranslatePackageManagerError(message);
             Assert.AreEqual(message, actual);
+        }
+
+        [Test]
+        public void WhenNoNetworkModeTooltipResourceRequestedThenItResolvesToNonEmpty()
+        {
+            // Guards against accidental deletion of the no-network mode tooltip resource string
+            // that the PM menu items in DynamoView.xaml depend on.
+            Assert.IsFalse(string.IsNullOrWhiteSpace(Resources.PackageManagerNoNetworkModeToolTip));
         }
 
         #endregion

--- a/test/DynamoCoreWpf2Tests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
+++ b/test/DynamoCoreWpf2Tests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
@@ -344,7 +344,7 @@ namespace DynamoCoreWpfTests
         [Test]
         public void GetExternalFilesShouldBailIfGraphExecuting()
         {
-            // Open test file to verify the external file references are not computed when RunEnabled is false. 
+            // Open test file to verify the external file references are not computed when RunEnabled is false.
             var examplePath = Path.Combine(@"core\ExternalReferencesTest.dyn");
             Open(examplePath);
             (Model.CurrentWorkspace as HomeWorkspaceModel).RunSettings.RunEnabled = false;
@@ -355,6 +355,51 @@ namespace DynamoCoreWpfTests
             WorkspaceReferencesExtension.DependencyRegen(Model.CurrentWorkspace, true);
             results = Model.CurrentWorkspace.ExternalFiles;
             Assert.AreEqual(2, results.Count());
+        }
+
+        [Test]
+        public void WhenInstallButtonResourceStringRequestedThenItResolvesToNonEmpty()
+        {
+            // Guards against accidental deletion of the no-network mode tooltip resource string.
+            Assert.IsFalse(string.IsNullOrWhiteSpace(Resources.InstallButtonNoNetworkModeToolTip));
+        }
+    }
+
+    /// <summary>
+    /// Fixture that boots Dynamo in NoNetworkMode to verify the Workspace References
+    /// install button is disabled and exposes the no-network tooltip.
+    /// </summary>
+    [TestFixture]
+    public class WorkspaceDependencyViewExtensionNoNetworkModeTests : DynamoTestUIBase
+    {
+        private WorkspaceDependencyViewExtension viewExtension = new WorkspaceDependencyViewExtension();
+
+        protected override DynamoModel.IStartConfiguration CreateStartConfiguration(IPathResolver pathResolver)
+        {
+            return new DynamoModel.DefaultStartConfiguration()
+            {
+                PathResolver = pathResolver,
+                StartInTestMode = true,
+                GeometryFactoryPath = preloader.GeometryFactoryPath,
+                ProcessMode = TaskProcessMode.Synchronous,
+                NoNetworkMode = true,
+            };
+        }
+
+        [Test]
+        public void WhenNoNetworkModeThenWorkspaceReferencesInstallButtonIsDisabled()
+        {
+            RaiseLoadedEvent(this.View);
+            var extensionManager = View.viewExtensionManager;
+            extensionManager.Add(viewExtension);
+
+            var loadedParams = new ViewLoadedParams(View, ViewModel);
+            viewExtension.pmExtension = this.Model.ExtensionManager.Extensions.OfType<PackageManagerExtension>().FirstOrDefault();
+            viewExtension.Loaded(loadedParams);
+
+            // The view's NoNetworkMode flag should reflect the model startup configuration
+            // and that flag is what drives the DownloadPackageButton's IsEnabled state.
+            Assert.IsTrue(viewExtension.DependencyView.NoNetworkMode);
         }
     }
 }


### PR DESCRIPTION
Closes https://autodesk.atlassian.net/browse/DYN-8957

h1. Package Manager No-Network Mode Tooltips Implementation Plan

h2. Overview

In no-network mode, every Package Manager (PM) entry point in Dynamo's UI must visibly communicate _why_ it is disabled, rather than appearing arbitrarily greyed out. The existing PM-related menu items and the custom-node Publish context-menu entry are already command-disabled but unannotated; the Workspace References extension's Install button is wired to a raw {{Click}} handler and is not even disabled. This plan adds two localized tooltip resources, attaches them to the four PM menu items through a re-usable XAML pattern, and adds an explicit {{IsEnabled=False}} binding plus tooltip on the Workspace References Install button, mirroring the existing offline Sign-In pattern in {{ShortcutToolbar.xaml}}.

h2. Current State Analysis

h3. Key Discoveries

* The PM-launching {{MenuItem}}s on the main {{Packages}} menu ({{src/DynamoCoreWpf/Views/Core/DynamoView.xaml:615-619}}) are already disabled in no-network mode via their bound {{Command}}s — they only need tooltips.
* The custom-workspace {{Publish}} context-menu item ({{src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml:756}}) shares {{PublishCurrentWorkspaceCommand}} with the main menu, so it disables for free and likewise just needs a tooltip.
* The Workspace References {{DownloadPackageButton}} ({{src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml:250}}) uses a {{Click}} event, not an {{ICommand}}. It must be explicitly disabled via a {{Style.Triggers}} {{DataTrigger}} driven by a {{NoNetworkMode}} property exposed on {{WorkspaceDependencyView}}, populated from {{ViewLoadedParams.StartupParams.NoNetworkMode}}.
* The PM Window's internal install/publish controls ({{PackageManagerView.xaml}}, {{PackageManagerPackagesControl.xaml}}, {{PackageDetailsView.xaml}}) are unreachable in no-network mode because the entry-menu items that open the window are themselves disabled. They are deliberately out of scope.
* The Preferences-dialog "Package Manager" hyperlink ({{PreferencesView.xaml:2028}}) already has a separate {{IsHitTestVisible}} + greyed-out {{Foreground}} disable treatment and is not part of this ticket.
* The reference pattern for a disabled-state tooltip lives on the Sign-In button ({{src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml}}, around {{LoginButton}}), which uses {{ToolTipService.ShowOnDisabled="True"}} and a {{Style.Triggers}} {{DataTrigger}} on {{PlacementTarget.IsEnabled}}.

h2. Desired End State

* In no-network mode ({{--NoNetworkMode}} startup flag set), hovering any of the following disabled controls shows a tooltip explaining that Network Mode must be enabled:
** {{Packages}} menu → {{Publish Nodes}}, {{Publish Workspace}}, {{Show Package Manager}}
** Custom-workspace context menu → {{Publish}}
** Workspace References extension → {{Install Specified Version}} button
* In normal (network) mode, the same controls behave exactly as before with no tooltip leakage and no visual regression.
* New tooltip strings are present in both {{DynamoCoreWpf}} and {{WorkspaceDependencyViewExtension}} resource bundles (invariant + {{en-US}}) and surface via the generated {{Resources.Designer.cs}} accessors.
* NUnit regression tests guard against accidental removal of the new resource strings and assert that the Workspace References extension propagates {{NoNetworkMode}} from {{StartupParams}} when Dynamo boots with that flag.
* {{msbuild src/Dynamo.All.sln /p:Configuration=Release}} builds clean.
* {{dotnet test test/DynamoCoreWpf2Tests/DynamoCoreWpf2Tests.csproj --filter "Name~NoNetworkMode|Name~InstallButtonResource|Name~NoNetworkModeTooltipResource"}} passes.

h2. What We're NOT Doing

* Changing the underlying no-network gating logic in {{DynamoModel}}, {{DynamoViewModel}}, or {{PackageManagerClientViewModel}} — those gates are already correct.
* Adding tooltips inside the PM Window (search results, package details, empty-state publish). They are unreachable in no-network mode.
* Modifying the Preferences-dialog Package Manager hyperlink — its disabled UX is already implemented and is out of scope.
* Backfilling translated resources into the non-{{en-US}} {{.resx}} files; those are handled by the periodic {{master-localization}} merge.
* Refactoring {{DownloadPackageButton}} from a {{Click}} handler to a bindable {{ICommand}}. Out of scope; only its enabled state and tooltip are being changed.
* Touching {{DynamoModel.cs}} template-loading code or any other behavior unrelated to PM-disabled tooltips.

h2. Implementation Approach

Match the existing {{SignInOfflineButtonContentToolTip}} pattern: introduce per-feature resource strings, attach {{ToolTipService.ShowOnDisabled="True"}} to each affected control, and use a {{Style.Triggers}} {{DataTrigger}} on {{PlacementTarget.IsEnabled}} (or, for the explicitly-controlled Install button, on a code-behind {{NoNetworkMode}} property) to swap a default-collapsed tooltip into a visible state when the control is disabled. Land the work in five small, reviewable commits — resources first, then each XAML surface, then the extension code-behind + tests — so each step is independently buildable and reviewable.

----

h3. TASK 1: Add localized resource strings for the new tooltips [HIGH PRIORITY]

*Status:* DONE
*Milestone:* Both {{Resources.PackageManagerNoNetworkModeToolTip}} (DynamoCoreWpf) and {{Resources.InstallButtonNoNetworkModeToolTip}} (WorkspaceDependencyViewExtension) resolve from C# code and from XAML {{{x:Static p:Resources.*}}} bindings.

* [x] Add {{PackageManagerNoNetworkModeToolTip}} = {{Enable Network Mode to be able to use Package Manager.}} to {{src/DynamoCoreWpf/Properties/Resources.resx}} (invariant) and {{Resources.en-US.resx}}, placed next to the existing {{SignInOfflineButtonContentToolTip}} entry for locality.
* [x] Add {{InstallButtonNoNetworkModeToolTip}} = {{Enable Network Mode to be able to install packages.}} to {{src/WorkspaceDependencyViewExtension/Properties/Resources.resx}} (invariant) and {{Resources.en-US.resx}}, placed next to the existing {{InstallButtonText}} entry.
* [x] Regenerate {{Resources.Designer.cs}} for both projects so the new keys surface as {{public static string}} properties.
* [x] Do not edit the other locale {{.resx}} files; they are filled in via the master-localization merge.

*Validation:* {{msbuild src/Dynamo.All.sln /p:Configuration=Release}} succeeds and {{Resources.PackageManagerNoNetworkModeToolTip}} / {{Resources.InstallButtonNoNetworkModeToolTip}} are accessible via IntelliSense in their respective namespaces.

*Requirements from spec:*

* Provide user-facing messaging explaining that PM is disabled in no-network mode (per DYN-6409 messaging convention).
* Mirror the existing {{SignInOfflineButtonContentToolTip}} precedent for offline messaging.

*Files to Modify:*

* {{src/DynamoCoreWpf/Properties/Resources.resx}} — add invariant {{PackageManagerNoNetworkModeToolTip}}.
* {{src/DynamoCoreWpf/Properties/Resources.en-US.resx}} — add en-US {{PackageManagerNoNetworkModeToolTip}}.
* {{src/DynamoCoreWpf/Properties/Resources.Designer.cs}} — regenerated public static getter.
* {{src/WorkspaceDependencyViewExtension/Properties/Resources.resx}} — add invariant {{InstallButtonNoNetworkModeToolTip}}.
* {{src/WorkspaceDependencyViewExtension/Properties/Resources.en-US.resx}} — add en-US {{InstallButtonNoNetworkModeToolTip}}.
* {{src/WorkspaceDependencyViewExtension/Properties/Resources.Designer.cs}} — regenerated public static getter.

*Implementation Details:*
Keep both strings short and parallel in voice to the existing {{SignInOfflineButtonContentToolTip}} ({{Enable Network Mode to be able to sign in.}}). Two separate keys (rather than one shared resource) are intentional because the two tooltips live in two different assemblies — duplicating the string keeps each resource bundle self-contained.

----

h3. TASK 2: Attach no-network tooltips to the Packages menu items [HIGH PRIORITY]

*Status:* DONE
*Milestone:* In no-network mode, hovering any of {{Publish Nodes}}, {{Publish Workspace}}, or {{Show Package Manager}} under the {{Packages}} menu shows {{PackageManagerNoNetworkModeToolTip}}; in normal mode the items show no tooltip.

* [x] In {{src/DynamoCoreWpf/Views/Core/DynamoView.xaml}}, on the three {{MenuItem}} elements {{publishSelected}}, {{publishCurrent}}, and {{showPM}}:
** [x] Add {{ToolTipService.ShowOnDisabled="True"}}.
** [x] Add a {{MenuItem.ToolTip}} containing a {{ToolTip}} whose {{Style}} (based on {{GenericToolTipLight}}) starts with {{Visibility="Collapsed"}} and a {{Style.Triggers}} {{DataTrigger}} on {{Binding="{Binding PlacementTarget.IsEnabled, RelativeSource={RelativeSource Self}}" Value="False"}} that sets {{Visibility="Visible"}} and {{Content="{x:Static p:Resources.PackageManagerNoNetworkModeToolTip}"}}.
* [x] Keep the existing {{Command}} bindings — the {{MenuItem}} disabled state already comes from {{CanPublishSelectedNodes}} / {{CanPublishCurrentWorkspace}} / {{CanShowPackageManager}}.

*Validation:*

* Launch Dynamo with {{--NoNetworkMode}}, open the {{Packages}} menu, hover each of the three items → tooltip appears.
* Launch Dynamo normally, open the {{Packages}} menu, hover each item → no tooltip is shown.

*Requirements from spec:*

* Add tooltips describing PM is disabled in no-network mode (the explicit ticket ask).

*Files to Modify:*

* {{src/DynamoCoreWpf/Views/Core/DynamoView.xaml}} — extend three {{MenuItem}} elements inside the {{PackageManagerMenu}} block.

*Implementation Details:*
The collapsed-by-default style is important: WPF will still allocate the {{ToolTip}} for an enabled {{MenuItem}}, and {{ToolTipService.ShowOnDisabled}} only suppresses the show-while-disabled blocker. Hiding the tooltip via {{Visibility="Collapsed"}} and revealing it only on {{IsEnabled=False}} prevents an empty tooltip from flashing on enabled items.

----

h3. TASK 3: Attach no-network tooltip to the custom-workspace Publish context-menu item [MEDIUM PRIORITY]

*Status:* DONE
*Milestone:* In no-network mode, right-clicking a custom-node workspace and hovering the {{Publish}} menu entry shows {{PackageManagerNoNetworkModeToolTip}}.

* [x] In {{src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml}}, on the {{MenuItem}} named {{Publish}} bound to {{PublishCurrentWorkspaceCommand}}:
** [x] Add {{ToolTipService.ShowOnDisabled="True"}}.
** [x] Add the same {{MenuItem.ToolTip}} + {{Style.Triggers}} pattern used in Task 2, with content {{PackageManagerNoNetworkModeToolTip}}.
* [x] Leave the existing {{Visibility}} binding on {{IsHomeSpace}} intact — it controls whether the item is shown at all (only on custom-node workspaces), independent of enabled state.

*Validation:* In no-network mode, open a custom node, right-click anywhere on its workspace canvas → context menu shows a disabled {{Publish}} entry whose tooltip reads the PM no-network message.

*Requirements from spec:*

* Tooltip coverage for the Publish action on custom-node workspaces (parity with the main {{Packages}} menu).

*Files to Modify:*

* {{src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml}} — extend the {{Publish}} {{MenuItem}} under the workspace context menu.

*Implementation Details:*
Same XAML pattern as Task 2. Re-using the same resource string is correct: from the user's standpoint these are all "Package Manager publish" actions, regardless of the menu path.

----

h3. TASK 4: Disable the Workspace References Install button in no-network mode and attach a tooltip [HIGH PRIORITY]

*Status:* DONE
*Milestone:* When Dynamo runs with {{--NoNetworkMode}}, the {{Install Specified Version}} button in the Workspace References extension is visibly disabled and shows {{InstallButtonNoNetworkModeToolTip}} on hover. In normal mode it works exactly as before.

* [x] In {{src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs}}:
** [x] Add a {{public bool NoNetworkMode { get; private set; }}} property with an XML doc comment explaining its purpose.
** [x] In the existing constructor that takes {{ViewLoadedParams p}}, set {{NoNetworkMode = p.StartupParams.NoNetworkMode;}} next to the existing {{loadedParams = p; packageInstaller = p.PackageInstaller;}} assignments.
* [x] In {{src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml}}, on the {{DownloadPackageButton}}:
** [x] Move the existing {{Style="{StaticResource SmallTextButton}"}} into a {{Button.Style}} whose base style is {{SmallTextButton}}.
** [x] Add a {{Style.Triggers}} {{DataTrigger}} on {{Binding="{Binding NoNetworkMode, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}" Value="True"}} that sets {{IsEnabled="False"}}.
** [x] Add {{ToolTipService.ShowOnDisabled="True"}}.
** [x] Add a {{Button.ToolTip}} containing a {{ToolTip}} styled like Task 2 (collapsed by default, visible with content {{{x:Static w:Resources.InstallButtonNoNetworkModeToolTip}}} when {{PlacementTarget.IsEnabled}} is {{False}}).
* [x] Leave the {{Visibility="{Binding Path=ShowDownloadButton, Converter={StaticResource BoolToVis}}"}} binding intact — it remains the gate on whether the button is shown at all.

*Validation:*

* Launch Dynamo with {{--NoNetworkMode}}, open a graph that has missing package dependencies, switch to the Workspace References extension → {{Install Specified Version}} is disabled and hovers show the tooltip.
* Launch Dynamo normally → the button is enabled and clicking it still invokes {{DownloadPackage}} as before.

*Requirements from spec:*

* _We also need to disable install package button in workspace references extension and add tooltip._ (verbatim from ticket description)

*Files to Modify:*

* {{src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs}} — add {{NoNetworkMode}} property and constructor wiring.
* {{src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml}} — convert {{DownloadPackageButton}} to a {{Button.Style}}-driven disable + tooltip.

*Implementation Details:*
The button uses a {{Click}} event handler ({{DownloadPackage}}) rather than an {{ICommand}}, so there is no {{CanExecute}} path to hang the disabled state on. Binding to {{NoNetworkMode}} on the hosting {{UserControl}} via {{RelativeSource AncestorType=UserControl}} is the lightest viable touch and avoids introducing a DataContext-swapping change. Marking the setter {{private}} is fine — the value never changes after {{Loaded(...)}} returns.

----

h3. TASK 5: Add regression tests for the new strings and the extension wiring [MEDIUM PRIORITY]

*Status:* DONE
*Milestone:* NUnit tests cover (a) presence of both new resource strings and (b) propagation of {{StartupParams.NoNetworkMode}} into {{WorkspaceDependencyView.NoNetworkMode}}.

* [x] In {{test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUnitTests.cs}}:
** [x] Add {{using Dynamo.Wpf.Properties;}} if not already present.
** [x] Add {{[Test] public void WhenNoNetworkModeTooltipResourceRequestedThenItResolvesToNonEmpty()}} asserting {{!string.IsNullOrWhiteSpace(Resources.PackageManagerNoNetworkModeToolTip)}} with a one-line comment noting that the DynamoView.xaml {{PackageManagerMenu}} items depend on this key.
* [x] In {{test/DynamoCoreWpf2Tests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs}}:
** [x] Add {{[Test] public void WhenInstallButtonResourceStringRequestedThenItResolvesToNonEmpty()}} to the existing fixture, asserting {{!string.IsNullOrWhiteSpace(Resources.InstallButtonNoNetworkModeToolTip)}}.
** [x] Add a new {{[TestFixture] public class WorkspaceDependencyViewExtensionNoNetworkModeTests : DynamoTestUIBase}} that overrides {{CreateStartConfiguration}} to return a {{DefaultStartConfiguration}} with {{NoNetworkMode = true, StartInTestMode = true, ProcessMode = TaskProcessMode.Synchronous}}, etc.
** [x] In that fixture, add {{[Test] public void WhenNoNetworkModeThenWorkspaceReferencesInstallButtonIsDisabled()}} that raises the {{Loaded}} event, registers the extension, builds a {{ViewLoadedParams}}, calls {{viewExtension.Loaded(loadedParams)}}, and asserts {{viewExtension.DependencyView.NoNetworkMode}} is {{true}}. Comment briefly that this flag is what drives the button's {{IsEnabled}} trigger.

*Validation:*

{code:bash}dotnet test test/DynamoCoreWpf2Tests/DynamoCoreWpf2Tests.csproj --filter "Name~WhenNoNetworkMode|Name~WhenInstallButtonResource"{code}

All three new tests pass and no existing {{WorkspaceDependencyViewExtensionTests}} tests regress.

*Requirements from spec:*

* Guard against silent breakage of the new resource keys (Dynamo's localization tooling occasionally trims unused entries).
* Verify that the no-network startup flag actually flows into the extension view, which is the contract Task 4's XAML trigger depends on.

*Files to Modify:*

* {{test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUnitTests.cs}} — one new test method.
* {{test/DynamoCoreWpf2Tests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs}} — one new test method in the existing fixture, plus a new {{WorkspaceDependencyViewExtensionNoNetworkModeTests}} fixture.

*Implementation Details:*
{{DynamoTestUIBase.CreateStartConfiguration}} is the established hook for booting Dynamo with a non-default {{IStartConfiguration}} from a test fixture (other tests use the same pattern). Asserting the flag on {{DependencyView.NoNetworkMode}} is intentionally indirect — directly asserting the {{Button.IsEnabled}} state is brittle because WPF triggers do not fire until the visual tree is fully realized, which is not guaranteed in a headless NUnit run.

----

h2. Testing Strategy

h3. Unit Tests

* {{WhenNoNetworkModeTooltipResourceRequestedThenItResolvesToNonEmpty}} — {{PackageManagerNoNetworkModeToolTip}} resolves non-empty.
* {{WhenInstallButtonResourceStringRequestedThenItResolvesToNonEmpty}} — {{InstallButtonNoNetworkModeToolTip}} resolves non-empty.

h3. Integration Tests

* {{WhenNoNetworkModeThenWorkspaceReferencesInstallButtonIsDisabled}} — boots Dynamo with {{NoNetworkMode = true}} via {{DynamoTestUIBase.CreateStartConfiguration}}, registers {{WorkspaceDependencyViewExtension}}, invokes {{Loaded(loadedParams)}}, and verifies the extension view's {{NoNetworkMode}} property reflects the startup configuration.

h3. Manual Testing Steps

# Build the full solution: {{msbuild src/Dynamo.All.sln /p:Configuration=Release}}.
# Launch Dynamo with the no-network flag: {{DynamoSandbox.exe --NoNetworkMode}}.
# Open the {{Packages}} menu in the main toolbar; verify all three items ({{Publish Nodes}}, {{Publish Workspace}}, {{Show Package Manager}}) are disabled and hovering each shows {{Enable Network Mode to be able to use Package Manager.}}
# Create or open a custom-node workspace, right-click the canvas, verify the {{Publish}} context-menu item is disabled and hovers show the same tooltip.
# Open a graph with at least one missing package dependency. Open the Workspace References extension panel from the Extensions menu. Verify the {{Install Specified Version}} button is greyed out and that hovering shows {{Enable Network Mode to be able to install packages.}}
# Restart Dynamo without {{--NoNetworkMode}} and confirm none of the controls show a tooltip and all behave normally — the {{Install Specified Version}} button still invokes {{DownloadPackage}} when clicked.
# Edge case: open and close the Workspace References extension panel multiple times in no-network mode and confirm the disabled state and tooltip persist ({{NoNetworkMode}} is set in the constructor, not in a per-event handler).

h2. Performance Considerations

The pattern uses WPF data triggers that resolve at tooltip-open time and tooltip-realize time only — no per-frame cost. No additional event subscriptions, timers, or background work are introduced. Resource lookups happen once during XAML parsing.

h2. Migration Notes

No persisted data is affected. The new public {{NoNetworkMode}} property on {{WorkspaceDependencyView}} is additive (no removal or rename of existing members) and therefore does not require a {{PublicAPI.Unshipped.txt}} entry on the public API surface ({{WorkspaceDependencyView}} is not part of the public {{WorkspaceDependencyViewExtension}} API contract — only the {{WorkspaceDependencyViewExtension}} class itself is — but the property is {{public}} for XAML binding visibility). If a {{PublicAPI.Unshipped.txt}} exists for this assembly during review, add {{WorkspaceDependencyViewExtension.WorkspaceDependencyView.NoNetworkMode.get -> bool}} to be safe. The new resource keys are additions to existing {{.resx}} bundles and do not change any existing keys, so no breaking change is introduced.