### PR TITLE
DYN-9707: Fix ForceBlockRun not applied when opening legacy XML workspaces

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2465,6 +2465,7 @@ namespace Dynamo.Models
         /// <param name="forceManualExecutionMode">Set this to true to discard
         /// execution mode specified in the file and set manual mode</param>
         /// <param name="isTemplate">When true, marks the opened workspace as a template (for example when opened via <see cref="OpenTemplateFromPath"/>).</param>
+        /// <param name="forceBlockRun">Set this to true to block the graph from running after opening.</param>
         /// <returns>True if workspace was opened successfully</returns>
         private bool OpenXmlFileFromPath(XmlDocument xmlDoc, string filePath, bool forceManualExecutionMode, bool isTemplate = false, bool forceBlockRun = false)
         {

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2256,7 +2256,7 @@ namespace Dynamo.Models
                     // When Json opening failed, either this file is corrupted or file might be XML
                     if (ex is JsonReaderException && DynamoUtilities.PathHelper.isValidXML(filePathToOpen, out xmlDoc, out ex))
                     {
-                        openedSuccessfully = OpenXmlFileFromPath(xmlDoc, filePathToOpen, forceManualExecutionMode);
+                        openedSuccessfully = OpenXmlFileFromPath(xmlDoc, filePathToOpen, forceManualExecutionMode, forceBlockRun: forceBlockRun);
                         return;
                     }
                     else
@@ -2466,7 +2466,7 @@ namespace Dynamo.Models
         /// execution mode specified in the file and set manual mode</param>
         /// <param name="isTemplate">When true, marks the opened workspace as a template (for example when opened via <see cref="OpenTemplateFromPath"/>).</param>
         /// <returns>True if workspace was opened successfully</returns>
-        private bool OpenXmlFileFromPath(XmlDocument xmlDoc, string filePath, bool forceManualExecutionMode, bool isTemplate = false)
+        private bool OpenXmlFileFromPath(XmlDocument xmlDoc, string filePath, bool forceManualExecutionMode, bool isTemplate = false, bool forceBlockRun = false)
         {
             try
             {
@@ -2491,6 +2491,8 @@ namespace Dynamo.Models
                         if (OpenXmlFile(workspaceInfo, xmlDoc, out ws))
                         {
                             ws.IsTemplate = isTemplate;
+                            if (ws is HomeWorkspaceModel homeWs && homeWs.RunSettings != null)
+                                homeWs.RunSettings.ForceBlockRun = forceBlockRun;
                             OpenWorkspace(ws);
 
                             // Set up workspace cameras here


### PR DESCRIPTION
### Purpose

Follow-up fix for the `ForceBlockRun` refactor introduced in #17153 (DYN-9707). The legacy XML workspace open path was not updated to propagate the `forceBlockRun` flag, leaving `HomeWorkspaceModel.RunSettings.ForceBlockRun` unset for any `.dyn` file stored in old XML format.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

N/A — internal fix to file trust enforcement; no user-visible behavior change.

### Reviewers

@ivaylo-matov — follow-up to your PR #17153; please take a look.

The regression was caught by `DynamoCoreWpfTests.DynamoViewTests.OpeningWorkspaceWithTrustWarning`, a test introduced in #17153 itself. The test file `TestAdd.dyn` is a legacy XML-format file, so the new `ForceBlockRun` assertion exercised the XML open path. Because `DynamoCoreWpfTests` is not run in the GitHub Actions PR CI (only in the daily Jenkins build), the failure was not visible before merge.

### FYIs

N/A