### PR TITLE
DYN-9801: cherry-pick Locale property to RC4.1.2_master (fixes Complete Install Test)

### DIFF
--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -470,32 +470,34 @@ namespace Dynamo.Applications
             return model;
         }
 
+        /// <summary>
+        /// Sets the application locale from parsed command-line arguments.
+        /// </summary>
+        /// <param name="cmdLineArgs">Parsed command-line arguments.</param>
+        /// <returns>A locale environment string in the format <c>LANGUAGE=xx_YY</c> for the resolved locale.</returns>
+        [Obsolete("The API has been deprecated and will be removed in a future release of Dynamo. Make a direct call to DynamoModel.SetUICulture instead.")]
         public static string SetLocale(CommandLineArguments cmdLineArgs)
         {
-            var supportedLocale = new HashSet<string>(Configuration.Configurations.SupportedLocaleDic.Values);
-            string libgLocale = string.Empty;
+            var supportedLocale = new HashSet<string>(Configurations.SupportedLocaleDic.Values);
+            string locale = string.Empty;
 
             if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
             {
-                // Change the application locale, if a locale information is supplied.
                 DynamoModel.SetUICulture(cmdLineArgs.Locale);
-                libgLocale = cmdLineArgs.Locale;
+                locale = cmdLineArgs.Locale;
             }
             else
             {
-                // In case no language is specified, libG's locale should be that of the OS.
-                // There is no need to set Dynamo's locale in this case.
-                libgLocale = CultureInfo.InstalledUICulture.ToString();
+                locale = CultureInfo.InstalledUICulture.ToString();
             }
 
             // If locale is not supported by Dynamo, default to en-US.
-            if (!supportedLocale.Any(s => s.Equals(libgLocale, StringComparison.InvariantCultureIgnoreCase)))
+            if (!supportedLocale.Any(s => s.Equals(locale, StringComparison.InvariantCultureIgnoreCase)))
             {
-                libgLocale = "en-US";
+                locale = "en-US";
             }
-            // Change the locale that LibG depends on.
             StringBuilder sb = new StringBuilder("LANGUAGE=");
-            sb.Append(libgLocale.Replace("-", "_"));
+            sb.Append(locale.Replace("-", "_"));
             return sb.ToString();
         }
 

