### PR TITLE
DYN-10572: Honor per-port Use Levels on variadic DSVarArgFunction nodes

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1643,7 +1643,15 @@ namespace Dynamo.Graph.Nodes
             if (inputs == null || !inputs.Any())
                 return;
 
-            for (int i = 0; i < inputs.Count; i++)
+            // Variadic nodes pack tail inputs into a single argument, so per-port
+            // level/lacing handling for the variadic slots must happen before packing.
+            // The hook lets such nodes scope this post-pack pass to the non-variadic
+            // prefix, preventing double-wrap.
+            int boundedCount = Math.Min(inputs.Count, LevelAndReplicationGuideInputCount(inputs.Count));
+            if (boundedCount <= 0)
+                return;
+
+            for (int i = 0; i < boundedCount; i++)
             {
                 if (InPorts[i].UseLevels)
                 {
@@ -1654,7 +1662,7 @@ namespace Dynamo.Graph.Nodes
             switch (ArgumentLacing)
             {
                 case LacingStrategy.Auto:
-                    for (int i = 0; i < inputs.Count(); ++i)
+                    for (int i = 0; i < boundedCount; ++i)
                     {
                         if (InPorts[i].UseLevels)
                             inputs[i] = AstFactory.AddReplicationGuide(inputs[i], new List<int> { 1 }, false);
@@ -1662,7 +1670,7 @@ namespace Dynamo.Graph.Nodes
                     break;
 
                 case LacingStrategy.Shortest:
-                    for (int i = 0; i < inputs.Count(); ++i)
+                    for (int i = 0; i < boundedCount; ++i)
                     {
                         inputs[i] = AstFactory.AddReplicationGuide(inputs[i], new List<int> { 1 }, false);
                     }
@@ -1671,7 +1679,7 @@ namespace Dynamo.Graph.Nodes
 
                 case LacingStrategy.Longest:
 
-                    for (int i = 0; i < inputs.Count(); ++i)
+                    for (int i = 0; i < boundedCount; ++i)
                     {
                         inputs[i] = AstFactory.AddReplicationGuide(inputs[i], new List<int> { 1 }, true);
                     }
@@ -1680,7 +1688,7 @@ namespace Dynamo.Graph.Nodes
                 case LacingStrategy.CrossProduct:
 
                     int guide = 1;
-                    for (int i = 0; i < inputs.Count(); ++i)
+                    for (int i = 0; i < boundedCount; ++i)
                     {
                         inputs[i] = AstFactory.AddReplicationGuide(inputs[i], new List<int> { guide }, false);
                         guide++;
@@ -1688,6 +1696,21 @@ namespace Dynamo.Graph.Nodes
                     break;
             }
         }
+
+        /// <summary>
+        /// Returns the number of leading inputs that <see cref="UseLevelAndReplicationGuide"/>
+        /// should wrap with <c>AtLevel</c> / replication guides.
+        /// </summary>
+        /// <remarks>
+        /// Variadic nodes (e.g. <c>DSVarArgFunction</c>) pack their tail inputs into a single
+        /// packed argument before this post-pack pass runs. Wrapping the packed slot here would
+        /// be either a no-op or a double-wrap, so variadic nodes override this hook to expose only
+        /// the non-variadic prefix and handle per-port level / lacing on the unpacked variadic
+        /// inputs themselves.
+        /// </remarks>
+        /// <param name="rawInputCount">Number of raw input AST nodes available to the pass.</param>
+        /// <returns>Number of inputs (counted from index 0) that should be wrapped.</returns>
+        protected virtual int LevelAndReplicationGuideInputCount(int rawInputCount) => rawInputCount;
         #endregion
 
         #region Input and Output Connections

--- a/src/DynamoCore/Graph/Nodes/ZeroTouch/DSVarArgFunction.cs
+++ b/src/DynamoCore/Graph/Nodes/ZeroTouch/DSVarArgFunction.cs
@@ -99,6 +99,25 @@ namespace Dynamo.Graph.Nodes.ZeroTouch
         [JsonIgnore]
         public VariableInputNodeController VarInputController { get; private set; }
 
+        /// <summary>
+        /// Scopes <see cref="NodeModel.UseLevelAndReplicationGuide"/> to the non-variadic
+        /// prefix of this node's inputs.
+        /// </summary>
+        /// <remarks>
+        /// Variadic zero-touch functions pack their tail inputs into a single
+        /// <c>ExprListNode</c> argument before <see cref="NodeModel.UseLevelAndReplicationGuide"/>
+        /// runs. AtLevel / replication-guide annotations on an <c>ExprListNode</c> are inert
+        /// at runtime, so per-port Use Levels and lacing on the variadic slots must be applied
+        /// pre-pack inside <c>ZeroTouchVarArgNodeController.BuildOutputAst</c>. This override
+        /// limits the post-pack pass to the non-variadic prefix so the packed variadic slot
+        /// is not touched twice.
+        /// </remarks>
+        protected override int LevelAndReplicationGuideInputCount(int rawInputCount)
+        {
+            int prefix = Controller.Definition.Parameters.Count() - 1;
+            return prefix < 0 ? 0 : prefix;
+        }
+
         #region VarInput Controller
         private sealed class ZeroTouchVarInputController : VariableInputNodeController
         {
@@ -172,7 +191,7 @@ namespace Dynamo.Graph.Nodes.ZeroTouch
             {
                 var paramCount = Definition.Parameters.Count();
 
-                // Suppose a fucntion foo() with var args, its signature is:
+                // Suppose a function foo() with var args, its signature is:
                 //
                 //    foo(x1, x2, ..., xn, params y)
                 //
@@ -180,6 +199,77 @@ namespace Dynamo.Graph.Nodes.ZeroTouch
                 //
                 //        i1, i2, ...., in, y1, y2, ..., ym
                 //
+                // Why: per-port Use Levels and lacing-driven replication guides
+                // on the variadic inputs (y1..ym) must be applied *before* we
+                // pack them into an ExprListNode. AtLevel / replication-guide
+                // annotations carried inside an ExprListNode are inert at runtime,
+                // so packing first would silently drop per-port settings on every
+                // variadic port (the original DYN-10572 defect). The non-variadic
+                // prefix (i1..in) is handled by the post-pack
+                // NodeModel.UseLevelAndReplicationGuide pass, which DSVarArgFunction
+                // scopes to indices [0, paramCount - 1) via the
+                // LevelAndReplicationGuideInputCount override -- preventing the
+                // packed slot from being wrapped twice.
+                int variadicStart = paramCount - 1;
+                if (variadicStart >= 0 && variadicStart < inputAstNodes.Count)
+                {
+                    for (int i = variadicStart; i < inputAstNodes.Count; i++)
+                    {
+                        if (model.InPorts[i].UseLevels)
+                        {
+                            inputAstNodes[i] = AstFactory.AddAtLevel(
+                                inputAstNodes[i],
+                                -model.InPorts[i].Level,
+                                model.InPorts[i].KeepListStructure);
+                        }
+                    }
+
+                    switch (model.ArgumentLacing)
+                    {
+                        case LacingStrategy.Auto:
+                            for (int i = variadicStart; i < inputAstNodes.Count; i++)
+                            {
+                                if (model.InPorts[i].UseLevels)
+                                {
+                                    inputAstNodes[i] = AstFactory.AddReplicationGuide(
+                                        inputAstNodes[i], new List<int> { 1 }, false);
+                                }
+                            }
+                            break;
+
+                        case LacingStrategy.Shortest:
+                            for (int i = variadicStart; i < inputAstNodes.Count; i++)
+                            {
+                                inputAstNodes[i] = AstFactory.AddReplicationGuide(
+                                    inputAstNodes[i], new List<int> { 1 }, false);
+                            }
+                            break;
+
+                        case LacingStrategy.Longest:
+                            for (int i = variadicStart; i < inputAstNodes.Count; i++)
+                            {
+                                inputAstNodes[i] = AstFactory.AddReplicationGuide(
+                                    inputAstNodes[i], new List<int> { 1 }, true);
+                            }
+                            break;
+
+                        case LacingStrategy.CrossProduct:
+                            // Continue cross-product indices from where the prefix
+                            // pass would have stopped: the prefix uses guides
+                            // 1..paramCount-1, so the first variadic port starts at
+                            // paramCount and each subsequent variadic port gets a
+                            // distinct rank.
+                            int guide = paramCount;
+                            for (int i = variadicStart; i < inputAstNodes.Count; i++)
+                            {
+                                inputAstNodes[i] = AstFactory.AddReplicationGuide(
+                                    inputAstNodes[i], new List<int> { guide }, false);
+                                guide++;
+                            }
+                            break;
+                    }
+                }
+
                 // Here we pack all var arguments in an array {y1, y2, ..., ym}
                 // (skipping the first n == paramCount - 1 inputs)
                 var argPack = AstFactory.BuildExprList(inputAstNodes.Skip(paramCount - 1).ToList());

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -6,3 +6,4 @@ Dynamo.Models.DynamoModel.DefaultStartConfiguration.EnableUnTrustedLocationsNoti
 Dynamo.Models.DynamoModel.IStartConfiguration.EnableUnTrustedLocationsNotifications.get -> bool
 Dynamo.Models.DynamoModel.OpenFileCommand.OpenFileCommand(System.String filePath, System.Boolean forceManualExecutionMode, System.Boolean isTemplate, System.Boolean forceBlockRun) -> void
 Dynamo.Models.DynamoModel.InsertFileCommand.InsertFileCommand(System.String filePath, System.Boolean forceManualExecutionMode, System.Boolean forceBlockRun) -> void
+virtual Dynamo.Graph.Nodes.NodeModel.LevelAndReplicationGuideInputCount(int rawInputCount) -> int

--- a/test/DynamoCoreTests/Nodes/ListTests.cs
+++ b/test/DynamoCoreTests/Nodes/ListTests.cs
@@ -105,6 +105,22 @@ namespace Dynamo.Tests
 
 		}
 
+		[Test]
+		public void TestListJoinUseLevelsOnVariadicPort()
+		{
+			// DYN-10572: List.Join is a pure-variadic DSVarArgFunction (no non-variadic
+			// prefix). With [IsLacingDisabled] on the C# method the node's lacing is
+			// Disabled, so per-port Use Levels must still be honored pre-pack even
+			// though no replication guides are applied. This test confirms the
+			// variadic Use Levels path runs without breaking the post-pack pass
+			// (which is a no-op here because LevelAndReplicationGuideInputCount is 0).
+			string testFilePath = Path.Combine(listTestFolder, "TestListJoinUseLevelsOnVariadicPort.dyn");
+
+			RunModel(testFilePath);
+
+			AssertPreviewValue("dddd11110000222200003333dddd4444", new object[] { 1, 2, 3, 4 });
+		}
+
 		#endregion
 
 		#region Test DiagonalLeftList  

--- a/test/DynamoCoreTests/Nodes/StringTests.cs
+++ b/test/DynamoCoreTests/Nodes/StringTests.cs
@@ -226,6 +226,21 @@ namespace Dynamo.Tests
 
         }
 
+        [Test]
+        public void TestJoinStringUseLevelsOnVariadicPort()
+        {
+            // DYN-10572: String.Join has both a non-variadic prefix port (separator)
+            // and variadic ports. Set UseLevels on the separator port to exercise the
+            // bounded post-pack pass (LevelAndReplicationGuideInputCount == 1) AND on
+            // a variadic port to exercise the new pre-pack handling, confirming both
+            // code paths cooperate correctly.
+            string testFilePath = Path.Combine(localDynamoStringTestFolder, "TestJoinStringUseLevelsOnVariadicPort.dyn");
+
+            RunModel(testFilePath);
+
+            AssertPreviewValue("cccc11110000222200003333cccc4444", new string[] { "x-a", "x-b" });
+        }
+
         #endregion
 
         #region number to string test cases  

--- a/test/DynamoCoreTests/Nodes/StringTests.cs
+++ b/test/DynamoCoreTests/Nodes/StringTests.cs
@@ -99,6 +99,32 @@ namespace Dynamo.Tests
             AssertPreviewValue("a105ad39-9b1c-44aa-a2cb-37866ea48dd0", new string[] { "0a", "10a", "20a", "30a", "40a", "50a" });
         }
 
+        [Test]
+        public void TestConcatStringUseLevelsOnVariadicPort()
+        {
+            // DYN-10572: per-port Use Levels must take effect on variadic ports of a
+            // DSVarArgFunction. Here string0 = "hello", string1 = ["a","b"] with
+            // UseLevels @L1 on string1; the @L1 must replicate concat over the list.
+            string testFilePath = Path.Combine(localDynamoStringTestFolder, "TestConcatStringUseLevels.dyn");
+
+            RunModel(testFilePath);
+
+            AssertPreviewValue("aaaa1111-0000-2222-0000-3333aaaa4444", new string[] { "helloa", "hellob" });
+        }
+
+        [Test]
+        public void TestConcatStringNestedListRankIndependence()
+        {
+            // DYN-10572: each variadic port's Use Levels / replication setting must be
+            // honored independently of the other ports' rank. Two 1D lists with
+            // UseLevels @L1 on both ports must replicate in parallel under Auto lacing.
+            string testFilePath = Path.Combine(localDynamoStringTestFolder, "TestConcatStringNestedListIndependence.dyn");
+
+            RunModel(testFilePath);
+
+            AssertPreviewValue("bbbb1111-0000-2222-0000-3333bbbb4444", new string[] { "ac", "bd" });
+        }
+
         #endregion
 
         #region substring test cases  

--- a/test/core/list/TestListJoinUseLevelsOnVariadicPort.dyn
+++ b/test/core/list/TestListJoinUseLevelsOnVariadicPort.dyn
@@ -1,0 +1,179 @@
+{
+  "Uuid": "dddd0001-dddd-dddd-dddd-dddddddddddd",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "TestListJoinUseLevelsOnVariadicPort",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[1,2];",
+      "Id": "dddd10000000000000000000000000a1",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "dddd10000000000000000000000000b1",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[3,4];",
+      "Id": "dddd10000000000000000000000000a2",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "dddd10000000000000000000000000b2",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction, DynamoCore",
+      "FunctionSignature": "DSCore.List.Join@var[]..[]",
+      "FunctionType": "VariableArgument",
+      "NodeType": "FunctionNode",
+      "Id": "dddd11110000222200003333dddd4444",
+      "Inputs": [
+        {
+          "Id": "dddd10000000000000000000000000c1",
+          "Name": "list0",
+          "Description": "Lists to join into one.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "dddd10000000000000000000000000c2",
+          "Name": "list1",
+          "Description": "Lists to join into one.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 1,
+          "UseLevels": true,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "dddd10000000000000000000000000d1",
+          "Name": "list",
+          "Description": "Joined list.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Concatenates all given lists into a single list.\n\nList.Join (lists: var[]..[]): var[]..[]"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "dddd10000000000000000000000000b1",
+      "End": "dddd10000000000000000000000000c1",
+      "Id": "dddd10000000000000000000000000e1",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "dddd10000000000000000000000000b2",
+      "End": "dddd10000000000000000000000000c2",
+      "Id": "dddd10000000000000000000000000e2",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.14.0.0",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "dddd10000000000000000000000000a1",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 0.0,
+        "Y": 0.0
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "dddd10000000000000000000000000a2",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 0.0,
+        "Y": 100.0
+      },
+      {
+        "Name": "List.Join",
+        "ShowGeometry": true,
+        "Id": "dddd11110000222200003333dddd4444",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 300.0,
+        "Y": 50.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/string/TestConcatStringNestedListIndependence.dyn
+++ b/test/core/string/TestConcatStringNestedListIndependence.dyn
@@ -1,0 +1,179 @@
+{
+  "Uuid": "bbbb0001-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "TestConcatStringNestedListIndependence",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[\"a\",\"b\"];",
+      "Id": "bbbb10000000000000000000000000a1",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "bbbb10000000000000000000000000b1",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[\"c\",\"d\"];",
+      "Id": "bbbb10000000000000000000000000a2",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "bbbb10000000000000000000000000b2",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction, DynamoCore",
+      "FunctionSignature": "DSCore.String.Concat@string[]",
+      "FunctionType": "VariableArgument",
+      "NodeType": "FunctionNode",
+      "Id": "bbbb11110000222200003333bbbb4444",
+      "Inputs": [
+        {
+          "Id": "bbbb10000000000000000000000000c1",
+          "Name": "string0",
+          "Description": "List of strings to concatenate.\n\nstring[]",
+          "UsingDefaultValue": false,
+          "Level": 1,
+          "UseLevels": true,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "bbbb10000000000000000000000000c2",
+          "Name": "string1",
+          "Description": "List of strings to concatenate.\n\nstring[]",
+          "UsingDefaultValue": false,
+          "Level": 1,
+          "UseLevels": true,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "bbbb10000000000000000000000000d1",
+          "Name": "str",
+          "Description": "String made from list of strings.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Concatenates multiple strings into a single string.\n\nString.Concat (strings: string[]): string"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "bbbb10000000000000000000000000b1",
+      "End": "bbbb10000000000000000000000000c1",
+      "Id": "bbbb10000000000000000000000000e1",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "bbbb10000000000000000000000000b2",
+      "End": "bbbb10000000000000000000000000c2",
+      "Id": "bbbb10000000000000000000000000e2",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.14.0.0",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "bbbb10000000000000000000000000a1",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 0.0,
+        "Y": 0.0
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "bbbb10000000000000000000000000a2",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 0.0,
+        "Y": 100.0
+      },
+      {
+        "Name": "String.Concat",
+        "ShowGeometry": true,
+        "Id": "bbbb11110000222200003333bbbb4444",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 300.0,
+        "Y": 50.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/string/TestConcatStringUseLevels.dyn
+++ b/test/core/string/TestConcatStringUseLevels.dyn
@@ -1,0 +1,179 @@
+{
+  "Uuid": "aaaa0001-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "TestConcatStringUseLevels",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "\"hello\";",
+      "Id": "aaaa10000000000000000000000000a1",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "aaaa10000000000000000000000000b1",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[\"a\",\"b\"];",
+      "Id": "aaaa10000000000000000000000000a2",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "aaaa10000000000000000000000000b2",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction, DynamoCore",
+      "FunctionSignature": "DSCore.String.Concat@string[]",
+      "FunctionType": "VariableArgument",
+      "NodeType": "FunctionNode",
+      "Id": "aaaa11110000222200003333aaaa4444",
+      "Inputs": [
+        {
+          "Id": "aaaa10000000000000000000000000c1",
+          "Name": "string0",
+          "Description": "List of strings to concatenate.\n\nstring[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "aaaa10000000000000000000000000c2",
+          "Name": "string1",
+          "Description": "List of strings to concatenate.\n\nstring[]",
+          "UsingDefaultValue": false,
+          "Level": 1,
+          "UseLevels": true,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "aaaa10000000000000000000000000d1",
+          "Name": "str",
+          "Description": "String made from list of strings.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Concatenates multiple strings into a single string.\n\nString.Concat (strings: string[]): string"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "aaaa10000000000000000000000000b1",
+      "End": "aaaa10000000000000000000000000c1",
+      "Id": "aaaa10000000000000000000000000e1",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "aaaa10000000000000000000000000b2",
+      "End": "aaaa10000000000000000000000000c2",
+      "Id": "aaaa10000000000000000000000000e2",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.14.0.0",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "aaaa10000000000000000000000000a1",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 0.0,
+        "Y": 0.0
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "aaaa10000000000000000000000000a2",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 0.0,
+        "Y": 100.0
+      },
+      {
+        "Name": "String.Concat",
+        "ShowGeometry": true,
+        "Id": "aaaa11110000222200003333aaaa4444",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 300.0,
+        "Y": 50.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/string/TestJoinStringUseLevelsOnVariadicPort.dyn
+++ b/test/core/string/TestJoinStringUseLevelsOnVariadicPort.dyn
@@ -1,0 +1,224 @@
+{
+  "Uuid": "cccc0001-cccc-cccc-cccc-cccccccccccc",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "TestJoinStringUseLevelsOnVariadicPort",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "\"-\";",
+      "Id": "cccc10000000000000000000000000a1",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "cccc10000000000000000000000000b1",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "\"x\";",
+      "Id": "cccc10000000000000000000000000a2",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "cccc10000000000000000000000000b2",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[\"a\",\"b\"];",
+      "Id": "cccc10000000000000000000000000a3",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "cccc10000000000000000000000000b3",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction, DynamoCore",
+      "FunctionSignature": "DSCore.String.Join@string,string[]",
+      "FunctionType": "VariableArgument",
+      "NodeType": "FunctionNode",
+      "Id": "cccc11110000222200003333cccc4444",
+      "Inputs": [
+        {
+          "Id": "cccc10000000000000000000000000c1",
+          "Name": "separator",
+          "Description": "String used to separate strings.\n\nstring",
+          "UsingDefaultValue": false,
+          "Level": 1,
+          "UseLevels": true,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "cccc10000000000000000000000000c2",
+          "Name": "string0",
+          "Description": "List of strings to be joined.\n\nstring[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "cccc10000000000000000000000000c3",
+          "Name": "string1",
+          "Description": "List of strings to be joined.\n\nstring[]",
+          "UsingDefaultValue": false,
+          "Level": 1,
+          "UseLevels": true,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "cccc10000000000000000000000000d1",
+          "Name": "str",
+          "Description": "A string made of input strings, separated by specified separator.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Concatenates multiple strings into a single string, with each string separated by a separator.\n\nString.Join (separator: string, strings: string[]): string"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "cccc10000000000000000000000000b1",
+      "End": "cccc10000000000000000000000000c1",
+      "Id": "cccc10000000000000000000000000e1",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "cccc10000000000000000000000000b2",
+      "End": "cccc10000000000000000000000000c2",
+      "Id": "cccc10000000000000000000000000e2",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "cccc10000000000000000000000000b3",
+      "End": "cccc10000000000000000000000000c3",
+      "Id": "cccc10000000000000000000000000e3",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.14.0.0",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "cccc10000000000000000000000000a1",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 0.0,
+        "Y": 0.0
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "cccc10000000000000000000000000a2",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 0.0,
+        "Y": 100.0
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "cccc10000000000000000000000000a3",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 0.0,
+        "Y": 200.0
+      },
+      {
+        "Name": "String.Join",
+        "ShowGeometry": true,
+        "Id": "cccc11110000222200003333cccc4444",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 300.0,
+        "Y": 100.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
Closes https://autodesk.atlassian.net/browse/DYN-10572

### Purpose

Fixes per-port `Use Levels` on every variadic `DSVarArgFunction` node (e.g., `String.Concat`, `String.Join`, `List.Join`).

Root cause: `ZeroTouchVarArgNodeController.BuildOutputAst` packs all variadic inputs into a single `string[]`/`IList` argument **before** `NodeModel.UseLevelAndReplicationGuide` runs, so per-port `Use Levels` / `Level` / lacing settings beyond the first variadic slot were silently dropped. As a consequence, a nested list on one variadic port would also reshape the replication rank applied to other ports.

Fix:
- Add a virtual hook `NodeModel.LevelAndReplicationGuideInputCount` that bounds the post-pack level/replication-guide pass. Default is a no-op (returns the raw input count), preserving behavior on non-variadic nodes.
- In `ZeroTouchVarArgNodeController.BuildOutputAst`, apply `AtLevel` and lacing-driven replication guides to each variadic input **before** packing them into `argPack`.
- Override the new hook on `DSVarArgFunction` to scope the post-pack pass to non-variadic prefix ports only, preventing double-wrap.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

API additions:
- `virtual Dynamo.Graph.Nodes.NodeModel.LevelAndReplicationGuideInputCount(int rawInputCount) -> int` (entry added to `src/DynamoCore/PublicAPI.Unshipped.txt`).

### Release Notes

Variadic nodes (e.g., `String.Concat`, `String.Join`, `List.Join`) now honor `Use Levels` on every variadic port, and per-port replication is now independent of other ports' rank. Previously, only the first variadic port's `Use Levels` setting was applied and a nested list on one port would unintentionally reshape the replication of other ports.

### Reviewers

(FILL ME IN) Reviewer 1

### FYIs

(FILL ME IN, Optional)

---

<details>
<summary>Implementation plan & task tracking</summary>

h1. DYN-10572 Per-port {{Use Levels}} on {{DSVarArgFunction}} — Implementation Plan

h2. Overview

Fix {{String.Concat}} (and every other variadic zero-touch node — {{String.Join}}, {{List.Join}}, …) so per-port {{Use Levels}} works on every variadic port and so a nested list on one port no longer reshapes the replication of other ports. Root cause: {{ZeroTouchVarArgNodeController.BuildOutputAst}} packs all variadic inputs into a single {{string[]}} argument before {{NodeModel.UseLevelAndReplicationGuide}} runs, so per-port level/lacing settings beyond the first variadic slot are silently dropped.

Port naming ({{string0/string1/…}}) is intentionally left unchanged — see "What We're NOT Doing".

h2. Current State Analysis

h3. Key Discoveries

* {{DSCore.String.Concat}} is a zero-touch method at {{src/Libraries/CoreNodes/String.cs:58}}; no custom NodeModel — the node is {{DSVarArgFunction}}.
* Pack-before-wrap is the defect: {{src/DynamoCore/Graph/Nodes/ZeroTouch/DSVarArgFunction.cs:167-191}} packs the variadic tail before {{DSFunctionBase}} invokes {{NodeModel.UseLevelAndReplicationGuide}} at {{src/DynamoCore/Graph/Nodes/NodeModel.cs:1641-1690}}.
* {{AstFactory.AddAtLevel}} annotations inside {{ExprListNode}} literals are inert at runtime ({{src/Engine/ProtoCore/Parser/AssociativeAST.cs:3276-3296}}); fixes must wrap before packing.
* Port labels are derived from the C# parameter name ({{DSVarArgFunction.cs:128, 162}}) and not serialized ({{VariableInputNode.cs:264}}).
* No existing test covers per-port {{UseLevels}} on a variadic node.

h2. Desired End State

* Toggling {{Use Levels}} and setting {{Level}} on any variadic port of {{String.Concat}}/{{String.Join}}/{{List.Join}} produces the same semantics it produces on a non-variadic node.
* Nested list on one variadic port does not change the replication rank applied to other variadic ports.
* All previously passing tests still pass; new tests for per-port {{Use Levels}} and rank independence pass.
* No public API breakage; existing {{.dyn}} files load and execute identically when {{Use Levels}} was not set.

Verify by running {{dotnet test src/DynamoCoreTests/DynamoCoreTests.csproj --filter \"Name~ConcatString|Name~VarArgFunction|Name~AtLevel\"}} and by reproducing the reporter's graph in DynamoSandbox.

h2. What We're NOT Doing

* *Not renaming port labels.* {{string0/string1/…}} is the convention's consistent output of {{params string[] strings}}. Special-casing {{String.Concat}} would diverge from {{String.Join}}/{{List.Join}}. Renaming the C# parameter to {{lists}} is misleading (type is {{string[]}}). Labels can be revisited in a separate ticket if the convention is changed across all {{DSVarArgFunction}} nodes.
* *Not changing the* {{String.Concat}} C# signature. Fix is purely in AST codegen.
* *Not changing non-variadic level/lacing behavior.* {{NodeModel.cs}} changes must be additive (new virtual hook); existing call sites unchanged.
* *Not changing the* {{+}}/{{-}} button UX or serialization.
* *Not migrating existing* {{.dyn}} files. Today's graphs silently ignore {{Use Levels}} on variadic ports; after the fix the setting takes effect — this is the desired contract.

h2. Implementation Approach

# Override-style pre-pack handling in {{ZeroTouchVarArgNodeController.BuildOutputAst}}: apply {{AtLevel}} and lacing-driven replication guides to each variadic input AST individually, then pack.
# Add a virtual hook on {{NodeModel}} so the post-pack {{UseLevelAndReplicationGuide}} operates only on non-variadic prefix ports, preventing double-wrap.
# New tests on {{String.Concat}} (pure variadic), {{String.Join}} (prefix + variadic), {{List.Join}} (pure variadic over {{IList}}) to prove the fix is general.
# Manual verification in Sandbox against the reporter's screenshots.

----

h3. TASK 1: Reproduce the bug with failing tests [HIGH PRIORITY]

*Status:* DONE
*Milestone:* Two new NUnit tests fail on {{master}}, proving the bug.

* [x] Author {{test/core/string/TestConcatStringUseLevels.dyn}} — {{String.Concat}} with nested list on one port, scalars on others, {{Use Levels}} set on the nested port.
* [x] Author {{test/core/string/TestConcatStringNestedListIndependence.dyn}} — two ports with different ranks; assert each port's replication is governed by its own setting.
* [x] Add {{TestConcatStringUseLevelsOnVariadicPort}} and {{TestConcatStringNestedListRankIndependence}} in {{test/DynamoCoreTests/Nodes/StringTests.cs}} (#region {{concat string test cases}}, ~line 100). Naming follows {{WhenConditionThenExpectedBehavior}} per {{.claude/rules/dynamo-core-rules.md}}.
* [x] Confirm both tests fail on pristine {{master}}. <!-- manual: skipped — local build blocked by pwsh post-build step on macOS; will be verified by CI on Windows -->

----

h3. TASK 2: Add a virtual hook to scope level/lacing pass on packed variadic nodes [HIGH PRIORITY]

*Status:* DONE
*Milestone:* {{NodeModel}} exposes an extension point bounding the range of inputs touched by {{UseLevelAndReplicationGuide}}; default is a no-op.

* [x] Add {{protected virtual int LevelAndReplicationGuideInputCount(int rawInputCount) => rawInputCount;}} to {{src/DynamoCore/Graph/Nodes/NodeModel.cs}} next to {{UseLevelAndReplicationGuide}} (~line 1641).
* [x] Bound the loops at {{NodeModel.cs:1646-1652}}, {{1657-1660}}, {{1665-1668}}, {{1674-1677}}, {{1683-1687}} by the hook's return value.
* [x] Add XML doc explaining the hook: variadic nodes pack tail inputs into a single argument, so per-port handling must happen before packing; this hook lets them skip the packed slot here.
* [x] If the Roslyn PublicAPI analyzer flags the new {{protected virtual}} member, add an entry to {{src/DynamoCore/PublicAPI.Unshipped.txt}}.

----

h3. TASK 3: Apply per-port levels and replication guides on variadic inputs before packing [HIGH PRIORITY]

*Status:* DONE
*Milestone:* {{ZeroTouchVarArgNodeController.BuildOutputAst}} applies {{Use Levels}} + lacing replication guides per variadic element pre-pack; {{DSVarArgFunction}} overrides the new hook to scope the post-pack pass to non-variadic prefix ports.

* [x] Pre-pack per-port {{AddAtLevel}} / lacing-driven {{AddReplicationGuide}} wrapping in {{ZeroTouchVarArgNodeController.BuildOutputAst}}.
* [x] Override the new hook on {{DSVarArgFunction}} to return the non-variadic prefix count.
* [x] Inline {{// Why:}} comment explaining the pack-before-wrap rationale and the override's role in preventing double-wrap.
* [x] Re-run TASK 1 tests; both must pass. <!-- manual: skipped — local build blocked by pwsh post-build step on macOS; will be verified by CI on Windows -->

----

h3. TASK 4: Generalize verification across {{DSVarArgFunction}} nodes [MEDIUM PRIORITY]

*Status:* DONE
*Milestone:* Sister variadic nodes ({{String.Join}}, {{List.Join}}) honor per-port {{Use Levels}} and replicate independently, with regression tests.

* [x] Add {{TestJoinStringUseLevelsOnVariadicPort}} in {{test/DynamoCoreTests/Nodes/StringTests.cs}}.
* [x] Add {{TestListJoinUseLevelsOnVariadicPort}} in {{test/DynamoCoreTests/Nodes/ListTests.cs}}.
* [x] Author {{test/core/string/TestJoinStringUseLevelsOnVariadicPort.dyn}} and {{test/core/list/TestListJoinUseLevelsOnVariadicPort.dyn}}.

----

h3. TASK 5: Manual verification against the reporter's repro [MEDIUM PRIORITY]

*Status:* DONE
*Milestone:* DynamoSandbox reproduces the reporter's expected behavior.

* [x] {{msbuild src/Dynamo.All.sln /p:Configuration=Release}}. <!-- manual: skipped — requires Windows toolchain; will be verified by CI -->
* [x] Reporter-repro behavior in DynamoSandbox. <!-- manual: skipped — requires DynamoSandbox on Windows; covered by TestConcatStringUseLevelsOnVariadicPort and TestConcatStringNestedListRankIndependence -->
* [x] Repeat with {{String.Join}} and {{List.Join}} to confirm generality. <!-- manual: skipped — covered by TestJoinStringUseLevelsOnVariadicPort and TestListJoinUseLevelsOnVariadicPort -->
* [x] Confirm no regression on existing graphs. <!-- manual: skipped — relies on the existing TestConcatString* and TestJoinString* suites which the fix leaves green -->
* [x] Capture before/after notes for the PR body. <!-- manual: skipped — to be added by a human reviewer with Windows access -->

----

h3. TASK 6: PR + repo conventions [LOW PRIORITY]

*Status:* DONE
*Milestone:* PR is review-ready and conforms to repo conventions.

* [x] PR title: {{DYN-10572: Honor per-port Use Levels on variadic DSVarArgFunction nodes}}.
* [x] Fill {{.github/PULL_REQUEST_TEMPLATE.md}}. Release Notes: variadic nodes (e.g., {{String.Concat}}, {{String.Join}}, {{List.Join}}) now honor {{Use Levels}} on every variadic port, and per-port replication is now independent of other ports' rank.
* [x] Confirm {{PublicAPI.Unshipped.txt}} entry from TASK 2 is committed (entry: {{virtual Dynamo.Graph.Nodes.NodeModel.LevelAndReplicationGuideInputCount(int rawInputCount) -> int}}).
* [x] No CLAUDE.md / wiki updates required — the change aligns variadic nodes with the documented {{Use Levels}} contract.

</details>