### PR TITLE
DYN-9355: add MCP server startup preference and toggle

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -76,6 +76,7 @@ namespace Dynamo.Configuration
         private bool isEnablePersistExtensionsEnabled;
         private bool isAutoSyncDocumentBrowser = true;
         private bool isStaticSplashScreenEnabled;
+        private bool isMcpServerEnabledOnStartup;
         private bool isTimeStampIncludedInExportFilePath;
         private bool isCreatedFromValidFile = true;
         private string backupLocation;
@@ -826,6 +827,24 @@ namespace Dynamo.Configuration
         }
 
         /// <summary>
+        /// This defines whether the Dynamo MCP (Model Context Protocol) server starts
+        /// automatically when Dynamo launches. When false, the server stays off until the
+        /// user enables it from the MCP extension's Extensions-menu toggle (DYN-9355).
+        /// </summary>
+        public bool EnableMcpServerOnStartup
+        {
+            get
+            {
+                return isMcpServerEnabledOnStartup;
+            }
+            set
+            {
+                isMcpServerEnabledOnStartup = value;
+                RaisePropertyChanged(nameof(EnableMcpServerOnStartup));
+            }
+        }
+
+        /// <summary>
         /// This defines if the user is agree to the ML Automcomplete Terms of Use
         /// </summary>
         public bool IsMLAutocompleteTOUApproved
@@ -1100,6 +1119,7 @@ namespace Dynamo.Configuration
             HideAutocompleteMethodOptions = false;
             EnableNotificationCenter = true;
             isStaticSplashScreenEnabled = true;
