### PR TITLE
DYN-10639: Fix toast notification position and premature dismissal

### DIFF
--- a/src/DynamoCoreWpf/UI/ToastManager.cs
+++ b/src/DynamoCoreWpf/UI/ToastManager.cs
@@ -98,7 +98,8 @@ namespace Dynamo.Wpf.UI
         /// </summary>
         private CustomPopupPlacement[] PlaceTopRight(Size popupSize, Size targetSize, Point offset)
         {
-            var x = targetSize.Width - popupSize.Width - RightInset;
+            // Clamp so a canvas narrower than the popup does not push the toast off the left edge.
+            var x = Math.Max(RightInset, targetSize.Width - popupSize.Width - RightInset);
             var y = TopInset;
             return new[] { new CustomPopupPlacement(new Point(x, y), PopupPrimaryAxis.None) };
         }

--- a/src/DynamoCoreWpf/UI/ToastManager.cs
+++ b/src/DynamoCoreWpf/UI/ToastManager.cs
@@ -10,11 +10,14 @@ namespace Dynamo.Wpf.UI
     public class ToastManager
     {
 
-        //The popup will be shown at the top-right section of the Dynamo window (at the left side of the statusBarPanel element)
-        //The VerticalOffset is used to move vertically the popup (using as a reference the statusBarPanel position)
-        private const double VerticalOffset = 10;
-        //The HorizontalOffset is used to move horizontally the popup (using as a reference the statusBarPanel position)
-        private const double HorizontalOffset = 110;
+        //The popup is shown at the top-right of the canvas, anchored to the persistent background_grid
+        //(which survives workspace swaps, unlike the per-workspace viewControlPanel). Its top-right
+        //corner coincides with the old viewControlPanel anchor, so these insets reproduce the original
+        //popup position.
+        //Distance from the popup's right edge to the canvas right edge.
+        private const double RightInset = 9;
+        //Distance from the popup's top edge to the canvas top edge.
+        private const double TopInset = 10;
         internal const int AutoCloseSeconds = 5;
 
         private RealTimeInfoWindow toastPopup;
@@ -32,8 +35,8 @@ namespace Dynamo.Wpf.UI
         /// </summary>
         /// <param name="content">The target content to display.</param>
         /// <param name="stayOpen">
-        /// boolean indicates if the popup will stay open until user dismiss it
-        /// note: all toasts are still auto-closed after a certain duration.</param>
+        /// When true the popup stays open until it is dismissed (by the user or by a caller). When
+        /// false the popup auto-closes after <see cref="AutoCloseSeconds"/> seconds.</param>
         /// <param name="headerText">The header text to display.</param>
         /// <param name="hyperlinkText">The hyperlink text to display.</param>
         /// <param name="hyperlinkUri">The hyperlink uri to navigate to.</param>
@@ -46,9 +49,6 @@ namespace Dynamo.Wpf.UI
             Uri hyperlinkUri = null,
             Uri fileLinkUri = null)
         {
-            //Search a UIElement with the Name "statusBarPanel" inside the Dynamo VisualTree
-            UIElement hostUIElement = GuideUtilities.FindChild(mainRootElement, "statusBarPanel");
-
             // When popup already exist, replace it
             CloseRealTimeInfoWindow();
             StopAutoCloseTimer();
@@ -56,9 +56,6 @@ namespace Dynamo.Wpf.UI
             // Create the popup
             toastPopup = new RealTimeInfoWindow()
             {
-                VerticalOffset = VerticalOffset,
-                HorizontalOffset = HorizontalOffset,
-                Placement = PlacementMode.Left,
                 StaysOpen = stayOpen,
                 HeaderContent = headerText,
                 HyperlinkText = hyperlinkText,
@@ -70,10 +67,40 @@ namespace Dynamo.Wpf.UI
             toastPopup.SetToastMessage(content, showFileLink, fileLinkUri);
             toastPopup.UpdateVisualState();
 
+            // Custom placement pins the popup to the top-right corner of the background_grid canvas
+            // regardless of the popup's width. background_grid is the canvas background declared
+            // directly in DynamoView, so it persists across workspace swaps (only the WorkspaceView
+            // content inside it changes) - unlike the per-workspace viewControlPanel, which gets torn
+            // out of the visual tree during file open and used to leave the popup orphaned. Its
+            // top-right corner coincides with the old viewControlPanel anchor. It is always laid out
+            // by the time a toast can be shown, since ToastManager is created in DynamoView_Loaded.
+            toastPopup.Placement = PlacementMode.Custom;
+            toastPopup.CustomPopupPlacementCallback = PlaceTopRight;
+
+            var hostUIElement = GuideUtilities.FindChild(mainRootElement, "background_grid");
             if (hostUIElement != null)
+            {
                 toastPopup.PlacementTarget = hostUIElement;
+            }
+
             toastPopup.IsOpen = true;
-            StartAutoCloseTimer(AutoCloseSeconds);
+
+            // Only start auto-close timer if the notification should not stay open
+            if (!stayOpen)
+            {
+                StartAutoCloseTimer(AutoCloseSeconds);
+            }
+        }
+
+        /// <summary>
+        /// Custom placement callback that positions the popup just inside the top-right corner of the
+        /// placement target (background_grid), independent of the popup's width.
+        /// </summary>
+        private CustomPopupPlacement[] PlaceTopRight(Size popupSize, Size targetSize, Point offset)
+        {
+            var x = targetSize.Width - popupSize.Width - RightInset;
+            var y = TopInset;
+            return new[] { new CustomPopupPlacement(new Point(x, y), PopupPrimaryAxis.None) };
         }
 
         /// <summary>
@@ -88,6 +115,7 @@ namespace Dynamo.Wpf.UI
                 toastPopup.IsOpen = false;
             }
         }
