### PR TITLE
DYN-10640: Port context menu flashes for a split second then disappears

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -1287,6 +1287,11 @@ namespace Dynamo.Views
             DataContextChanged -= OnWorkspaceViewDataContextChanged;
             Loaded -= WorkspaceView_Loaded;
             Unloaded -= WorkspaceView_Unloaded;
+            if (ownerWindow != null)
+            {
+                ownerWindow.Deactivated -= OwnerWindow_Deactivated;
+                ownerWindow = null;
+            }
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -65,7 +65,7 @@ namespace Dynamo.Views
         private PortViewModel snappedPort;
         private double currentNodeCascadeOffset;
         private Point inCanvasSearchPosition;
-        private List<DependencyObject> hitResultsList = new List<DependencyObject>();
+        private Window ownerWindow;
 
         static internal event Action<Window, ViewModelBase> RequestShowNodeAutoCompleteBar;
         private double currentRenderScale = -1;
@@ -916,26 +916,23 @@ namespace Dynamo.Views
         }
         private void WorkspaceView_Loaded(object sender, RoutedEventArgs e)
         {
-            var ownerWindow = Window.GetWindow(this);
             if (ownerWindow != null)
-            {
+                ownerWindow.Deactivated -= OwnerWindow_Deactivated;
+
+            ownerWindow = Window.GetWindow(this);
+            if (ownerWindow != null)
                 ownerWindow.Deactivated += OwnerWindow_Deactivated;
-            }
         }
 
         private void WorkspaceView_Unloaded(object sender, RoutedEventArgs e)
         {
-            var ownerWindow = Window.GetWindow(this);
             if (ownerWindow != null)
             {
                 ownerWindow.Deactivated -= OwnerWindow_Deactivated;
+                ownerWindow = null;
             }
         }
 
-        /// <summary>
-        /// If the Dynamo window loses focus, the port context menu must close,
-        /// otherwise it will remain open and be visible in other applications.
-        /// </summary>
         private void OwnerWindow_Deactivated(object sender, EventArgs e)
         {
             DestroyPortContextMenu();

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -109,6 +109,8 @@ namespace Dynamo.Views
             InitializeComponent();
 
             DataContextChanged += OnWorkspaceViewDataContextChanged;
+            Loaded += WorkspaceView_Loaded;
+            Unloaded += WorkspaceView_Unloaded;
 
             // view of items to drag
             draggedSelectionTemplate = (DataTemplate)FindResource("DraggedSelectionTemplate");
@@ -912,6 +914,32 @@ namespace Dynamo.Views
                 ViewModel.RequestTogglePanMode();
             }
         }
+        private void WorkspaceView_Loaded(object sender, RoutedEventArgs e)
+        {
+            var ownerWindow = Window.GetWindow(this);
+            if (ownerWindow != null)
+            {
+                ownerWindow.Deactivated += OwnerWindow_Deactivated;
+            }
+        }
+
+        private void WorkspaceView_Unloaded(object sender, RoutedEventArgs e)
+        {
+            var ownerWindow = Window.GetWindow(this);
+            if (ownerWindow != null)
+            {
+                ownerWindow.Deactivated -= OwnerWindow_Deactivated;
+            }
+        }
+
+        /// <summary>
+        /// If the Dynamo window loses focus, the port context menu must close,
+        /// otherwise it will remain open and be visible in other applications.
+        /// </summary>
+        private void OwnerWindow_Deactivated(object sender, EventArgs e)
+        {
+            DestroyPortContextMenu();
+        }
 
         /// <summary>
         /// Closes the port's context menu and sets its references to null.
@@ -1260,6 +1288,8 @@ namespace Dynamo.Views
         {
             RemoveViewModelsubscriptions(ViewModel);
             DataContextChanged -= OnWorkspaceViewDataContextChanged;
+            Loaded -= WorkspaceView_Loaded;
+            Unloaded -= WorkspaceView_Unloaded;
         }
     }
 }

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -1504,5 +1504,44 @@ namespace DynamoCoreWpfTests
             //Wait 3 seconds until the Click Right context menu is opened
             Task.WaitAll(new Task[] { Task.Delay(2000) });
         }
+
+        [Test]
+        [Category("UnitTests")]
+        public void PortContextMenu_ClosesWhenOwnerWindowIsDeactivated()
+        {
+            // Open a new workspace.
+            ViewModel.NewHomeWorkspaceCommand.Execute(null);
+            DispatcherUtil.DoEvents();
+
+            // Grab the WorkspaceView of the new workspace (it must be loaded so it has
+            // subscribed to the owner window's Deactivated event).
+            var currentWs = View.ChildOfType<WorkspaceView>();
+            Assert.IsNotNull(currentWs, "DynamoView does not have any WorkspaceView");
+            DispatcherUtil.DoEvents();
+
+            // The port context menu should not be open on a fresh workspace.
+            Assert.IsFalse(currentWs.PortContextMenu.IsOpen, "Port context menu should not be open on a new workspace");
+
+            // Open the port context menu popup.
+            currentWs.PortContextMenu.IsOpen = true;
+            DispatcherUtil.DoEvents();
+            Assert.IsTrue(currentWs.PortContextMenu.IsOpen, "Port context menu popup was not opened");
+
+            // Simulate the Dynamo window losing focus (e.g. the user switching to another application).
+            var ownerWindow = Window.GetWindow(currentWs);
+            Assert.IsNotNull(ownerWindow, "WorkspaceView does not have an owner window");
+            RaiseDeactivatedEvent(ownerWindow);
+            DispatcherUtil.DoEvents();
+
+            // The port context menu popup must close so it is not left visible on top of other applications.
+            Assert.IsFalse(currentWs.PortContextMenu.IsOpen, "Port context menu should close when the owner window is deactivated");
+        }
+
+        private static void RaiseDeactivatedEvent(Window window)
+        {
+            System.Reflection.MethodInfo onDeactivated = typeof(Window).GetMethod("OnDeactivated",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            onDeactivated.Invoke(window, new object[] { EventArgs.Empty });
+        }
     }
 }


### PR DESCRIPTION
### Purpose

This PR fixes [DYN-10639](https://autodesk.atlassian.net/browse/DYN-10639?atlOrigin=eyJpIjoiZGUzNWUyOWNhNTA0NDVjYmFkMWZlZTk0MWNmYTZmY2YiLCJwIjoiaiJ9), a regression introduced in #16763 where the port context menu briefly flashes and then disappears when opened with a left mouse click.

This PR makes WorkspaceView subscribe to its owner window's Deactivated event and close the port context menu when Dynamo loses focus:

- `WorkspaceView_Loaded` / `WorkspaceView_Unloaded` - resolve the owner window via `Window.GetWindow(this)` and subscribe/unsubscribe the Deactivated handler. The cached `ownerWindow` field guarantees we unsubscribe from the exact same window in Unloaded/Dispose.
- `OwnerWindow_Deactivated` - closes the port context menu via `DestroyPortContextMenu()` on window deactivation.

<img width="1280" height="720" alt="DYN-10640-Fix" src="https://github.com/user-attachments/assets/dab05d12-d7b5-4aea-8718-85e4a70efd0b" />


### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Port context menu does not flash only for a split second when called with left mouse click and closed when the owner window loses focus.

### Reviewers

@DynamoDS/eidos
@jasonstratton
@johnpierson 

### FYIs

@dnenov 