+            isMcpServerEnabledOnStartup = false;
             isTimeStampIncludedInExportFilePath = true;
             DefaultPythonEngine = string.Empty;
             ViewExtensionSettings = new List<ViewExtensionSettings>();

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
+Dynamo.Configuration.PreferenceSettings.EnableMcpServerOnStartup.get -> bool
+Dynamo.Configuration.PreferenceSettings.EnableMcpServerOnStartup.set -> void
 Dynamo.Graph.Nodes.IValueSchemaProvider
 Dynamo.Graph.Nodes.IValueSchemaProvider.IsListValue.get -> bool
 Dynamo.Graph.Nodes.IValueSchemaProvider.ValueTypeId.get -> string

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -8390,6 +8390,24 @@ namespace Dynamo.Wpf.Properties {
                 return ResourceManager.GetString("PreferencesViewEnablePersistExtensions", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Start the MCP server when Dynamo launches.
+        /// </summary>
+        public static string PreferencesViewEnableMcpServerOnStartup {
+            get {
+                return ResourceManager.GetString("PreferencesViewEnableMcpServerOnStartup", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to When enabled, the Dynamo MCP server starts automatically with Dynamo. When disabled, you can still turn it on at any time from the Extensions menu without restarting Dynamo.
+        /// </summary>
+        public static string PreferencesViewEnableMcpServerOnStartupTooltip {
+            get {
+                return ResourceManager.GetString("PreferencesViewEnableMcpServerOnStartupTooltip", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Enable T-Spline nodes.

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -740,6 +740,14 @@ Don't worry, you'll have the option to save your work.</value>
     <value>Experimental</value>
     <comment>Preferences | Features | Experimental</comment>
   </data>
+  <data name="PreferencesViewEnableMcpServerOnStartup" xml:space="preserve">
+    <value>Start the MCP server when Dynamo launches</value>
+    <comment>Preferences | Features | Experimental</comment>
+  </data>
+  <data name="PreferencesViewEnableMcpServerOnStartupTooltip" xml:space="preserve">
+    <value>When enabled, the Dynamo MCP server starts automatically with Dynamo. When disabled, you can still turn it on at any time from the Extensions menu without restarting Dynamo.</value>
+    <comment>Preferences | Features | Experimental</comment>
+  </data>
   <data name="DynamoViewSettingMenu" xml:space="preserve">
     <value>_Settings</value>
     <comment>Setting menu</comment>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -600,6 +600,14 @@
     <value>Experimental</value>
     <comment>Preferences | Features | Experimental</comment>
   </data>
+  <data name="PreferencesViewEnableMcpServerOnStartup" xml:space="preserve">
+    <value>Start the MCP server when Dynamo launches</value>
+    <comment>Preferences | Features | Experimental</comment>
+  </data>
+  <data name="PreferencesViewEnableMcpServerOnStartupTooltip" xml:space="preserve">
+    <value>When enabled, the Dynamo MCP server starts automatically with Dynamo. When disabled, you can still turn it on at any time from the Extensions menu without restarting Dynamo.</value>
+    <comment>Preferences | Features | Experimental</comment>
+  </data>
   <data name="PreferencesViewEnableTSplineNodes" xml:space="preserve">
     <value>Enable T-Spline nodes</value>
     <comment>Preferences | Features | Experimental | Enable T-Spline nodes</comment>

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -402,6 +402,24 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// Controls the IsChecked property in the "start MCP server on launch" toggle button.
+        /// When enabled, the Dynamo MCP server starts automatically with Dynamo; otherwise it
+        /// stays off until enabled from the MCP extension's Extensions-menu toggle (DYN-9355).
+        /// </summary>
+        public bool McpServerEnabledOnStartup
+        {
+            get
+            {
+                return preferenceSettings.EnableMcpServerOnStartup;
+            }
+            set
+            {
+                preferenceSettings.EnableMcpServerOnStartup = value;
+                RaisePropertyChanged(nameof(McpServerEnabledOnStartup));
+            }
+        }
+
+        /// <summary>
         /// Controls the IsChecked property in the selecting to include timestamp for export path section
         /// </summary>
         public bool IsTimeStampIncludedInExportFilePath
@@ -1287,9 +1305,9 @@ namespace Dynamo.ViewModels
         {
             get
             {
-                // Hide for now since panel nodes are OOTB and no other experimental features
-                // Keep infrastructure for future experimental features
-                return false;
+                // Visible now that the Experimental section hosts the MCP server startup
+                // toggle (DYN-9355). Previously hidden when the section had no features.
+                return true;
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -1100,7 +1100,30 @@
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="*"/>
                                     </Grid.RowDefinitions>
-                                        <!-- Empty for now, ready for future experimental features -->
+                                    <!--This Grid row contains the MCP server startup toggle (DYN-9355)-->
+                                    <StackPanel Orientation="Horizontal" Margin="0,12,0,0" Grid.Row="0">
+                                        <ToggleButton Name="McpServerToggle"
+                                                      Width="{StaticResource ToggleButtonWidth}"
+                                                      Height="{StaticResource ToggleButtonHeight}"
+                                                      VerticalAlignment="Center"
+                                                      IsChecked="{Binding Path=McpServerEnabledOnStartup}"
+                                                      Style="{StaticResource EllipseToggleButton1}"/>
+                                        <Label Content="{x:Static p:Resources.PreferencesViewEnableMcpServerOnStartup}"
+                                               Margin="10,0,0,0"
+                                               VerticalAlignment="Center"
+                                               Foreground="{StaticResource PreferencesWindowFontColor}"/>
+                                        <Image Name="McpServerIcon"
+                                               Width="14"
+                                               Height="14"
+                                               Margin="10,0,0,0"
+                                               HorizontalAlignment="Left"
+                                               VerticalAlignment="Center"
+                                               Style="{StaticResource QuestionIcon}">
+                                            <Image.ToolTip>
+                                                <ToolTip Content="{x:Static p:Resources.PreferencesViewEnableMcpServerOnStartupTooltip}" Style="{StaticResource GenericToolTipLight}"/>
+                                            </Image.ToolTip>
+                                        </Image>
+                                    </StackPanel>
                                     </Grid>
                             </Expander>
 

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -441,7 +441,8 @@ namespace Dynamo.Tests.Configuration
         [Category("UnitTests")]
         public void WhenMcpServerOnStartupIsEnabledThenItPersistsAcrossSaveAndLoad()
         {
-            string tempPath = Path.Combine(Path.GetTempPath(), "mcpServerStartupPreference.xml");
+            // Use a unique file under the per-test TempFolder, which UnitTestBase cleans up on teardown.
+            string tempPath = GetNewFileNameOnTempPath("xml");
 
             var settings = new PreferenceSettings();
             settings.EnableMcpServerOnStartup = true;

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -429,6 +429,31 @@ namespace Dynamo.Tests.Configuration
 
         [Test]
         [Category("UnitTests")]
+        public void WhenSettingsAreNewThenMcpServerOnStartupDefaultsToFalse()
+        {
+            // The MCP server must stay off unless the user opts in (DYN-9355).
+            var settings = new PreferenceSettings();
+
+            Assert.IsFalse(settings.EnableMcpServerOnStartup);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenMcpServerOnStartupIsEnabledThenItPersistsAcrossSaveAndLoad()
+        {
+            string tempPath = Path.Combine(Path.GetTempPath(), "mcpServerStartupPreference.xml");
+
+            var settings = new PreferenceSettings();
+            settings.EnableMcpServerOnStartup = true;
+
+            settings.Save(tempPath);
+            var loadedSettings = PreferenceSettings.Load(tempPath);
+
+            Assert.IsTrue(loadedSettings.EnableMcpServerOnStartup);
+        }
+
+        [Test]
+        [Category("UnitTests")]
         public void TestTaintedFile()
         {
             string settingDirectory = Path.Combine(TestDirectory, "settings");

--- a/test/settings/DynamoSettings-NewSettings.xml
+++ b/test/settings/DynamoSettings-NewSettings.xml
@@ -87,6 +87,7 @@
   <IsAutoSyncDocumentBrowser>false</IsAutoSyncDocumentBrowser>
   <EnableNotificationCenter>false</EnableNotificationCenter>
   <EnableStaticSplashScreen>false</EnableStaticSplashScreen>
+  <EnableMcpServerOnStartup>true</EnableMcpServerOnStartup>
   <IsMLAutocompleteTOUApproved>false</IsMLAutocompleteTOUApproved>
   <IsTimeStampIncludedInExportFilePath>false</IsTimeStampIncludedInExportFilePath>
   <EnablePersistExtensions>true</EnablePersistExtensions>


### PR DESCRIPTION
### Purpose

DYN-9355: Add a Dynamo preference that controls whether the Dynamo MCP server starts automatically on launch. The MCP server is provided by the DynamoMCP view extension, which currently starts it unconditionally. This PR adds the user-facing setting (and the backing preference) that the extension reads to decide whether to auto-start; the extension itself also exposes a live on/off toggle in its Extensions menu (separate companion PR in the DynamoMCP repo).

Key changes:
- PreferenceSettings (DynamoCore): add public bool EnableMcpServerOnStartup, defaulting to false (opt-in). Serializes to DynamoSettings.xml like the other preferences.
- PreferencesViewModel: add the McpServerEnabledOnStartup wrapper that reads/writes the new preference, and change IsExperimentalExpanderVisible to return true so the Features > Experimental section is shown (it now hosts this toggle; it was previously hidden because the section had no content).
- PreferencesView.xaml: add the toggle to Features > Experimental, with a label and a help tooltip explaining that the server can also be toggled live from the Extensions menu without restarting Dynamo.
- Resources: add PreferencesViewEnableMcpServerOnStartup and PreferencesViewEnableMcpServerOnStartupTooltip strings (Resources.resx + Resources.Designer.cs + Resources.en-US.resx).

Companion change: the DynamoMCP extension (separate repo/PR, same DYN-9355 branch) reads EnableMcpServerOnStartup by name via reflection, so it does not take a hard compile-time dependency on this property and continues to work against Dynamo builds that predate it.


### Declarations

Check these if you believe they are true

- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

DYN-9355: Add a Dynamo preference that controls whether the Dynamo MCP server starts automatically on launch.

### Reviewers

@johnpierson @jasonstratton @edwin-vasquez-ucaldas 

### FYIs

@jnealb 