--- a/src/DynamoCLI/Program.cs
+++ b/src/DynamoCLI/Program.cs
@@ -20,7 +20,10 @@ namespace DynamoCLI
             {
                 var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
                 useConsole = !cmdLineArgs.NoConsole;
-                var locale = StartupUtils.SetLocale(cmdLineArgs);
+                if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
+                {
+                    DynamoModel.SetUICulture(cmdLineArgs.Locale);
+                }
 
                 cmdLineArgs.SetDisableAnalytics();
 

--- a/src/DynamoSandbox/DynamoCoreSetup.cs
+++ b/src/DynamoSandbox/DynamoCoreSetup.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Windows;
 using Dynamo.Applications;
 using Dynamo.Controls;
@@ -28,9 +27,6 @@ namespace DynamoSandbox
         private const string sandboxWikiPage = @"https://github.com/DynamoDS/Dynamo/wiki/How-to-Utilize-Dynamo-Builds";
         private DynamoViewModel viewModel = null;
 
-        [DllImport("msvcrt.dll")]
-        public static extern int _putenv(string env);
-
         /// <summary>
         /// Constructor
         /// </summary>
@@ -38,8 +34,12 @@ namespace DynamoSandbox
         public DynamoCoreSetup(string[] args)
         {
             var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
-            var locale = StartupUtils.SetLocale(cmdLineArgs);
-            _putenv(locale);
+            // Set locale early so the splash screen renders in the correct language;
+            // DynamoModel construction will also call SetUICulture from preferences.
+            if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
+            {
+                DynamoModel.SetUICulture(cmdLineArgs.Locale);
+            }
 
             cmdLineArgs.SetDisableAnalytics();
 

--- a/src/DynamoWPFCLI/Program.cs
+++ b/src/DynamoWPFCLI/Program.cs
@@ -28,7 +28,10 @@ namespace DynamoWPFCLI
             {
                 var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
                 useConsole = !cmdLineArgs.NoConsole;
-                var locale = StartupUtils.SetLocale(cmdLineArgs);
+                if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
+                {
+                    DynamoModel.SetUICulture(cmdLineArgs.Locale);
+                }
 
                 cmdLineArgs.SetDisableAnalytics();
 

--- a/src/Engine/ProtoCore/FFI/ExtensionAppLoader.cs
+++ b/src/Engine/ProtoCore/FFI/ExtensionAppLoader.cs
@@ -169,7 +169,15 @@ namespace ProtoFFI
 
             if (null != extensionApp)
             {
-                extensionApp.StartUp(new ExtensionStartupParams { DisableADP = Analytics.DisableAnalytics });
+                extensionApp.StartUp(new ExtensionStartupParams
+                {
+                    DisableADP = Analytics.DisableAnalytics,
+                    //  If the extension app is initialized on a thread that hasn’t had DynamoModel.SetUICulture applied
+                    //  (or had it changed later), Locale can differ from Dynamo’s resolved UI culture and
+                    //  LibG/gettext will be set to the wrong language. This therefore assumes that the extension app is
+                    //  initialized on the same thread as DynamoModel.SetUICulture, which is currently the case.
+                    Locale = System.Threading.Thread.CurrentThread.CurrentUICulture.Name
+                });
             }
         }
         

--- a/src/NodeServices/Interfaces.cs
+++ b/src/NodeServices/Interfaces.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Autodesk.DesignScript.Interfaces
@@ -154,6 +154,15 @@ namespace Autodesk.DesignScript.Interfaces
             get;
             set;
         }
+
+        /// <summary>
+        /// Gets the locale to use during extension startup, expressed as a
+        /// BCP 47 culture name such as <c>en-US</c>
+        /// (see <see cref="System.Globalization.CultureInfo.Name"/>).
+        /// A <see langword="null"/> or empty value indicates that no explicit
+        /// locale was provided by the host.
+        /// </summary>
+        public string Locale { get; internal set; }
     }
 
     /// <summary>

--- a/src/NodeServices/PublicAPI.Unshipped.txt
+++ b/src/NodeServices/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+Autodesk.DesignScript.Interfaces.ExtensionStartupParams.Locale.get -> string
 Dynamo.Graph.Nodes.NodeCategoryAttribute
 Dynamo.Graph.Nodes.NodeCategoryAttribute.ElementCategory.get -> string
 Dynamo.Graph.Nodes.NodeCategoryAttribute.ElementCategory.set -> void


### PR DESCRIPTION
## Purpose

Fixes `MissingMethodException` in Complete Install Test phase — all geometry tests fail on startup with:

```
System.MissingMethodException: Method not found:
'System.String Autodesk.DesignScript.Interfaces.ExtensionStartupParams.get_Locale()'
at Autodesk.LibG.ExtensionApplication.StartUp(ExtensionStartupParams startParams)
```

LibG 4.0.0.5334 (introduced in #17175) calls `ExtensionStartupParams.get_Locale()`, which was added to master in #17060 but was not present on `RC4.1.2_master`. This is a cherry-pick of commit `795ddd9142` from master.

This was masked in earlier builds because the duplicate `PackageReference` issue (fixed in #17181) caused the old LibG 4.0.0.4610 to be used, which did not call `get_Locale()`.

## Validation

After merge, trigger a new build on master-15 with `DynamoBranch = RC4.1.2_master`. The Complete Install Test phase should pass.

## API Changes

- [ ] This PR does not include any public API changes.

## Release Notes

N/A - infrastructure fix for RC4.1.2_master, no user-facing change.