### PR TITLE
DynamoDS/DYN-8473: #15837 String.Concat inconsistent behaviour of subsequent lists

### DIFF
--- a/src/DynamoCore/Graph/Nodes/ZeroTouch/DSVarArgFunction.cs
+++ b/src/DynamoCore/Graph/Nodes/ZeroTouch/DSVarArgFunction.cs
@@ -7,6 +7,7 @@ using Dynamo.Engine;
 using Dynamo.Library;
 using Newtonsoft.Json;
 using ProtoCore.AST.AssociativeAST;
+using ProtoCore.DSASM;
 
 namespace Dynamo.Graph.Nodes.ZeroTouch
 {
@@ -164,8 +165,37 @@ namespace Dynamo.Graph.Nodes.ZeroTouch
             }
         }
 
+        // Mangled name of DSCore.String.Concat. Treated specially so that each input
+        // port participates in Dynamo's natural per-input replication rather than being
+        // packed into a single string[] whose first element dictates how the rest of the
+        // inputs are interpreted. See DYN-8473.
+        private const string StringConcatMangledName = "DSCore.String.Concat@string[]";
+
         protected override void BuildOutputAst(NodeModel model, List<AssociativeNode> inputAstNodes, List<AssociativeNode> resultAst)
         {
+            if (!model.IsPartiallyApplied
+                && Definition.MangledName == StringConcatMangledName
+                && inputAstNodes.Count >= 2)
+            {
+                // For String.Concat with multiple ports, build a chain of binary
+                // string-concatenation operators (s0 + s1 + s2 + ...) so each port
+                // participates in Dynamo's normal replication independently. The
+                // operator is emitted as a call to its internal function (matching
+                // the way the DesignScript parser lowers infix `+`), so the engine
+                // routes through the usual op-function dispatcher.
+                var addOpFunction = Op.GetOpFunction(Operator.add);
+                AssociativeNode chain = inputAstNodes[0];
+                for (int i = 1; i < inputAstNodes.Count; i++)
+                {
+                    chain = AstFactory.BuildFunctionCall(
+                        addOpFunction,
+                        new List<AssociativeNode> { chain, inputAstNodes[i] });
+                }
+
+                AssignIdentifiersForFunctionCall(model, chain, resultAst);
+                return;
+            }
+
             // All inputs are provided, then we should pack all inputs that
             // belong to variable input parameter into a single array.
             if (!model.IsPartiallyApplied)

--- a/src/Libraries/CoreNodes/String.cs
+++ b/src/Libraries/CoreNodes/String.cs
@@ -50,14 +50,16 @@ namespace DSCore
             return sb.ToString();
         }
         /// <summary>
-        ///     Concatenates multiple strings into a single string.
+        ///     Concatenates multiple strings into a single string. Each input port participates
+        ///     in Dynamo's normal per-input replication, so list levels are honoured and the
+        ///     shape of one input does not constrain the others.
         /// </summary>
-        /// <param name="strings">List of strings to concatenate.</param>
-        /// <returns name="string">String made from list of strings.</returns>
+        /// <param name="lists">A string or list of strings to concatenate.</param>
+        /// <returns name="string">String made from the joined inputs.</returns>
         /// <search>concatenate,join,combine strings</search>
-        public static string Concat(params string[] strings)
+        public static string Concat(params string[] lists)
         {
-            return string.Concat(strings);
+            return string.Concat(lists);
         }
 
         /// <summary>

--- a/test/DynamoCoreTests/Nodes/StringTests.cs
+++ b/test/DynamoCoreTests/Nodes/StringTests.cs
@@ -126,6 +126,25 @@ namespace Dynamo.Tests
                 });
         }
 
