### PR TITLE
DYN-10516: bump DynamoHome to 1.0.32

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -59,7 +59,6 @@
 
     <Target Name="NpmRunBuildHomePage" BeforeTargets="BeforeBuild">
         <PropertyGroup>
-            <PackageVersion>1.0.31</PackageVersion>
             <PackageVersion>1.0.32</PackageVersion>
             <PackageName>DynamoHome</PackageName>
         </PropertyGroup>

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -60,6 +60,7 @@
     <Target Name="NpmRunBuildHomePage" BeforeTargets="BeforeBuild">
         <PropertyGroup>
             <PackageVersion>1.0.31</PackageVersion>
+            <PackageVersion>1.0.32</PackageVersion>
             <PackageName>DynamoHome</PackageName>
         </PropertyGroup>
         <Exec Command="$(PowerShellCommand) -ExecutionPolicy Bypass -File &quot;$(SolutionDir)pkgexist.ps1&quot; &quot;$(PackageName)&quot; &quot;$(PackageVersion)&quot;" ConsoleToMSBuild="true">


### PR DESCRIPTION
### Purpose

[DYN-10516](https://jira.autodesk.com/browse/DYN-10516): Updates the DynamoHome npm package reference from 1.0.31 to 1.0.32 in `DynamoCoreWpf.csproj`. This version includes the frontend changes required by DYN-10516 (dynamic refresh of Templates and Recent Files on the Home screen).

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

N/A

### Reviewers

@DynamoDS/eidos 
@RobertGlobant20 
@johnpierson 

### FYIs

