### PR TITLE
DynamoDS/DYN-10516: Dynamo Home: refresh Templates and Recent Files from disk dynamically

### DIFF
--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -1,5 +1,7 @@
 using Dynamo.Configuration;
 using Dynamo.Logging;
+using Dynamo.Models;
+using Dynamo.UI.Prompts;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Properties;
@@ -673,6 +675,31 @@ namespace Dynamo.UI.Controls
         private void HandleFilePath(StartPageListItem item)
         {
             var path = item.ContextData;
+
+            if (!DynamoUtilities.PathHelper.IsValidPath(path))
+            {
+                if (IsTemplateFilePath(path))
+                {
+                    RefreshTemplates();
+                }
+                else
+                {
+                    this.DynamoViewModel.TryRemoveRecentFile(path);
+                }
+
+                if (!DynamoModel.IsTestMode)
+                {
+                    DynamoMessageBox.Show(
+                        this.DynamoViewModel.Owner,
+                        string.Format(Resources.HomeFileNoLongerExistsAtPath, path),
+                        Resources.HomeFileNoLongerExistsAtPathTitle,
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Warning);
+                }
+
+                return;
+            }
+
             // Listed templates: use the same open path as the template file-picker (ShowOpenTemplateDialog),
             // i.e. open as a new graph from the file contents, not as the saved template path on disk.
             object openArg = IsTemplateFilePath(path)

--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -216,7 +216,7 @@ namespace Dynamo.UI.Controls
             var dvm = this.DynamoViewModel;
             RefreshRecentFileList(dvm.RecentFiles, true);
             RefreshBackupFileList(dvm.Model.PreferenceSettings.BackupFiles);
-            LoadTemplates();
+            LoadTemplatesFromDisk(clearFirst: false);
             dvm.RecentFiles.CollectionChanged += OnRecentFilesChanged;
 
 
@@ -225,7 +225,26 @@ namespace Dynamo.UI.Controls
 
         private void LoadTemplates()
         {
-            // Retrieve the current Temlates location from Dynamo properties
+            LoadTemplatesFromDisk(clearFirst: false);
+        }
+
+        /// <summary>
+        /// Re-reads the templates directory from disk and refreshes
+        /// <see cref="TemplateFiles"/>. Safe to call multiple times.
+        /// </summary>
+        internal void RefreshTemplates()
+        {
+            LoadTemplatesFromDisk(clearFirst: true);
+        }
+
+        private void LoadTemplatesFromDisk(bool clearFirst)
+        {
+            if (clearFirst)
+            {
+                templateFiles.Clear();
+            }
+
+            // Retrieve the current Templates location from Dynamo properties
             var templatesDirectory = DynamoViewModel.Model.PathManager.TemplatesDirectory;
 
             if (Directory.Exists(templatesDirectory))

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3911,6 +3911,25 @@ namespace Dynamo.Wpf.Properties {
                 return ResourceManager.GetString("HideClassicNodeLibrary", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This file no longer exists at the following location and will be removed from your list.
+        ///{0}.
+        /// </summary>
+        public static string HomeFileNoLongerExistsAtPath {
+            get {
+                return ResourceManager.GetString("HomeFileNoLongerExistsAtPath", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to File Not Found.
+        /// </summary>
+        public static string HomeFileNoLongerExistsAtPathTitle {
+            get {
+                return ResourceManager.GetString("HomeFileNoLongerExistsAtPathTitle", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Hide Wires.

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1099,6 +1099,15 @@ Failed to publish file(s):
   <data name="GroupContextMenuUngroup" xml:space="preserve">
     <value>Ungr_oup</value>
   </data>
+  <data name="HomeFileNoLongerExistsAtPath" xml:space="preserve">
+    <value>This file no longer exists at the following location and will be removed from your list.
+{0}</value>
+    <comment>Home page | Shown when the user clicks a Templates/Recent Files tile whose file has been deleted. {0} is the missing file path.</comment>
+  </data>
+  <data name="HomeFileNoLongerExistsAtPathTitle" xml:space="preserve">
+    <value>File Not Found</value>
+    <comment>Home page | Title of the dialog shown when a Templates/Recent Files tile points at a missing file.</comment>
+  </data>
   <data name="HideClassicNodeLibrary" xml:space="preserve">
     <value>Hide Classic Node Library</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1197,6 +1197,15 @@ Don't worry, you'll have the option to save your work.</value>
   <data name="FilePathConverterNoFileSelected" xml:space="preserve">
     <value>No file selected.</value>
   </data>
+  <data name="HomeFileNoLongerExistsAtPath" xml:space="preserve">
+    <value>This file no longer exists at the following location and will be removed from your list.
+{0}</value>
+    <comment>Home page | Shown when the user clicks a Templates/Recent Files tile whose file has been deleted. {0} is the missing file path.</comment>
+  </data>
+  <data name="HomeFileNoLongerExistsAtPathTitle" xml:space="preserve">
+    <value>File Not Found</value>
+    <comment>Home page | Title of the dialog shown when a Templates/Recent Files tile points at a missing file.</comment>
+  </data>
   <data name="HideClassicNodeLibrary" xml:space="preserve">
     <value>Hide Classic Node Library</value>
   </data>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -595,6 +595,41 @@ namespace Dynamo.ViewModels
             }
         }
 
+        /// <summary>
+        /// Removes entries from <see cref="RecentFiles"/> whose underlying file no
+        /// longer exists on disk. Existing <see cref="ObservableCollection{T}.CollectionChanged"/>
+        /// subscribers propagate the changes (e.g. the Home view's WebView).
+        /// </summary>
+        internal void PruneInvalidRecentFiles()
+        {
+            if (recentFiles == null || recentFiles.Count == 0)
+            {
+                return;
+            }
+
+            var invalid = recentFiles.Where(p => !PathHelper.IsValidPath(p)).ToList();
+            foreach (var path in invalid)
+            {
+                recentFiles.Remove(path);
+            }
+        }
+
+        /// <summary>
+        /// Removes a single entry from <see cref="RecentFiles"/>. Used to surgically
+        /// drop a stale entry without re-scanning the whole list.
+        /// </summary>
+        /// <param name="path">The recent-file path to remove.</param>
+        /// <returns>True if the entry was present and removed; otherwise false.</returns>
+        internal bool TryRemoveRecentFile(string path)
+        {
+            if (string.IsNullOrEmpty(path) || recentFiles == null)
+            {
+                return false;
+            }
+
+            return recentFiles.Remove(path);
+        }
+
         public bool WatchIsResizable { get; set; }
 
         public string Version

--- a/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
+++ b/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
@@ -64,6 +64,8 @@ namespace Dynamo.UI.Views
 
         private bool _disposed = false;
 
+        private bool templateSubscribed = false;
+
         /// <summary>
         /// A helper tool to let us test flows without relying on side-effects
         /// </summary>
@@ -286,6 +288,12 @@ namespace Dynamo.UI.Views
             _ = LoadGraphs(recentFiles);
         }
 
+        private void TemplateFiles_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            var templateFiles = startPage.TemplateFiles?.DistinctBy(x => x.ContextData).ToList();
+            _ = LoadTemplates(templateFiles);
+        }
+
         #region FrontEnd Initialization Calls
         /// <summary>
         /// Sends graph data to react app
@@ -342,6 +350,12 @@ namespace Dynamo.UI.Views
             if (items != null && items.Any())
             {
                 await LoadTemplates(items);
+            }
+
+            if (!templateSubscribed && startPage.TemplateFiles != null)
+            {
+                startPage.TemplateFiles.CollectionChanged += TemplateFiles_CollectionChanged;
+                templateSubscribed = true;
             }
         }
 
@@ -761,6 +775,12 @@ namespace Dynamo.UI.Views
                             {
                                 startPage.DynamoViewModel.RecentFiles.CollectionChanged -= RecentFiles_CollectionChanged;
                             }
+                        }
+
+                        if (templateSubscribed && startPage.TemplateFiles != null)
+                        {
+                            startPage.TemplateFiles.CollectionChanged -= TemplateFiles_CollectionChanged;
+                            templateSubscribed = false;
                         }
                     }
 

--- a/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
+++ b/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
@@ -15,6 +15,7 @@ using System.Windows.Controls;
 using Autodesk.DesignScript.Runtime;
 using Dynamo.Models;
 using Dynamo.UI.Controls;
+using Dynamo.UI.Prompts;
 using Dynamo.Utilities;
 using Dynamo.Wpf.UI.GuidedTour;
 using Dynamo.Wpf.Utilities;
@@ -65,6 +66,8 @@ namespace Dynamo.UI.Views
         private bool _disposed = false;
 
         private bool templateSubscribed = false;
+
+        private bool? lastShowStartPage;
 
         /// <summary>
         /// A helper tool to let us test flows without relying on side-effects
@@ -130,7 +133,16 @@ namespace Dynamo.UI.Views
         {
             if(e.PropertyName == nameof(startPage.DynamoViewModel.ShowStartPage) && dynWebView?.CoreWebView2 != null)
             {
-                dynWebView.CoreWebView2.ExecuteScriptAsync(@$"window.setShowStartPageChanged('{startPage.DynamoViewModel.ShowStartPage}')");
+                var showStartPage = startPage.DynamoViewModel.ShowStartPage;
+                dynWebView.CoreWebView2.ExecuteScriptAsync(@$"window.setShowStartPageChanged('{showStartPage}')");
+
+                if (showStartPage && lastShowStartPage != true)
+                {
+                    startPage.RefreshTemplates();
+                    startPage.DynamoViewModel.PruneInvalidRecentFiles();
+                }
+
+                lastShowStartPage = showStartPage;
             }
         }
 
@@ -550,6 +562,13 @@ namespace Dynamo.UI.Views
         internal void OpenFile(string path)
         {
             if (String.IsNullOrEmpty(path)) return;
+
+            if (!PathHelper.IsValidPath(path))
+            {
+                HandleMissingFile(path);
+                return;
+            }
+
             if (DynamoModel.IsTestMode)
             {
                 TestHook?.Invoke(path);
@@ -564,6 +583,36 @@ namespace Dynamo.UI.Views
             {
                 dvm.OpenCommand.Execute(openArg);
             }
+        }
+
+        /// <summary>
+        /// Drops the stale entry (template or recent file) and notifies the user
+        /// that the underlying file no longer exists. Invoked from <see cref="OpenFile"/>
+        /// before <see cref="DynamoViewModel.OpenCommand"/> is reached, so the
+        /// side-effecting modal dialog inside <c>CanOpen</c> is never triggered from
+        /// the WebView2 host-object thread.
+        /// </summary>
+        internal void HandleMissingFile(string path)
+        {
+            if (startPage == null) return;
+
+            if (IsListedHomePageTemplate(path))
+            {
+                startPage.RefreshTemplates();
+            }
+            else
+            {
+                startPage.DynamoViewModel.TryRemoveRecentFile(path);
+            }
+
+            if (DynamoModel.IsTestMode) return;
+
+            DynamoMessageBox.Show(
+                startPage.DynamoViewModel.Owner,
+                string.Format(Wpf.Properties.Resources.HomeFileNoLongerExistsAtPath, path),
+                Wpf.Properties.Resources.HomeFileNoLongerExistsAtPathTitle,
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
         }
 
         private bool IsListedHomePageTemplate(string path)

--- a/test/DynamoCoreWpf3Tests/WorkspaceOpeningTests.cs
+++ b/test/DynamoCoreWpf3Tests/WorkspaceOpeningTests.cs
@@ -1,9 +1,12 @@
 using System;
 using System.IO;
+using System.Linq;
+using Dynamo.Configuration;
 using Dynamo.Events;
 using Dynamo.Graph;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
+using Dynamo.ViewModels;
 
 using NUnit.Framework;
 
@@ -187,6 +190,137 @@ namespace Dynamo.Tests
             // See QNTM-2839 and OpeningWorksapceWithManualRunState test above
             ViewModel.OpenCommand.Execute(openParams);
             return ViewModel.Model.CurrentWorkspace;
+        }
+
+        [Test]
+        public void PruneInvalidRecentFilesRemovesMissingPathsWhenInvoked()
+        {
+            // Arrange
+            var validPath = Path.Combine(SampleDirectory, @"en-US\Basics\Basics_Basic01.dyn");
+            var missingPath = Path.Combine(TempFolder, "definitely-not-on-disk.dyn");
+            ViewModel.RecentFiles.Clear();
+            ViewModel.RecentFiles.Add(validPath);
+            ViewModel.RecentFiles.Add(missingPath);
+
+            // Act
+            ViewModel.PruneInvalidRecentFiles();
+
+            // Assert
+            Assert.AreEqual(1, ViewModel.RecentFiles.Count);
+            Assert.AreEqual(validPath, ViewModel.RecentFiles[0]);
+        }
+
+        [Test]
+        public void PruneInvalidRecentFilesPreservesValidPathsWhenAllValid()
+        {
+            // Arrange
+            var first = Path.Combine(SampleDirectory, @"en-US\Basics\Basics_Basic01.dyn");
+            var second = Path.Combine(SampleDirectory, @"en-US\Basics\Basics_Basic02.dyn");
+            ViewModel.RecentFiles.Clear();
+            ViewModel.RecentFiles.Add(first);
+            ViewModel.RecentFiles.Add(second);
+
+            // Act
+            ViewModel.PruneInvalidRecentFiles();
+
+            // Assert
+            Assert.AreEqual(2, ViewModel.RecentFiles.Count);
+            CollectionAssert.AreEqual(new[] { first, second }, ViewModel.RecentFiles);
+        }
+
+        [Test]
+        public void TryRemoveRecentFileReturnsTrueWhenEntryExists()
+        {
+            // Arrange
+            var path = Path.Combine(TempFolder, "anything.dyn");
+            ViewModel.RecentFiles.Clear();
+            ViewModel.RecentFiles.Add(path);
+
+            // Act
+            var removed = ViewModel.TryRemoveRecentFile(path);
+
+            // Assert
+            Assert.IsTrue(removed);
+            Assert.IsEmpty(ViewModel.RecentFiles);
+        }
+
+        [Test]
+        public void TryRemoveRecentFileReturnsFalseWhenEntryMissing()
+        {
+            // Arrange
+            ViewModel.RecentFiles.Clear();
+
+            // Act
+            var removed = ViewModel.TryRemoveRecentFile(Path.Combine(TempFolder, "missing.dyn"));
+
+            // Assert
+            Assert.IsFalse(removed);
+        }
+
+        [Test]
+        public void RefreshTemplatesPicksUpNewlyAddedTemplateWhenInvokedAfterAdd()
+        {
+            // Arrange
+            var templatesDir = Path.Combine(TempFolder, "templates-add-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(templatesDir);
+            try
+            {
+                ViewModel.Model.UpdatePreferenceItemLocation(
+                    PathManager.PreferenceItem.Templates, templatesDir);
+
+                var startPage = new StartPageViewModel(ViewModel, isFirstRun: true);
+                Assert.AreEqual(0, startPage.TemplateFiles.Count, "Sanity: empty templates dir starts with zero items.");
+
+                var newTemplate = Path.Combine(templatesDir, "NewTemplate.dyn");
+                File.WriteAllText(newTemplate, "{}");
+
+                // Act
+                startPage.RefreshTemplates();
+
+                // Assert
+                Assert.AreEqual(1, startPage.TemplateFiles.Count);
+                Assert.AreEqual(newTemplate, startPage.TemplateFiles[0].ContextData);
+            }
+            finally
+            {
+                if (Directory.Exists(templatesDir))
+                {
+                    Directory.Delete(templatesDir, recursive: true);
+                }
+            }
+        }
+
+        [Test]
+        public void RefreshTemplatesDropsDeletedTemplateWhenInvokedAfterDelete()
+        {
+            // Arrange
+            var templatesDir = Path.Combine(TempFolder, "templates-delete-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(templatesDir);
+            var templatePath = Path.Combine(templatesDir, "DoomedTemplate.dyn");
+            File.WriteAllText(templatePath, "{}");
+            try
+            {
+                ViewModel.Model.UpdatePreferenceItemLocation(
+                    PathManager.PreferenceItem.Templates, templatesDir);
+
+                var startPage = new StartPageViewModel(ViewModel, isFirstRun: true);
+                Assert.AreEqual(1, startPage.TemplateFiles.Count, "Sanity: template loaded on construction.");
+
+                File.Delete(templatePath);
+
+                // Act
+                startPage.RefreshTemplates();
+
+                // Assert
+                Assert.AreEqual(0, startPage.TemplateFiles.Count);
+            }
+            finally
+            {
+                if (Directory.Exists(templatesDir))
+                {
+                    Directory.Delete(templatesDir, recursive: true);
+                }
+            }
         }
     }
 }

--- a/test/DynamoCoreWpfTests/HomePageTests.cs
+++ b/test/DynamoCoreWpfTests/HomePageTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Dynamo.Controls;
@@ -53,6 +54,73 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(homePage.RequestShowSampleDatasetsInFolder);
             Assert.IsNotNull(homePage.RequestShowBackupFilesInFolder);
             Assert.IsNotNull(homePage.RequestShowTemplate);
+        }
+
+        [Test]
+        public void OpenFileWithMissingPathDoesNotInvokeTestHook()
+        {
+            // Arrange
+            var vm = View.DataContext as DynamoViewModel;
+            var startPage = new StartPageViewModel(vm, true);
+            var homePage = new HomePage { DataContext = startPage };
+            var missingPath = Path.Combine(Path.GetTempPath(), "definitely-missing-" + Guid.NewGuid().ToString("N") + ".dyn");
+
+            var testHookInvoked = false;
+            HomePage.TestHook = (_) => testHookInvoked = true;
+
+            // Act
+            homePage.OpenFile(missingPath);
+
+            // Assert
+            Assert.IsFalse(testHookInvoked, "TestHook (proxy for OpenCommand) must not run when the path is invalid.");
+
+            // Clean up
+            HomePage.TestHook = null;
+        }
+
+        [Test]
+        public void OpenFileWithMissingRecentFilePathRemovesItFromRecentFiles()
+        {
+            // Arrange
+            var vm = View.DataContext as DynamoViewModel;
+            var startPage = new StartPageViewModel(vm, true);
+            var homePage = new HomePage { DataContext = startPage };
+            var missingPath = Path.Combine(Path.GetTempPath(), "stale-recent-" + Guid.NewGuid().ToString("N") + ".dyn");
+
+            vm.RecentFiles.Clear();
+            vm.RecentFiles.Add(missingPath);
+            HomePage.TestHook = null;
+
+            // Act
+            homePage.OpenFile(missingPath);
+
+            // Assert
+            CollectionAssert.DoesNotContain(vm.RecentFiles, missingPath);
+        }
+
+        [Test]
+        public void HandleMissingFileWithListedTemplateRefreshesTemplatesInsteadOfRecentFiles()
+        {
+            // Arrange
+            var vm = View.DataContext as DynamoViewModel;
+            var startPage = new StartPageViewModel(vm, true);
+            var homePage = new HomePage { DataContext = startPage };
+            var ghostTemplate = Path.Combine(Path.GetTempPath(), "ghost-template-" + Guid.NewGuid().ToString("N") + ".dyn");
+
+            // Inject a fake template entry so the missing path is treated as a template, not a recent file.
+            startPage.TemplateFiles.Add(new StartPageListItem("Ghost Template") { ContextData = ghostTemplate });
+            vm.RecentFiles.Clear();
+            vm.RecentFiles.Add(ghostTemplate);
+
+            // Act
+            homePage.HandleMissingFile(ghostTemplate);
+
+            // Assert
+            // Template path: RecentFiles should be untouched (no surgical remove); RefreshTemplates clears the fake.
+            Assert.IsFalse(startPage.TemplateFiles.Any(t => t.ContextData == ghostTemplate),
+                "RefreshTemplates should clear the stale template entry.");
+            CollectionAssert.Contains(vm.RecentFiles, ghostTemplate,
+                "Template-path branch must not touch RecentFiles.");
         }
 
         [Test]


### PR DESCRIPTION
Closes https://autodesk.atlassian.net/browse/DYN-10516

h1. Home — Refresh Templates and Recent Files Implementation Plan

h2. Overview

Make the Dynamo Home screen's Templates and Recent Files lists refresh from disk every time the Home view becomes visible (e.g., after a user closes a workspace), and fix the misleading warning + hang triggered by clicking a tile whose file has been deleted. Pure on-show refresh — no file system watchers, per the agreed scope.

h2. Current State Analysis

h3. Key Discoveries

* HomePage is created once and toggled via {{Visibility}} bound to {{DynamoViewModel.ShowStartPage}} ({{src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs:1556-1583}}); natural refresh hook is the existing {{HomePage.DynamoViewModel_PropertyChanged}} ({{src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs:127-133}}).
* {{StartPageViewModel.LoadTemplates()}} ({{StartPage.xaml.cs:226-254}}) does *not* clear {{templateFiles}} — the refresh method must.
* {{DynamoViewModel.RecentFiles}} is an ObservableCollection<string> ({{DynamoViewModel.cs:588-595}}); HomePage already subscribes to its {{CollectionChanged}} ({{HomePage.xaml.cs:283-287, 372}}), so mutating it auto-pushes to the WebView. {{TemplateFiles}} lacks such a subscription — add one.
* {{DynamoViewModel.CanOpen}} ({{DynamoViewModel.cs:2379-2399}}) pops a side-effecting modal dialog with archive-flavored text; from a WebView2 host-object callback that nested pump causes the hang. Pre-validating in the caller skips this path entirely.
* {{PathHelper.IsValidPath}} ({{src/DynamoUtilities/PathHelper.cs:64-67}}) is the canonical check — reuse it.
* Legacy {{StartPageView}} is dead-in-production ({{DynamoView.IsNewAppHomeEnabled}} always true at {{DynamoView.xaml.cs:2948-2954}}) but the same bug lives in {{StartPage.HandleFilePath}} — fix in parallel.

h2. Desired End State

* Closing a workspace and returning to Home re-reads {{PathManager.TemplatesDirectory}}; new templates appear, deleted templates disappear.
* Same trip prunes {{DynamoViewModel.RecentFiles}} of entries whose file no longer exists; the Home view updates in the same frame via the existing {{CollectionChanged}} push.
* Clicking a missing-file tile shows "This file no longer exists at the following location and will be removed from your list." (no archive language), removes the offending entry, re-renders Home, and does not hang.
* Manual repro from the ticket no longer reproduces; new NUnit tests cover the refresh/prune/click paths.

h2. What We're NOT Doing

* No live {{FileSystemWatcher}} (explicitly out of scope).
* No general refactor of {{CanOpen}} to remove its side-effecting dialog — scoped fix at the Home-screen callers only.
* No templates-folder schema/location changes; no sub-folder template support (current code is root-only).
* No HomePage instantiation re-architecture — it stays toggle-visibility.
* No JS / DynamoHome frontend changes — reuse existing {{window.receiveTemplatesDataFromDotNet}} / {{window.receiveGraphDataFromDotNet}} channels.
* No new analytics events.

h2. Implementation Approach

Three small layered changes:

# *Refresh APIs + resource strings:* add {{RefreshTemplates()}} on {{StartPageViewModel}}, {{PruneInvalidRecentFiles()}} + {{TryRemoveRecentFile()}} on {{DynamoViewModel}}, and new "File Not Found" resx entries.
# *Auto-push wiring:* subscribe to {{TemplateFiles.CollectionChanged}} in {{HomePage}} (mirroring the RecentFiles wiring) so collection changes flow to the WebView automatically.
# *Trigger + click fix:* in {{HomePage.DynamoViewModel_PropertyChanged}}, call the refresh APIs when {{ShowStartPage}} flips to true; in {{HomePage.OpenFile}} and {{StartPage.HandleFilePath}}, pre-validate the path — on miss show the new dialog, drop the stale entry, return early (avoids the {{CanOpen}} side-effect and removes the hang).

----

h3. TASK 1: Add refresh APIs and missing-file resource strings [HIGH PRIORITY]

*Status:* DONE
*Milestone:* Pure-logic refresh + prune methods exist, are unit-tested; new localized message strings are available.

* [x] Factor {{StartPageViewModel.LoadTemplates()}} body into a reusable helper that takes a {{clearFirst}} flag (ctor passes {{false}}, {{RefreshTemplates}} passes {{true}}).
* [x] Add {{internal void RefreshTemplates()}} on {{StartPageViewModel}}.
* [x] Add {{internal void PruneInvalidRecentFiles()}} on {{DynamoViewModel}}: {{RecentFiles.Where(p => !PathHelper.IsValidPath(p)).ToList()}} then {{Remove}} each (existing {{CollectionChanged}} listeners propagate).
* [x] Add {{internal bool TryRemoveRecentFile(string path)}} for surgical removal in the click handler.
* [x] Add resource entries in {{src/DynamoCoreWpf/Properties/Resources.en-US.resx}}:
** {{HomeFileNoLongerExistsAtPath}} = "This file no longer exists at the following location and will be removed from your list.\n{0}"
** {{HomeFileNoLongerExistsAtPathTitle}} = "File Not Found"
* [x] Keep new APIs {{internal}} (no {{PublicAPI.Unshipped.txt}} change). If any go public, add entries.

*Validation:* Tests in Task 4 pass; {{DynamoCoreWpf}} builds with the new resx entries.

*Requirements from spec:*

* "Refresh the Home Templates list when the Home view (re)instantiates..."
* "Same treatment for Recent Files."
* "Fix the hang when a missing file/template is clicked, and improve the warning message." (resource side; wiring in Task 3.)

*Files to Modify:*

* {{src/DynamoCoreWpf/Controls/StartPage.xaml.cs}}
* {{src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs}}
* {{src/DynamoCoreWpf/Properties/Resources.en-US.resx}} (Designer.cs regenerates)

*Implementation Details:*

* {{LoadTemplates()}} currently does not clear {{templateFiles}}; refactor as {{private void LoadTemplatesFromDisk(bool clearFirst)}}.
* {{PruneInvalidRecentFiles}} must run on the UI thread (called from a WebView2 callback) — listeners run synchronously on the calling thread.
* Reuse {{DynamoUtilities.PathHelper.IsValidPath}}.

----

h3. TASK 2: Wire HomePage to auto-push template-collection changes [HIGH PRIORITY]

*Status:* DONE
*Milestone:* Mutating {{StartPageViewModel.TemplateFiles}} updates the WebView's templates list without an explicit caller-side {{SendTemplateData()}}.

* [x] In {{HomePage.SendTemplateData()}} (or a helper called from {{LoadingDone}}), subscribe {{startPage.TemplateFiles.CollectionChanged += TemplateFiles_CollectionChanged;}} after the initial push (mirror RecentFiles at {{HomePage.xaml.cs:370-373}}).
* [x] Add {{private void TemplateFiles_CollectionChanged(...)}} that calls {{_ = LoadTemplates(startPage.TemplateFiles?.DistinctBy(x => x.ContextData).ToList())}}.
* [x] Unsubscribe in {{HomePage.Dispose(bool)}} (lines 747-782).
* [x] Guard against double-subscription with a {{bool templateSubscribed}} flag in case {{LoadingDone}} runs more than once.

*Validation:* Manual breakpoint confirms WebView receives updates on collection mutation; {{dotnet test src/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj --filter "Name~HomePage"}} passes.

*Requirements from spec:* Required scaffolding for Task 3.

*Files to Modify:* {{src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs}}

*Implementation Details:* Follow exact shape of {{RecentFiles_CollectionChanged}} (line 283) and its subscribe/unsubscribe sites for consistency. Handler ignores {{e.Action}}, rebuilds whole list.

----

h3. TASK 3: Refresh on Home-view show + fix missing-file click [HIGH PRIORITY]

*Status:* DONE
*Milestone:* Ticket repro no longer reproduces. Templates/Recent Files reflect on-disk state after returning to Home. Clicking a missing tile shows a clear message, removes the item, and does not hang Dynamo.

* [x] Extend {{HomePage.DynamoViewModel_PropertyChanged}} ({{HomePage.xaml.cs:127-133}}): when {{e.PropertyName == nameof(ShowStartPage)}} AND the new value is {{true}}, call {{startPage.RefreshTemplates()}} and {{startPage.DynamoViewModel.PruneInvalidRecentFiles()}}. Keep the existing {{setShowStartPageChanged}} JS call.
* [x] Track previous {{ShowStartPage}} in a private field to avoid redundant refreshes if the setter fires when the value is unchanged.
* [x] In {{HomePage.OpenFile}} ({{HomePage.xaml.cs:536-553}}), *before* computing {{openArg}}, add a pre-validate block: if {{!PathHelper.IsValidPath(path)}}, drop the stale entry ({{RefreshTemplates()}} if it's a template, else {{TryRemoveRecentFile(path)}}), then {{DynamoMessageBox.Show(startPage.DynamoViewModel.Owner, string.Format(WpfResources.HomeFileNoLongerExistsAtPath, path), WpfResources.HomeFileNoLongerExistsAtPathTitle, MessageBoxButton.OK, MessageBoxImage.Warning)}} and {{return}}. Apply this *before* the {{IsTestMode}} early return so tests can exercise it (or extract to an internal helper invoked from tests directly).
* [x] Make the same pre-validate change in {{StartPage.HandleFilePath}} ({{StartPage.xaml.cs:654-666}}) for legacy parity.
* [x] Default to no batching; if {{Clear()}} + bulk {{Add()}} causes WebView flicker, batch by temporarily detaching {{TemplateFiles_CollectionChanged}}, refreshing, reattaching, and firing one final push.

*Validation:*

* Manual: follow the ticket repro — delete a template via Explorer, click the now-missing tile. Expected: clear "File Not Found" dialog, no archive language, no hang, tile disappears.
* Manual: open a workspace, close it back to Home; newly-added .dyn appears.
* Manual: open + save a workspace, delete the file via Explorer, close back to Home; Recent Files no longer lists it.
* Automated tests added in Task 4 pass.

*Requirements from spec:* All three bullets under "Scope".

*Files to Modify:*

* {{src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs}}
* {{src/DynamoCoreWpf/Controls/StartPage.xaml.cs}}

*Implementation Details:*

* Pre-validate skips {{OpenCommand.CanExecute}}, so the side-effecting modal in {{CanOpen}} is never invoked from the WebView2 host-object thread — removes the hang. Do *not* modify {{CanOpen}} itself; other call sites (File menu, ShowOpenDialog) keep current behavior.
* Use {{DynamoMessageBox.Show(Owner, ...)}} (same pattern as {{CanOpen}}).
* The {{ShowStartPage = true}} → refresh trigger covers both repro scenarios (workspace close, Home button click) because all paths flow through that setter.

----

h3. TASK 4: Tests [MEDIUM PRIORITY]

*Status:* DONE
*Milestone:* Test coverage protects refresh/prune/click behaviors against regression.

* [x] In {{test/DynamoCoreWpf3Tests/WorkspaceOpeningTests.cs}}:
** {{PruneInvalidRecentFilesRemovesMissingPathsWhenInvoked}}
** {{PruneInvalidRecentFilesPreservesValidPathsWhenAllValid}}
** {{TryRemoveRecentFileReturnsTrueWhenEntryExists}}
** {{TryRemoveRecentFileReturnsFalseWhenEntryMissing}}
** {{RefreshTemplatesPicksUpNewlyAddedTemplateWhenInvokedAfterAdd}}
** {{RefreshTemplatesDropsDeletedTemplateWhenInvokedAfterDelete}}
** Template tests use {{Model.UpdatePreferenceItemLocation(PathManager.PreferenceItem.Templates, ...)}} to redirect to an isolated {{TempFolder}} subdirectory, then write/delete {{.dyn}} files there.
* [x] In {{test/DynamoCoreWpfTests/HomePageTests.cs}}:
** {{OpenFileWithMissingPathDoesNotInvokeTestHook}} — assert {{TestHook}} (proxy for {{OpenCommand}}) is not invoked when the path is missing.
** {{OpenFileWithMissingRecentFilePathRemovesItFromRecentFiles}} — assert the stale recent-file entry is pruned via {{TryRemoveRecentFile}}.
** {{HandleMissingFileWithListedTemplateRefreshesTemplatesInsteadOfRecentFiles}} — assert the template branch refreshes templates and leaves {{RecentFiles}} untouched.
* [x] NUnit conventions: {{WhenConditionThenExpectedBehavior}} naming, AAA structure, one behavior per test, no {{[Ignore]}}/{{[Explicit]}}.

*Validation:*

* {{dotnet test src/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj --filter "Name~HomePage"}} passes.
* {{dotnet test src/DynamoCoreWpf3Tests/DynamoCoreWpfTests3.csproj --filter "Name~RefreshTemplates|Name~PruneInvalidRecentFiles"}} passes.

*Files to Modify:*

* {{test/DynamoCoreWpf3Tests/WorkspaceOpeningTests.cs}}
* {{test/DynamoCoreWpfTests/HomePageTests.cs}}

*Implementation Details:* The pre-validate in {{HomePage.OpenFile}} runs *before* the {{IsTestMode}} short-circuit, so {{TestHook}} not being invoked is the observable signal of the missing-path branch. Template-branch coverage drives {{HandleMissingFile}} directly with an injected fake {{TemplateFiles}} entry. The {{DynamoViewModel_PropertyChanged}} flow is guarded by {{dynWebView?.CoreWebView2 != null}} and is therefore covered by the existing manual-test plan rather than a unit test (the underlying {{RefreshTemplates}}/{{PruneInvalidRecentFiles}} methods are independently covered in {{WorkspaceOpeningTests}}).

----

h2. Testing Strategy

h3. Unit Tests

* {{PruneInvalidRecentFiles}} with mixed valid/invalid inputs.
* {{RefreshTemplates}} against a temp templates directory (add/remove scenarios).
* {{PathHelper.IsValidPath}} already covered — no duplication.

h3. Integration Tests

* Existing {{WorkspaceOpeningTests}} exercising {{OpenCommand}} continue to pass (the change is at the caller, not {{OpenCommand}}).
* Existing {{HomePageTests.ShowTemplateCommandFromHomePage}} ({{HomePageTests.cs:486}}) continues to pass.

h3. Manual Testing Steps

# Build ({{msbuild src/Dynamo.All.sln /p:Configuration=Release}}), launch sandbox.
# Verify Home → Templates section is populated.
# With Dynamo running, drop a new {{.dyn}} into the templates folder; open a workspace; close it. New template appears on Home.
# With Dynamo running, delete a template via Explorer; open a workspace; close it. Deleted template disappears.
# Repeat (4) but click the tile BEFORE refresh: expect "File Not Found" dialog, tile auto-removed, no hang.
# Save a graph, open it, close it; delete the file via Explorer; navigate back to Home; confirm Recent Files no longer lists it.
# Repeat (6) click flow before refresh: expect "File Not Found" dialog, auto-removal, no hang.
# Confirm no regression on the trust-warning path for valid template opens.

h2. Performance Considerations

* {{RefreshTemplates}} re-reads {{TemplatesDirectory}} and deserializes each {{.dyn}} via {{GetFileProperties}} ({{StartPage.xaml.cs:684-703}}). Template count is small (single digits); negligible UI-thread cost.
* {{PruneInvalidRecentFiles}} is O(n) with {{n ≤ MaxNumRecentFiles}} (default 10).
* {{Clear()}} + bulk {{Add()}} on {{TemplateFiles}} fires multiple {{CollectionChanged}} events; for ≤10 templates the resulting ≤11 WebView pushes are invisible. Add batching only if observable flicker shows up.

h2. Migration Notes

* No persisted-data schema changes; {{PreferenceSettings.RecentFiles}} and templates folder location unchanged.
* New resource strings flow through the standard {{master-localization}} translation pipeline; implementation does not require translations to land first.
* No public-API additions if new methods stay {{internal}}. If any are made public, append to {{src/DynamoCoreWpf/PublicAPI.Unshipped.txt}}.

