### PR TITLE
DYN-8957 fix: set NoNetworkMode before InitializeComponent in WorkspaceDependencyView

### DIFF
--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -146,6 +146,10 @@ namespace Dynamo.WorkspaceDependency
         /// <param name="p">ViewLoadedParams</param>
         public WorkspaceDependencyView(WorkspaceDependencyViewExtension viewExtension, ViewLoadedParams p)
         {
+            // NoNetworkMode must be set before InitializeComponent so the XAML DataTrigger
+            // that disables the Install button reads the correct value on first evaluation.
+            // A plain CLR property has no change notification, so the trigger only fires once.
+            NoNetworkMode = p.StartupParams.NoNetworkMode;
             InitializeComponent();
             this.DataContext = this;
             currentWorkspace = p.CurrentWorkspaceModel as WorkspaceModel;
@@ -156,7 +160,6 @@ namespace Dynamo.WorkspaceDependency
             currentWorkspace.PropertyChanged += OnWorkspacePropertyChanged;
             loadedParams = p;
             packageInstaller = p.PackageInstaller;
-            NoNetworkMode = p.StartupParams.NoNetworkMode;
             dependencyViewExtension = viewExtension;
             HomeWorkspaceModel.WorkspaceClosed += this.CloseExtensionTab;
         }


### PR DESCRIPTION
## Summary

- `NoNetworkMode` is a plain CLR property with no `INotifyPropertyChanged`. When it was assigned *after* `InitializeComponent()`, the XAML `DataTrigger` (which drives `IsEnabled` on the Install Specified Version button) had already evaluated the binding with the default value `false` and would never re-fire.
- This meant the Install button remained enabled even when Dynamo started in no-network mode.
- Fix: move the assignment to *before* `InitializeComponent()` so the trigger reads the correct value on first evaluation.

## Test plan

- [ ] Existing test `WhenNoNetworkModeThenWorkspaceReferencesInstallButtonIsDisabled` passes (verifies `DependencyView.NoNetworkMode` is propagated)
- [ ] Manual: launch Dynamo with `--NoNetworkMode`, open a graph with missing packages, open Workspace References — Install Specified Version button should be disabled

🤖 Generated with [Claude Code](https://claude.ai/claude-code)