### PR TITLE
DYN-8957 refactor: rename test to match its actual assertion

### DIFF
--- a/test/DynamoCoreWpf2Tests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
+++ b/test/DynamoCoreWpf2Tests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
@@ -387,9 +387,10 @@ namespace DynamoCoreWpfTests
         // NoNetworkMode on the view is what drives the XAML DataTrigger that disables the
         // Install Specified Version button. Asserting the property directly is intentional:
         // WPF triggers do not fire until the visual tree is fully realized, which is not
-        // guaranteed in a headless NUnit run.
+        // guaranteed in a headless NUnit run. See WhenNoNetworkModeThenWorkspaceReferencesInstallButtonIsDisabled
+        // in AGT tests for the UI-level assertion.
         [Test]
-        public void WhenNoNetworkModeThenWorkspaceReferencesInstallButtonIsDisabled()
+        public void WhenNoNetworkModeThenDependencyViewNoNetworkModeIsTrue()
         {
             RaiseLoadedEvent(this.View);
             var extensionManager = View.viewExtensionManager;


### PR DESCRIPTION
## Summary

- `WhenNoNetworkModeThenWorkspaceReferencesInstallButtonIsDisabled` implies a UI-level assertion on `Button.IsEnabled`, but the test only verifies that `DependencyView.NoNetworkMode` is propagated from `StartupParams`.
- Rename to `WhenNoNetworkModeThenDependencyViewNoNetworkModeIsTrue` so the test name accurately describes what it asserts.
- Updated the comment to note that the UI-level assertion belongs in AGT tests (per Neal Burnham's Jira comment).

## Test plan

- [ ] Renamed test `WhenNoNetworkModeThenDependencyViewNoNetworkModeIsTrue` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)