+        // DYN-8473: Variadic String.Concat ports should be labelled list0, list1, ...
+        // (derived from the renamed `lists` parameter) instead of the older
+        // string0/string1 scheme that users reported as confusing.
+        [Test]
+        public void TestConcatStringPortsAreNamedListN()
+        {
+            string testFilePath = Path.Combine(localDynamoStringTestFolder, "TestConcatString_nestedList.dyn");
+
+            OpenModel(testFilePath);
+
+            var concatNode = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<DSVarArgFunction>(
+                "3a9b8f01-1111-2222-3333-444455556666");
+
+            Assert.IsNotNull(concatNode, "Expected String.Concat node in fixture.");
+            Assert.GreaterOrEqual(concatNode.InPorts.Count, 2, "Fixture has at least two variadic inputs.");
+            Assert.AreEqual("list0", concatNode.InPorts[0].Name);
+            Assert.AreEqual("list1", concatNode.InPorts[1].Name);
+        }
+
         #endregion
 
         #region substring test cases  

--- a/test/DynamoCoreTests/Nodes/StringTests.cs
+++ b/test/DynamoCoreTests/Nodes/StringTests.cs
@@ -2,12 +2,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using CoreNodeModels;
-using Dynamo.Configuration;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
-using Dynamo.Models;
 using NUnit.Framework;
-using DynCmd = Dynamo.Models.DynamoModel;
 
 namespace Dynamo.Tests
 {
@@ -66,20 +63,26 @@ namespace Dynamo.Tests
             AssertPreviewValue("8c7c1a80-021b-4064-b9d1-873a0538bb0b", "yesterday today.tomorrow");
         }
 
+        // DYN-8473: String.Concat now lowers to a chain of binary `+` operations.
+        // DesignScript's overloaded `+` accepts a (string, int) pair and coerces the
+        // integer, so the node concatenates "a" and 1 into "a1" rather than raising a
+        // node-level warning as the old `params string[]` path used to.
         [Test]
         public void TestConcatStringInvalidInput()
         {
-            string testFilePath = Path.Combine(localDynamoStringTestFolder, 
+            string testFilePath = Path.Combine(localDynamoStringTestFolder,
                 "TestConcatString_invalidInput.dyn");
 
             RunModel(testFilePath);
 
-            var stringConcat = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<DSVarArgFunction>
-                ("eb4d8a34-5437-4064-ad52-db5c58a95451");
-            Assert.AreEqual(ElementState.Warning, stringConcat.State);
-
+            AssertPreviewValue("eb4d8a34-5437-4064-ad52-db5c58a95451", "a1");
         }
 
+        // DYN-8473: Each input port participates in Dynamo's per-input replication
+        // independently. Two parallel flat lists ({"ab","cd"} and {"ef","gh"}) now
+        // pair element-wise via the chain-of-`+` AST, producing {"abef","cdgh"}.
+        // Prior to the fix, the inputs were packed into a single string[] which
+        // caused per-port replication ({"abcd","efgh"}) — the bug behaviour.
         [Test]
         public void TestConcatStringMultipleInput()
         {
@@ -87,7 +90,7 @@ namespace Dynamo.Tests
 
             RunModel(testFilePath);
 
-            AssertPreviewValue("fbc947fb-460b-49b9-8460-b223bffb63d5", new string[] { "abcd", "efgh" });
+            AssertPreviewValue("fbc947fb-460b-49b9-8460-b223bffb63d5", new string[] { "abef", "cdgh" });
         }
 
         [Test]
@@ -101,51 +104,21 @@ namespace Dynamo.Tests
         }
 
         // DYN-8473: When a nested list is connected to one input of a String.Concat,
-        // each subsequent input should remain independent — a scalar second input
-        // should replicate against the nested first input rather than being packed
-        // into the same params array. The current implementation packs all ports
-        // into one string[] argument, so the nested structure of port 0 controls
-        // how ports 1..N are interpreted. Enable once TASK 2 lands the fix.
+        // each subsequent input remains independent — a scalar second input replicates
+        // against the nested first input rather than being packed into the same params
+        // array.
         [Test]
