### PR TITLE
DYN-10639: Revert DYN-8575 to fix pop-ups flashing then disappearing

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1618,11 +1618,7 @@ namespace Dynamo.Controls
         {
             var workspace = this.ChildOfType<WorkspaceView>();
             if (workspace != null)
-            {
                 workspace.HideAllPopUp(obj);
-                workspace.DestroyPortContextMenu();
-            }
-
         }
 
         private void TrackStartupAnalytics()

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -108,11 +108,6 @@ namespace Dynamo.Views
 
             InitializeComponent();
 
-            Loaded += WorkspaceView_Loaded;
-            Unloaded += WorkspaceView_Unloaded;
-
-            LostFocus += WorkspaceView_LostFocus;
-
             DataContextChanged += OnWorkspaceViewDataContextChanged;
 
             // view of items to drag
@@ -122,11 +117,6 @@ namespace Dynamo.Views
             // let draggedSelectionTemplate know about views of node, note, annotation, connector
             dictionaries.Add(SharedDictionaryManager.ConnectorsDictionary);
             dictionaries.Add(SharedDictionaryManager.DataTemplatesDictionary);
-        }
-
-        private void WorkspaceView_LostFocus(object sender, RoutedEventArgs e)
-        {
-            DestroyPortContextMenu();
         }
 
         void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -914,8 +904,8 @@ namespace Dynamo.Views
             InCanvasSearchBar.IsOpen = false;
             if (GeoScalingPopup != null)
                 GeoScalingPopup.IsOpen = false;
-
-            if (PortContextMenu.IsOpen) DestroyPortContextMenu();
+            
+            if(PortContextMenu.IsOpen) DestroyPortContextMenu();
 
             if (!ViewModel.IsConnecting && !ViewModel.IsPanning && e.MiddleButton == MouseButtonState.Pressed)
             {
@@ -923,38 +913,11 @@ namespace Dynamo.Views
             }
         }
 
-        private void WorkspaceView_Loaded(object sender, RoutedEventArgs e)
-        {
-            var ownerWindow = Window.GetWindow(this);
-            if (ownerWindow != null)
-            {
-                ownerWindow.Deactivated += OwnerWindow_Deactivated;
-            }
-        }
-
-        private void WorkspaceView_Unloaded(object sender, RoutedEventArgs e)
-        {
-            var ownerWindow = Window.GetWindow(this);
-            if (ownerWindow != null)
-            {
-                ownerWindow.Deactivated -= OwnerWindow_Deactivated;
-            }
-        }
-
-        /// <summary>
-        /// When the Dynamo/Revit window loses focus, close the port context menu
-        /// so it doesn't float above other windows.
-        /// </summary>
-        private void OwnerWindow_Deactivated(object sender, EventArgs e)
-        {
-            DestroyPortContextMenu();
-        }
-
         /// <summary>
         /// Closes the port's context menu and sets its references to null.
         /// </summary>
-        internal void DestroyPortContextMenu() => PortContextMenu.IsOpen = false;
-
+        private void DestroyPortContextMenu() => PortContextMenu.IsOpen = false;
+        
         private void OnMouseRelease(object sender, MouseButtonEventArgs e)
         {
             if (e == null) return; // in certain bizarre cases, e can be null
@@ -1296,10 +1259,6 @@ namespace Dynamo.Views
         public void Dispose()
         {
             RemoveViewModelsubscriptions(ViewModel);
-
-            Loaded -= WorkspaceView_Loaded;
-            Unloaded -= WorkspaceView_Unloaded;
-            LostFocus -= WorkspaceView_LostFocus;
             DataContextChanged -= OnWorkspaceViewDataContextChanged;
         }
     }


### PR DESCRIPTION
### Purpose

Fixes [DYN-10639](https://autodesk.atlassian.net/browse/DYN-10639).

Pop-up messages appear for a split second and then disappear. Two reported surfaces:
- The **element-binding toast** on graph open (e.g. `WallBindingFile.dyn` → `LegacyTraceDataWarning`) — the message Localization needs to screen-capture for the Primer.
- The **"Modify list @ level"** chevron menu on a node input port.

Reproduces in **4.1.0 and up** (not in 4.0.2).

**Root cause — DYN-8575 (#16763).** That change added two triggers that call `DestroyPortContextMenu()`:
- `WorkspaceView.LostFocus` — `LostFocus` bubbles up from child elements, so it fires on *internal* focus changes (e.g. while a graph is opening).
- the owning window's `Deactivated` event — which also fires when one of Dynamo's own transparent (`AllowsTransparency`) popups opens and momentarily deactivates the main window.

The net effect is that opening these transparent popups (or simply loading a graph) tears the pop-ups back down almost immediately — the "flash".

**Fix.** Revert DYN-8575. Verified in Dynamo for Revit: reverting fixes **both** the toast and the chevron menu. Confirmed empirically by bisecting — DYN-8575 is not present in 4.0.2 (no repro) and is present in 4.1.0 (repro), and reverting it on current `master` resolves both symptoms.

> ⚠️ **Follow-up required.** DYN-8575 addressed a genuine issue — the port context menu floating above *other applications* when you switch windows. This revert reintroduces that. It should be re-implemented without the regression (e.g. only tear down on a genuine cross-process app switch, not on internal focus changes or our own popups opening). Tracking on DYN-10639.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixed pop-up menus and toast notifications (including the element-binding message and the "Modify list @ level" menu) that would appear for a split second and then disappear.

### Reviewers

@Chloepeg (author of DYN-8575 / #16763), Dynamo team

### FYIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)