+
         /// <summary>
         /// This method will be used when the PlacementTarget element of the Popup was moved or resize so we need to update the popup
         /// </summary>

--- a/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
+++ b/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
@@ -252,7 +252,12 @@ namespace Dynamo.PythonMigration
             SubscribeToWorkspaceEvents();
 
             CurrentWorkspace.HasShownPythonAutoMigrationNotification = false;
-            DynamoViewModel.ToastManager?.CloseRealTimeInfoWindow();
+
+            // Only close toast notification if the previous workspace had shown a Python migration notification
+            if (previous != null && previous.HasShownPythonAutoMigrationNotification)
+            {
+                DynamoViewModel.ToastManager?.CloseRealTimeInfoWindow();
+            }
 
             if (previous != null)
             {

--- a/test/DynamoCoreWpfTests/DynamoViewTests.cs
+++ b/test/DynamoCoreWpfTests/DynamoViewTests.cs
@@ -236,9 +236,9 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
-        public void TestToastAutoCloses()
+        public void WhenToastIsStickyThenItStaysVisibleAfterAutoCloseDuration()
         {
-            // Create a toast
+            // A sticky toast (stayOpen: true) must remain visible until dismissed; it must not auto-close.
             ViewModel.UIDispatcher.Invoke(() =>
             {
                 ViewModel.ToastManager.CreateRealTimeInfoWindow(
@@ -249,18 +249,45 @@ namespace DynamoCoreWpfTests
             // It should be visible immediately
             Assert.IsTrue(ViewModel.ToastManager.PopupIsVisible, "Toast should be visible right after showing.");
 
-            // Pump the dispatcher for a little longer than the set auto-close time
-            var sw = System.Diagnostics.Stopwatch.StartNew();
-            var waitTime = TimeSpan.FromSeconds(ToastManager.AutoCloseSeconds + 2);
+            // Pump the dispatcher for a little longer than the auto-close time
+            PumpDispatcherFor(TimeSpan.FromSeconds(ToastManager.AutoCloseSeconds + 2));
 
-            while (sw.Elapsed < waitTime)
+            // Sticky toast should still be visible (no auto-close timer was started)
+            Assert.IsTrue(ViewModel.ToastManager.PopupIsVisible, "Sticky toast should remain visible after the auto-close duration.");
+
+            // Cleanup so the open popup does not leak into other tests.
+            ViewModel.UIDispatcher.Invoke(() => ViewModel.ToastManager.CloseRealTimeInfoWindow());
+        }
+
+        [Test]
+        public void WhenToastIsNotStickyThenItAutoCloses()
+        {
+            // A non-sticky toast (stayOpen: false) auto-closes after AutoCloseSeconds.
+            ViewModel.UIDispatcher.Invoke(() =>
+            {
+                ViewModel.ToastManager.CreateRealTimeInfoWindow(
+                    content: "Test auto-close toast",
+                    stayOpen: false);
+            });
+
+            // It should be visible immediately
+            Assert.IsTrue(ViewModel.ToastManager.PopupIsVisible, "Toast should be visible right after showing.");
+
+            // Pump the dispatcher for a little longer than the auto-close time
+            PumpDispatcherFor(TimeSpan.FromSeconds(ToastManager.AutoCloseSeconds + 2));
+
+            // Toast should have auto-closed
+            Assert.IsFalse(ViewModel.ToastManager.PopupIsVisible, "Non-sticky toast should auto-close after the auto-close duration.");
+        }
+
+        private void PumpDispatcherFor(TimeSpan duration)
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            while (sw.Elapsed < duration)
             {
                 ViewModel.UIDispatcher.Invoke(() => { }, System.Windows.Threading.DispatcherPriority.Background);
                 System.Threading.Thread.Sleep(10);
             }
-
-            // Toast should have auto-closed
-            Assert.IsFalse(ViewModel.ToastManager.PopupIsVisible, "Toast should auto-close.");
         }
     }
 }


### PR DESCRIPTION
### Purpose

Fixes [DYN-10639](https://jira.autodesk.com/browse/DYN-10639).

The toast notification shown by `ToastManager.CreateRealTimeInfoWindow` (e.g. the legacy element-binding warning shown on opening an older workspace) appeared in the **middle of the canvas / over the title bar** instead of the top-right, and could disappear almost immediately after appearing.

**Root cause — position:** the popup was anchored to the per-workspace `viewControlPanel`. When a toast is raised mid workspace-open, the outgoing `WorkspaceView` (and its `viewControlPanel`) is torn out of the visual tree as the workspace swaps. The popup's `PlacementTarget` disconnects (`This Visual is not connected to a PresentationSource`) and WPF re-places the orphaned popup at the window origin.

**Root cause — premature dismissal:** `OnCurrentWorkspaceChanged` in the Python Migration view extension closed the toast unconditionally on every workspace change, dismissing unrelated toasts ~1s after they appeared.

**Fix:**
- Anchor the popup to `background_grid` — the canvas background declared directly in `DynamoView`, which persists across workspace swaps (only the `WorkspaceView` content inside it changes). Its top-right corner coincides with the old `viewControlPanel` anchor, so the position is unchanged.
- Use `PlacementMode.Custom` with a placement callback that pins the popup just inside the canvas top-right corner, independent of popup width.
- Honor `stayOpen` so persistent toasts are not auto-closed after the timeout.
- In `PythonMigrationViewExtension`, only close the toast on workspace change when the previous workspace had actually shown the Python migration notification.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixed the in-canvas toast notification (such as the legacy element-binding warning) so it consistently appears in the top-right of the canvas and is no longer mispositioned or dismissed immediately when opening a workspace.

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)