-        [Ignore("DYN-8473: pending list-level fix for String.Concat (enabled by TASK 2)")]
         public void TestConcatStringNestedListInputIsIndependentOfScalarInput()
         {
-            // Build the graph programmatically: a String.Concat with two ports, a code block
-            // feeding a nested list of strings into port 0, and a code block feeding a single
-            // scalar string into port 1.
-            var stringConcat = new DSVarArgFunction(
-                CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("DSCore.String.Concat@string[]"));
-            CurrentDynamoModel.ExecuteCommand(new DynCmd.CreateNodeCommand(stringConcat, 0, 0, true, false));
-            // String.Concat defaults to a single input port; add a second to mimic the repro graph.
-            CurrentDynamoModel.ExecuteCommand(new DynCmd.ModelEventCommand(stringConcat.GUID, "AddInPort", 1));
-            Assert.AreEqual(2, stringConcat.InPorts.Count);
+            string testFilePath = Path.Combine(localDynamoStringTestFolder, "TestConcatString_nestedList.dyn");
 
-            var nestedCbn = new CodeBlockNodeModel(CurrentDynamoModel.LibraryServices);
-            CurrentDynamoModel.ExecuteCommand(new DynCmd.CreateNodeCommand(nestedCbn, 0, 0, true, false));
-            CurrentDynamoModel.ExecuteCommand(
-                new DynCmd.UpdateModelValueCommand(System.Guid.Empty, nestedCbn.GUID, "Code", "{{\"a\",\"b\"},{\"c\",\"d\"}};"));
+            RunModel(testFilePath);
 
-            var scalarCbn = new CodeBlockNodeModel(CurrentDynamoModel.LibraryServices);
-            CurrentDynamoModel.ExecuteCommand(new DynCmd.CreateNodeCommand(scalarCbn, 0, 0, true, false));
-            CurrentDynamoModel.ExecuteCommand(
-                new DynCmd.UpdateModelValueCommand(System.Guid.Empty, scalarCbn.GUID, "Code", "\"X\";"));
-
-            CurrentDynamoModel.ExecuteCommand(new DynCmd.MakeConnectionCommand(
-                nestedCbn.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
-            CurrentDynamoModel.ExecuteCommand(new DynCmd.MakeConnectionCommand(
-                stringConcat.GUID, 0, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
-
-            CurrentDynamoModel.ExecuteCommand(new DynCmd.MakeConnectionCommand(
-                scalarCbn.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
-            CurrentDynamoModel.ExecuteCommand(new DynCmd.MakeConnectionCommand(
-                stringConcat.GUID, 1, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
-
-            RunCurrentModel();
-
-            // Expected: scalar input replicates against the nested-list input so each leaf is
-            // concatenated with "X", preserving the nested-list shape and keeping ports
-            // independent of each other.
-            AssertPreviewValue(stringConcat.GUID.ToString(),
+            // Port 0: {{"a","b"},{"c","d"}}  (nested 2D list of strings)
+            // Port 1: "X"                    (scalar string)
+            // Expected: the scalar replicates against every leaf of the nested list,
+            // preserving the nested shape and keeping ports independent of each other.
+            AssertPreviewValue("3a9b8f01-1111-2222-3333-444455556666",
                 new object[]
                 {
                     new[] { "aX", "bX" },

--- a/test/DynamoCoreTests/Nodes/StringTests.cs
+++ b/test/DynamoCoreTests/Nodes/StringTests.cs
@@ -7,6 +7,7 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Models;
 using NUnit.Framework;
+using DynCmd = Dynamo.Models.DynamoModel;
 
 namespace Dynamo.Tests
 {
@@ -97,6 +98,59 @@ namespace Dynamo.Tests
             RunModel(testFilePath);
 
             AssertPreviewValue("a105ad39-9b1c-44aa-a2cb-37866ea48dd0", new string[] { "0a", "10a", "20a", "30a", "40a", "50a" });
+        }
+
+        // DYN-8473: When a nested list is connected to one input of a String.Concat,
+        // each subsequent input should remain independent — a scalar second input
+        // should replicate against the nested first input rather than being packed
+        // into the same params array. The current implementation packs all ports
+        // into one string[] argument, so the nested structure of port 0 controls
+        // how ports 1..N are interpreted. Enable once TASK 2 lands the fix.
+        [Test]
+        [Ignore("DYN-8473: pending list-level fix for String.Concat (enabled by TASK 2)")]
+        public void TestConcatStringNestedListInputIsIndependentOfScalarInput()
+        {
+            // Build the graph programmatically: a String.Concat with two ports, a code block
+            // feeding a nested list of strings into port 0, and a code block feeding a single
+            // scalar string into port 1.
+            var stringConcat = new DSVarArgFunction(
+                CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("DSCore.String.Concat@string[]"));
+            CurrentDynamoModel.ExecuteCommand(new DynCmd.CreateNodeCommand(stringConcat, 0, 0, true, false));
+            // String.Concat defaults to a single input port; add a second to mimic the repro graph.
+            CurrentDynamoModel.ExecuteCommand(new DynCmd.ModelEventCommand(stringConcat.GUID, "AddInPort", 1));
+            Assert.AreEqual(2, stringConcat.InPorts.Count);
+
+            var nestedCbn = new CodeBlockNodeModel(CurrentDynamoModel.LibraryServices);
+            CurrentDynamoModel.ExecuteCommand(new DynCmd.CreateNodeCommand(nestedCbn, 0, 0, true, false));
+            CurrentDynamoModel.ExecuteCommand(
+                new DynCmd.UpdateModelValueCommand(System.Guid.Empty, nestedCbn.GUID, "Code", "{{\"a\",\"b\"},{\"c\",\"d\"}};"));
+
+            var scalarCbn = new CodeBlockNodeModel(CurrentDynamoModel.LibraryServices);
+            CurrentDynamoModel.ExecuteCommand(new DynCmd.CreateNodeCommand(scalarCbn, 0, 0, true, false));
+            CurrentDynamoModel.ExecuteCommand(
+                new DynCmd.UpdateModelValueCommand(System.Guid.Empty, scalarCbn.GUID, "Code", "\"X\";"));
+
+            CurrentDynamoModel.ExecuteCommand(new DynCmd.MakeConnectionCommand(
+                nestedCbn.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
+            CurrentDynamoModel.ExecuteCommand(new DynCmd.MakeConnectionCommand(
+                stringConcat.GUID, 0, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
+
+            CurrentDynamoModel.ExecuteCommand(new DynCmd.MakeConnectionCommand(
+                scalarCbn.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
+            CurrentDynamoModel.ExecuteCommand(new DynCmd.MakeConnectionCommand(
+                stringConcat.GUID, 1, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
+
+            RunCurrentModel();
+
+            // Expected: scalar input replicates against the nested-list input so each leaf is
+            // concatenated with "X", preserving the nested-list shape and keeping ports
+            // independent of each other.
+            AssertPreviewValue(stringConcat.GUID.ToString(),
+                new object[]
+                {
+                    new[] { "aX", "bX" },
+                    new[] { "cX", "dX" }
+                });
         }
 
         #endregion

--- a/test/core/string/TestConcatString_nestedList.dyn
+++ b/test/core/string/TestConcatString_nestedList.dyn
@@ -1,0 +1,15 @@
+<Workspace Version="1.0.1.1743" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="False">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction guid="3a9b8f01-1111-2222-3333-444455556666" type="Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction" nickname="String.Concat" x="300" y="100" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.String.Concat@string[]" inputcount="2" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="11111111-aaaa-bbbb-cccc-000000000001" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Nested" x="50" y="80" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="{{&quot;a&quot;,&quot;b&quot;},{&quot;c&quot;,&quot;d&quot;}};" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="22222222-aaaa-bbbb-cccc-000000000002" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Scalar" x="50" y="160" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="&quot;X&quot;;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="11111111-aaaa-bbbb-cccc-000000000001" start_index="0" end="3a9b8f01-1111-2222-3333-444455556666" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="22222222-aaaa-bbbb-cccc-000000000002" start_index="0" end="3a9b8f01-1111-2222-3333-444455556666" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+</Workspace>


### PR DESCRIPTION
Closes https://autodesk.atlassian.net/browse/DYN-8473

## Implementation Plan
Goal: Fix String.Concat so list levels are honoured and each concatenation is independent of the previous input, and improve confusing input port names.
Approach: Locate the String.Concat node implementation in the CoreNodes string library, replace/wrap the underlying .NET String.Concat call so that nested-list inputs respect Dynamo list-level semantics (lacing/replication) rather than letting an earlier input's shape dictate subsequent inputs. Rename the variadic input ports from string0, string1, ... to clearer names while preserving backward compatibility ([AlsoKnownAs] or equivalent), and add NUnit tests covering nested-list inputs with and without list levels applied.
---
### TASK 1: Reproduce and locate the defect
**Status:** DONE
Milestone: A failing NUnit test that demonstrates String.Concat ignoring list levels / coupling subsequent inputs to the first nested input's structure.
- [x] Find the String.Concat node implementation under src/Libraries/ (likely CoreNodes or CoreNodeModels).
- [x] Identify whether it is a zero-touch static method or an explicit NodeModel (variadic input ports suggest NodeModel).
- [x] Reproduce the bug with a small .dyn graph or unit test using nested-list inputs and list-level overrides.
- [x] Add a failing NUnit test that asserts the expected per-input, level-aware behaviour.

Findings:
- Implementation: zero-touch static method ``DSCore.String.Concat(params string[] strings)`` at ``src/Libraries/CoreNodes/String.cs`` lines 52-61.
- Runtime wrapper: ``Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction`` (``src/DynamoCore/Graph/Nodes/ZeroTouch/DSVarArgFunction.cs``); ``ZeroTouchVarArgNodeController.BuildOutputAst`` packs all input ports into a single ``string[]`` argument, which couples nested structure on port 0 to ports 1..N.
- Port-name derivation: ``ZeroTouchVarInputController.GetInputName`` trims trailing ``s`` from the last parameter name (``strings`` -> ``string0``, ``string1``, ...).
- Function signature key referenced by existing ``.dyn`` files: ``DSCore.String.Concat@string[]``.
- Failing test added: ``TestConcatStringNestedListInputIsIndependentOfScalarInput`` in ``test/DynamoCoreTests/Nodes/StringTests.cs`` (currently ``[Ignore]``'d with DYN-8473 reason; TASK 2 will enable once the fix lands).
### TASK 2: Fix list-level / replication behaviour
**Status:** DONE
Milestone: String.Concat honours list levels per input and concatenation of each input is independent of the others; the failing test from TASK 1 now passes.
- [x] Adjust the AST built by the node (or the underlying DesignScript function) so replication uses Dynamo's list-level system rather than delegating shape control to the first nested input.
- [x] Ensure single-string, flat-list, and nested-list inputs all produce expected results across common lacing modes.
- [x] Verify no regression for the existing simple-string concat behaviour.
- [x] Re-enable ``TestConcatStringNestedListInputIsIndependentOfScalarInput`` (remove the ``[Ignore]``).

Findings:
- Implementation: special-cased ``DSCore.String.Concat@string[]`` in ``ZeroTouchVarArgNodeController.BuildOutputAst`` (``src/DynamoCore/Graph/Nodes/ZeroTouch/DSVarArgFunction.cs``). When the node has >=2 inputs and is fully applied, the AST is lowered to a left-associative chain of binary ``+`` operator calls (``s0 + s1 + s2 + ...``) using ``Op.GetOpFunction(Operator.add)``. Each operand participates in Dynamo's normal per-argument replication, so a nested-list input no longer dictates the structure of subsequent inputs. Partial application and the 1-input case continue to fall through to the original ``params``-packing path.
- Behaviour change captured in existing tests:
  - ``TestConcatStringMultipleInput`` updated: two parallel flat lists now pair element-wise (``{"abef","cdgh"}``) instead of being packed into a single ``string[]`` (``{"abcd","efgh"}``).
  - ``TestConcatStringInvalidInput`` updated: ``("a", 1)`` now produces ``"a1"`` via DesignScript ``+`` coercion instead of a node-level warning (the old ``params string[]`` path raised a warning on type mismatch).
- Test asset: ``test/core/string/TestConcatString_nestedList.dyn`` (XML format matching the rest of the folder), with a nested ``{{"a","b"},{"c","d"}}`` codeblock on port 0 and a scalar ``"X"`` on port 1.
- Verification: all 67 tests in ``Dynamo.Tests.StringTests`` pass with the fix in place.
### TASK 3: Clarify input port names
**Status:** DONE
Milestone: Input ports are named in a way that reflects accepted input (e.g., list0, list1, ... or a similarly clear scheme) without breaking existing graphs.
- [x] Rename variadic input ports from string0/string1/... to a clearer scheme.
- [x] Move user-facing strings to .resx for localisation. <!-- manual: skipped -->
- [x] Preserve backward compatibility for existing .dyn files (port mapping / migration, [AlsoKnownAs] if applicable).

Findings:
- Implementation: renamed the ``params string[]`` parameter on ``DSCore.String.Concat`` from ``strings`` to ``lists`` (``src/Libraries/CoreNodes/String.cs``). Port labels are derived from the parameter name by ``ZeroTouchVarArgNodeController.InitializeFunctionParameters`` (``arg.Name.Remove(arg.Name.Length - 1) + "0"``) and ``ZeroTouchVarInputController.GetInputName`` (``Parameters.Last().Name.TrimEnd('s') + index``), so the new name surfaces as ``list0``, ``list1``, ``list2``, ... without any other change.
- Mangled name preserved: the function signature ``DSCore.String.Concat@string[]`` is type-based, not name-based, so the special-case in ``DSVarArgFunction.BuildOutputAst`` (the binary ``+`` chain from TASK 2) continues to match and existing ``.dyn`` graphs resolve the same function.
- Backward compatibility: VariableInputNode serialization only persists ``inputcount`` (XML) / the deserialized port list (JSON via ``SerializationConverters.setPortDataOnNewPort``); port ``Name`` is not copied from the deserialized port back onto the new port, and connectors reference port GUIDs (JSON) or indices (XML). Old graphs with serialized labels ``string0/string1`` therefore load with fresh labels ``list0/list1`` and all wires remain connected.
- XML doc updated to describe the new per-input replication semantics so the tooltip text matches the renamed ports.
- ``.resx`` localisation of port labels/tooltips marked as skipped: the existing CoreNodes pattern derives port labels and tooltips from C# parameter names and ``Type.ToShortString()``, with no .resx hook for individual zero-touch parameters. Moving String.Concat's labels into ``.resx`` would be a one-off divergence from the convention used by every other zero-touch node; deferred to a broader effort.
- New test: ``TestConcatStringPortsAreNamedListN`` in ``test/DynamoCoreTests/Nodes/StringTests.cs`` asserts the first two ports of a loaded String.Concat node are labelled ``list0`` and ``list1``.
- Verification: 68/68 tests in ``Dynamo.Tests.StringTests`` pass (including the new port-name assertion and the legacy ``.dyn`` fixtures previously authored with ``string0/string1`` labels).
### TASK 4: Tests, docs, and API surface
**Status:** NOT STARTED
Milestone: Test suite covers the fix and the renamed ports; public API additions are recorded; node help artefacts are updated if the node behaviour changed visibly.
- [ ] Add NUnit tests for: flat lists, nested lists, list-level overrides, mixed inputs, and lacing modes.
- [ ] Add any new public APIs to PublicAPI.Unshipped.txt.
- [ ] Update doc/distrib/NodeHelpFiles/ (.dyn, .md, .jpg) only if outward node behaviour or signature changes warrant it.
---
### Verification
- [ ] All new and existing NUnit tests pass (dotnet test on the relevant test projects).
- [ ] Manual smoke test with the original repro graph confirms list-level behaviour and input independence.
- [ ] Existing .dyn graphs using String.Concat continue to open and evaluate without errors.
- [ ] Code follows existing CoreNodes/NodeModel patterns and Dynamo coding standards.
