### PR TITLE
DYN-9719: Python auto migration leaves custom definitions marked as dirty

### DIFF
--- a/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
+++ b/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
@@ -534,7 +534,7 @@ namespace Dynamo.PythonMigration
             if (node is PythonNodeBase pyNode && pyNode.EngineName == PythonEngineManager.CPython3EngineName)
             {
                 pyNode.EngineName = PythonEngineManager.PythonNet3EngineName;
-                pyNode.OnNodeModified();
+                pyNode.MarkNodeAsModified();
 
                 if (pyNode is PythonNode py)
                 {

--- a/test/DynamoCoreWpf2Tests/ViewExtensions/PythonMigrationViewExtensionTests.cs
+++ b/test/DynamoCoreWpf2Tests/ViewExtensions/PythonMigrationViewExtensionTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using CoreNodeModels;
+using Dynamo.Graph.Workspaces;
 using Dynamo.PythonServices;
 using Dynamo.Tests;
 using Dynamo.Utilities;
@@ -127,6 +128,61 @@ namespace DynamoCoreWpfTests
                 .Any(engine => string.Equals(engine, expectedEngine, StringComparison.Ordinal));
 
             Assert.IsTrue(match, $"Expected at least one Python node with engine '{expectedEngine}' in '{Path.GetFileName(dyfPath)}'.");
+        }
+
+        [Test]
+        public void ClosingGraphWithCPython3NodesLeavesNoWorkspaceWithUnsavedChanges()
+        {
+            // Turn auto-migration notifications off so they don't interfere with the assertion.
+            Assert.IsNotNull(Model.PreferenceSettings, "Model.PreferenceSettings must be initialized.");
+            Model.PreferenceSettings.ShowPythonAutoMigrationNotifications = false;
+
+            // Assert that the Python Migration view extension is loaded,
+            Assert.IsTrue(View.viewExtensionManager.ViewExtensions.Any(e => e != null && e.Name == "Python Migration"),
+                "Python Migration view extension is not loaded.");
+
+            var pythonDir = Path.Combine(GetTestDirectory(ExecutingDirectory), "core", "python");
+            var childPath = Path.Combine(pythonDir, "CNWithCPython_Child.dyf");
+            var parentPath = Path.Combine(pythonDir, "CNWithCPython_Parent.dyf");
+            var graphPath = Path.Combine(pythonDir, "WithNestedCPythonCustomNodes.dyn");
+
+            Assert.IsTrue(File.Exists(childPath), "Missing test file: " + childPath);
+            Assert.IsTrue(File.Exists(parentPath), "Missing test file: " + parentPath);
+            Assert.IsTrue(File.Exists(graphPath), "Missing test file: " + graphPath);
+
+            // Both custom nodes contain CPython3 nodes before loading.
+            AssertDyfContainsPythonNodesWithEngine(childPath, PythonEngineManager.CPython3EngineName);
+            AssertDyfContainsPythonNodesWithEngine(parentPath, PythonEngineManager.CPython3EngineName);
+
+            Assert.IsTrue(ViewModel.Model.CustomNodeManager.AddUninitializedCustomNode(childPath, true, out _));
+            Assert.IsTrue(ViewModel.Model.CustomNodeManager.AddUninitializedCustomNode(parentPath, true, out _));
+
+            // Open the graph to trigger the in-memory CPython3 -> PythonNet3 migration.
+            Open(graphPath);
+
+            // Assert that the custom node Python nodes were actually migrated in memory.
+            var migratedPyNodes = ViewModel.Model.CustomNodeManager.LoadedWorkspaces
+                .SelectMany(ws => ws.Nodes.OfType<PythonNode>())
+                .ToList();
+            Assert.IsTrue(migratedPyNodes.Any(), "Expected CPython custom node workspaces to be loaded.");
+            Assert.IsTrue(
+                migratedPyNodes.All(n => n.EngineName == PythonEngineManager.PythonNet3EngineName),
+                "Custom node Python nodes were not auto-migrated to PythonNet3.");
+
+            // Close the host graph (creates a fresh, empty home workspace).
+            // The custom node workspaces remain cached in CustomNodeManager.
+            ViewModel.CloseHomeWorkspaceCommand.Execute(null);
+
+            // Assert that no workspace - home or any cached custom node definition  report unsaved changes.
+            var dirtyWorkspaces = Model.Workspaces
+                .Concat(ViewModel.Model.CustomNodeManager.LoadedWorkspaces.Cast<WorkspaceModel>())
+                .Where(ws => ws.HasUnsavedChanges)
+                .Select(ws => ws.Name)
+                .ToList();
+
+            Assert.IsEmpty(dirtyWorkspaces,
+                "These workspaces still report HasUnsavedChanges after closing the graph: "
+                + string.Join(", ", dirtyWorkspaces));
         }
     }
 }


### PR DESCRIPTION
### Purpose

This is a small PR that fixes a bug related to [DYN-9719](https://autodesk.atlassian.net/browse/DYN-9719?atlOrigin=eyJpIjoiMzJmMjA2Mzc5Zjg3NGQzZmFlM2MyMDc2NjNlZmEzOGYiLCJwIjoiaiJ9), although it does not have a dedicated Jira ticket.

Problem :

When a graph containing CPython nodes (or custom nodes that contain CPython nodes) is opened, `PythonMigrationViewExtension.SetEngine(...)` automatically migrates those nodes to PythonNet3 and marks them as modified via `OnNodeModified()`.
Since the graph is not executed during this process, `ClearDirtyFlag()` is never called, leaving the migrated nodes with `IsModified == true`. Custom node workspaces are cached and shared by `CustomNodeManager`, so they remain in memory even after the host graph has been closed.
As a result, when a user attempts to publish a package containing custom nodes that were auto-migrated, `PublishManagerViewModel.GetAllFiles(...)` detects `workspace.HasUnsavedChanges == true` and displays a warning that prevents the publishing process from continuing.

Solution :

This PR replaces `OnNodeModified()` with `MarkNodesAsModified()`. The new approach sets only the `ExecutionHint` dirty flag and does not raise the `Modified` event, preventing `NodeModified` and `HasUnsavedChanges` from being updated.

The PR also adds a regression test to `PythonMigrationViewExtensionTests`.


Before:

<img width="1280" height="720" alt="Before" src="https://github.com/user-attachments/assets/4869b270-c3dc-4ab2-9de3-32e53061f21e" />
</br>

After:

<img width="1280" height="720" alt="After" src="https://github.com/user-attachments/assets/4dcd2c14-cc9f-4680-80e3-5252d0827d82" />
</br>


### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixes a bug where auto-migrating CPython custom nodes prevents packages being published in the same Dynamo session.

### Reviewers

@DynamoDS/eidos
@jasonstratton
@johnpierson

### FYIs

@dnenov 
