### PR TITLE
DYN-10450: Consume DynamoAssistant NuGet as a built-in package

### DIFF
--- a/.github/scripts/check_file_version.ps1
+++ b/.github/scripts/check_file_version.ps1
@@ -81,7 +81,13 @@ $excludedFiles = @(
     "JsonSchema.Net.dll",
     "JsonPointer.Net.dll",
     "Json.More.dll",
-    "DynamoPlayer.*.dll"
+    "DynamoPlayer.*.dll",
+    # DynamoAssistant built-in package (DYN-10450) — versioned independently of Dynamo, signed in its own pipeline.
+    "AutodeskAssistantViewExtension.dll",
+    "AutodeskAssistantViewExtension.resources.dll",
+    "AdpSDKCSharpWrapper.dll",
+    "Analytics.NET.ADP.dll",
+    "Analytics.NET.Core.dll"
 )
 $noVersion = @()
 $wrongVersion = @()

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2234,6 +2234,31 @@
     </ItemGroup>
     <Copy SourceFiles="@(DynamoMcpPkg)" DestinationFolder="$(DynamoMcpDestRoot)%(RecursiveDir)" SkipUnchangedFiles="True" />
   </Target>
+  <!--
+    DynamoAssistant (Autodesk Assistant) built-in package (DYN-10450). Consumed as a signed NuGet
+    (id DynamoVisualProgramming.DynamoAssistant) published by the Dynamo-AutodeskAssistant repo to
+    nuget.org (mirrors DynamoMCP / PythonNet3Engine's NuGet-consume pattern):
+      * ExcludeAssets="all"      -> files only, no compile/runtime refs
+      * GeneratePathProperty="true" -> exposes $(PkgDynamoVisualProgramming_DynamoAssistant)
+    Hard-pinned to an exact version so a transitive bump can't pull an AA built against a
+    different DynamoVisualProgramming.* API. Bump in lockstep with the AA release for this line.
+  -->
+  <ItemGroup>
+    <PackageReference Include="DynamoVisualProgramming.DynamoAssistant" Version="[0.2.2]" GeneratePathProperty="true" ExcludeAssets="all" />
+  </ItemGroup>
+  <!--
+    The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_DynamoAssistant)\bin IS
+    the package layout (pkg.json + bin\ + extra\). Copy it verbatim into Built-In Packages.
+  -->
+  <Target Name="BuildDynamoAssistantDynamoPackage" AfterTargets="Build">
+    <PropertyGroup>
+      <DynamoAssistantDestRoot>$(OutputPath)\Built-In Packages\packages\DynamoAssistant\</DynamoAssistantDestRoot>
+    </PropertyGroup>
+    <ItemGroup>
+      <DynamoAssistantPkg Include="$(PkgDynamoVisualProgramming_DynamoAssistant)\bin\**\*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(DynamoAssistantPkg)" DestinationFolder="$(DynamoAssistantDestRoot)%(RecursiveDir)" SkipUnchangedFiles="True" />
+  </Target>
   <Target Name="CopyPMWizardHtmlFiles" AfterTargets="Build">
     <ItemGroup>
       <HtmlAndBundleFiles Include="Packages\PackageManagerWizard\dist\index.html" />

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2244,7 +2244,7 @@
     different DynamoVisualProgramming.* API. Bump in lockstep with the AA release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.DynamoAssistant" Version="[0.2.2]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.DynamoAssistant" Version="[0.3.1]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
     The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_DynamoAssistant)\bin IS

--- a/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerExtensionLoadingTests.cs
+++ b/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerExtensionLoadingTests.cs
@@ -60,6 +60,7 @@ namespace DynamoCoreWpfTests.PackageManager
                 Is.EquivalentTo(
                     new List<string>
                     {
+                        "Autodesk Assistant",
                         "Documentation Browser",
                         "Dynamo MCP View Extension",
                         "DynamoManipulationExtension",

--- a/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
@@ -38,7 +38,7 @@ namespace DynamoCoreWpfTests.PackageManager
 
         internal string BuiltinPackagesTestDir { get { return Path.Combine(TestDirectory, "builtinpackages testdir", "Packages"); } }
 
-        internal int ExpectedNumberOfBuiltInPackages { get { return 3; } }
+        internal int ExpectedNumberOfBuiltInPackages { get { return 4; } }
 
         #region Utility functions
 

--- a/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerViewExtensionTests.cs
+++ b/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerViewExtensionTests.cs
@@ -159,7 +159,7 @@ namespace DynamoCoreWpfTests.PackageManager
         public void PackageManagerViewExtensionHasCorrectNumberOfRequestedExtensions()
         {
             var pkgViewExtension = View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault();
-            Assert.AreEqual(pkgViewExtension.RequestedExtensions.Count(), 3);
+            Assert.AreEqual(pkgViewExtension.RequestedExtensions.Count(), 4);
         }
 
         [Test]
@@ -208,7 +208,7 @@ namespace DynamoCoreWpfTests.PackageManager
                 var pkg = loader.ScanPackageDirectory(pkgDir);
                 loader.LoadPackages(new List<Package> { pkg });
                 Assert.AreEqual(1, loader.RequestedExtensions.Count());
-                Assert.AreEqual(4, View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault().RequestedExtensions.Count());
+                Assert.AreEqual(5, View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault().RequestedExtensions.Count());
                 Assert.IsTrue(viewExtensionLoadStart);
                 Assert.IsTrue(viewExtensionAdd);
                 Assert.IsTrue(viewExtensionLoaded);


### PR DESCRIPTION
### Purpose

DYN-10450: Consume the Autodesk Assistant NuGet (`DynamoVisualProgramming.DynamoAssistant`, published to nuget.org) and ship it as a **built-in package** under `Built-In Packages\packages\DynamoAssistant`, so Dynamo no longer depends on a separately-installed copy under the user's `AppData` packages folder. Mirrors the DynamoMCP (#17165) / PythonNet3Engine NuGet-consume pattern.

Key changes:
- `src/DynamoCoreWpf/DynamoCoreWpf.csproj`: pinned `DynamoVisualProgramming.DynamoAssistant` `PackageReference` to the published `[0.3.1]` (`GeneratePathProperty` + `ExcludeAssets="all"`), plus a `BuildDynamoAssistantDynamoPackage` target that copies the package verbatim into `Built-In Packages\packages\DynamoAssistant`.
- `.github/scripts/check_file_version.ps1`: exclude the Assistant package's independently-versioned binaries (same treatment as TuneUp / DSPythonNet3 / DynamoMCP) — `AutodeskAssistantViewExtension.dll`, its resources, `AdpSDKCSharpWrapper.dll`, `Analytics.NET.ADP.dll`, `Analytics.NET.Core.dll` (`Newtonsoft.Json.dll` is already excluded).
- PackageManager tests: account for the new built-in package / view extension — added `"Autodesk Assistant"` to the loaded-view-extension list, bumped `ExpectedNumberOfBuiltInPackages` 3→4, and `RequestedExtensions` 3→4 / 4→5.

Notes:
- The version is hard-pinned to the exact `[0.3.1]` release and should be bumped in lockstep with future Autodesk Assistant releases for this line.
- No public API changes; `PublicAPI.Unshipped.txt` is unaffected.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document. (No public API changes in this PR.)

### Release Notes

Autodesk Assistant is now shipped as a built-in package in Dynamo.

### Reviewers

@edwin-vasquez-ucaldas

### FYIs

(N/A)
