### PR TITLE
DYN-10516: remove duplicate LibG PackageReferences blocking signed DLL delivery

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -32,9 +32,6 @@
   <ItemGroup Label="Common dependencies">
     <PackageReference Include="Autodesk.IDSDK" Version="1.2.5" />
     <PackageReference Include="Greg" Version="3.0.2.8780" />
-    <PackageReference Include="DynamoVisualProgramming.LibG_231_0_0" Version="4.0.0.4614" GeneratePathProperty="true" ExcludeAssets="all"/>
-    <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.4610" Condition=" '$(Configuration)' == 'Release' " GeneratePathProperty="true" ExcludeAssets="runtime"/>
-    <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0_debug" Version="4.0.0.4610" Condition=" '$(Configuration)' == 'Debug' " GeneratePathProperty="true" ExcludeAssets="runtime"/>
     <PackageReference Include="DynamoVisualProgramming.LibG_231_0_0" Version="4.0.0.5336" GeneratePathProperty="true" ExcludeAssets="all"/>
     <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334" Condition=" '$(Configuration)' == 'Release' " GeneratePathProperty="true" ExcludeAssets="runtime"/>
     <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0_debug" Version="4.0.0.5334" Condition=" '$(Configuration)' == 'Debug' " GeneratePathProperty="true" ExcludeAssets="runtime"/>

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -483,7 +483,6 @@
       <PackageReference Include="HelixToolkit.Core.Wpf" Version="2.24.0" />
       <PackageReference Include="HelixToolkit.SharpDX.Core.Wpf" Version="2.24.0" />
       <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-      <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.4610" />
       <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334" />
     <PackageReference Include="FontAwesome5" Version="2.1.11" />
     <PackageReference Include="AvalonEdit" Version="6.3.0.90" CopyXML="true" />

--- a/src/DynamoManipulation/DynamoManipulation.csproj
+++ b/src/DynamoManipulation/DynamoManipulation.csproj
@@ -40,7 +40,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.4610" />
     <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Libraries/Analysis/Analysis.csproj
+++ b/src/Libraries/Analysis/Analysis.csproj
@@ -18,7 +18,6 @@
     <None Remove="AnalysisImages.resources" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.4610"/>
     <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334"/>
     
     <ProjectReference Include="..\..\DynamoCore\DynamoCore.csproj">

--- a/src/Libraries/CoreNodes/CoreNodes.csproj
+++ b/src/Libraries/CoreNodes/CoreNodes.csproj
@@ -19,7 +19,6 @@
     <Compile Remove="GeometryColor.cs" />
   </ItemGroup>
   <ItemGroup Label="Common dependencies">
-    <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.4610"/>
     <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334"/>
     
   </ItemGroup>

--- a/src/Libraries/GeometryColor/GeometryColor.csproj
+++ b/src/Libraries/GeometryColor/GeometryColor.csproj
@@ -14,7 +14,6 @@
     <NoWarn>MSB3539;CS1591;NUnit2005;NUnit2007;CS0618;CS0612;CS0672</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.4610"/>
     <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334"/>
     
   </ItemGroup>

--- a/src/Libraries/GeometryUI/GeometryUI.csproj
+++ b/src/Libraries/GeometryUI/GeometryUI.csproj
@@ -17,7 +17,6 @@
 	 </ReferenceCopyLocalPaths>
 	</ItemDefinitionGroup>
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.4610"/>
     <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334"/>
     
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/Libraries/GeometryUIWpf/GeometryUIWpf.csproj
+++ b/src/Libraries/GeometryUIWpf/GeometryUIWpf.csproj
@@ -21,7 +21,6 @@
 	</ReferenceCopyLocalPaths>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.4610"/>
     <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334"/>
     
   </ItemGroup>

--- a/src/Libraries/Tesellation/Tessellation.csproj
+++ b/src/Libraries/Tesellation/Tessellation.csproj
@@ -16,7 +16,6 @@
   <ItemGroup>
     <PackageReference Include="MIConvexHull" version="1.1.19.1019" CopyPDB="true" />
 	<PackageReference Include="StarMath" version="2.0.20.204" CopyPDB="true" />
-    <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.4610" />
     <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334" />
     <PackageReference Include="System.Resources.Extensions" Version="5.0.0" />
   </ItemGroup>

--- a/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
@@ -15,7 +15,6 @@
         <PackageReference Include="Greg" Version="3.0.2.8780" />
         <PackageReference Include="Magick.NET.Core" Version="14.10.3" />
         <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.10.3" />
-        <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.4610"/>
         <PackageReference Include="Magick.NET.Core" Version="14.12.0" />
         <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.12.0" />
         <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334"/>

--- a/test/Libraries/AnalysisTests/AnalysisTests.csproj
+++ b/test/Libraries/AnalysisTests/AnalysisTests.csproj
@@ -10,7 +10,6 @@
     <AssemblyName>AnalysisTests</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.4610"/>
     <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334"/>
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />

--- a/test/Libraries/DynamoPythonTests/DynamoPythonTests.csproj
+++ b/test/Libraries/DynamoPythonTests/DynamoPythonTests.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="AvalonEdit" Version="6.3.0.90" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.4610"/>
     <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334"/>
     
     <PackageReference Include="DynamicLanguageRuntime" Version="1.2.2" />

--- a/test/Libraries/GeometryColorTests/GeometryColorTests.csproj
+++ b/test/Libraries/GeometryColorTests/GeometryColorTests.csproj
@@ -10,7 +10,6 @@
     <AssemblyName>DisplayTests</AssemblyName>
   </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.4610"/>
         <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334"/>
         
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />

--- a/test/Libraries/TessellationTests/TessellationTests.csproj
+++ b/test/Libraries/TessellationTests/TessellationTests.csproj
@@ -10,7 +10,6 @@
     <AssemblyName>TessellationTests</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.4610"/>
     <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/test/Libraries/TestServices/TestServices.csproj
+++ b/test/Libraries/TestServices/TestServices.csproj
@@ -10,7 +10,6 @@
     <AssemblyName>TestServices</AssemblyName>
   </PropertyGroup>
   <ItemGroup>         
-    <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.4610"/>
     <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334"/>
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />

--- a/test/Libraries/WorkflowTests/WorkflowTests.csproj
+++ b/test/Libraries/WorkflowTests/WorkflowTests.csproj
@@ -14,7 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.4610"/>
     <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334"/>
     
     <PackageReference Include="NUnit" Version="3.13.3" />


### PR DESCRIPTION
## Purpose

Fixes the root cause of unsigned en-GB locale DLLs in the Dynamo 4.1.2 release zip.

The cherry-pick of #17175 (LibG version bump to 4.0.0.5334 / 4.0.0.5336) added the new `PackageReference` entries to 16 csproj files on `RC4.1.2_master` but did not remove the pre-existing old entries (4.0.0.4610 / 4.0.0.4614). NuGet NU1504 duplicate resolution picked the **lower** version, so the build restored the old unsigned packages instead of the new signed ones.

This PR removes the 16 stale duplicate entries, leaving only the correct 4.0.0.5334 / 4.0.0.5336 references.

**Files affected:** 10 src csproj files + 6 test csproj files

## Validation

After merge, trigger a new build on master-15 with `DynamoBranch = RC4.1.2_master` and verify the en-GB locale DLLs in the output zip are signed by Autodesk, Inc. and carry version 4.0.0.5334.

## API Changes

- [ ] This PR does not include any public API changes.

## Release Notes

N/A - infrastructure fix for RC4.1.2_master, no user-facing change.