### PR TITLE
DYN-: Dyn 10540 template folder tree read only in dynamo

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2919,6 +2919,7 @@ namespace Dynamo.ViewModels
         {
             var directoryInfo = new DirectoryInfo(templatesDirectory);
             if (directoryInfo.Parent != null &&
+                directoryInfo.Name.Length == 5 && directoryInfo.Name[2] == '-' &&
                 string.Equals(directoryInfo.Parent.Name, Configurations.TemplatesAsString, StringComparison.OrdinalIgnoreCase))
             {
                 return directoryInfo.Parent.FullName;

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2837,7 +2837,7 @@ namespace Dynamo.ViewModels
             {
                 Model.Logger.Log(string.Format(Properties.Resources.SavingInProgress, path));
                 var hasSaved = false;
-                if (path.Contains(Model.PathManager.TemplatesDirectory))
+                if (IsPathInTemplateDirectoryTree(path, Model.PathManager.TemplatesDirectory))
                 {
                     // Give user notifications
                     DynamoMessageBox.Show(Owner, WpfResources.WorkspaceSaveTemplateDirectoryBlockMsg, WpfResources.WorkspaceSaveTemplateDirectoryBlockTitle,
@@ -2882,6 +2882,49 @@ namespace Dynamo.ViewModels
                         MessageBoxButton.OK,
                         MessageBoxImage.Warning);
             }
+        }
+
+        internal static bool IsPathInTemplateDirectoryTree(string path, string templatesDirectory)
+        {
+            if (string.IsNullOrEmpty(path) || string.IsNullOrEmpty(templatesDirectory))
+            {
+                return false;
+            }
+
+            try
+            {
+                var templateRootDirectory = GetTemplateRootDirectory(templatesDirectory);
+                var templateRootPath = Path.GetFullPath(templateRootDirectory).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                var savePath = Path.GetFullPath(path);
+
+                return savePath.Equals(templateRootPath, StringComparison.OrdinalIgnoreCase) ||
+                    savePath.StartsWith(templateRootPath + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
+                    savePath.StartsWith(templateRootPath + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+            catch (IOException)
+            {
+                return false;
+            }
+            catch (NotSupportedException)
+            {
+                return false;
+            }
+        }
+
+        private static string GetTemplateRootDirectory(string templatesDirectory)
+        {
+            var directoryInfo = new DirectoryInfo(templatesDirectory);
+            if (directoryInfo.Parent != null &&
+                string.Equals(directoryInfo.Parent.Name, Configurations.TemplatesAsString, StringComparison.OrdinalIgnoreCase))
+            {
+                return directoryInfo.Parent.FullName;
+            }
+
+            return directoryInfo.FullName;
         }
 
         /// <summary>

--- a/test/DynamoCoreWpf3Tests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpf3Tests/WorkspaceSaving.cs
@@ -613,6 +613,13 @@ namespace Dynamo.Tests
                 Path.Combine(customTemplateDirectory, "Nested", "Template.dyn"), customTemplateDirectory));
             Assert.IsFalse(DynamoViewModel.IsPathInTemplateDirectoryTree(
                 Path.Combine(TempFolder, "Template.dyn"), customTemplateDirectory));
+
+            // Custom path whose parent happens to be named "templates" should not climb to the parent
+            var customUnderTemplatesParent = Path.Combine(TempFolder, "templates", "CustomTemplates");
+            Assert.IsFalse(DynamoViewModel.IsPathInTemplateDirectoryTree(
+                Path.Combine(TempFolder, "templates", "other.dyn"), customUnderTemplatesParent));
+            Assert.IsTrue(DynamoViewModel.IsPathInTemplateDirectoryTree(
+                Path.Combine(customUnderTemplatesParent, "Template.dyn"), customUnderTemplatesParent));
         }
 
         [Test]

--- a/test/DynamoCoreWpf3Tests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpf3Tests/WorkspaceSaving.cs
@@ -575,6 +575,48 @@ namespace Dynamo.Tests
 
         [Test]
         [Category("UnitTests")]
+        public void TemplateSavePathCheckBlocksTemplateRootAndChildren()
+        {
+            var templateRoot = Path.Combine(TempFolder, "templates");
+            var localizedTemplateDirectory = Path.Combine(templateRoot, "en-US");
+
+            Assert.IsTrue(DynamoViewModel.IsPathInTemplateDirectoryTree(
+                Path.Combine(templateRoot, "Template.dyn"), localizedTemplateDirectory));
+            Assert.IsTrue(DynamoViewModel.IsPathInTemplateDirectoryTree(
+                Path.Combine(localizedTemplateDirectory, "Template.dyn"), localizedTemplateDirectory));
+            Assert.IsTrue(DynamoViewModel.IsPathInTemplateDirectoryTree(
+                Path.Combine(templateRoot, "fr-FR", "Template.dyn"), localizedTemplateDirectory));
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void TemplateSavePathCheckAllowsPathsOutsideTemplateRoot()
+        {
+            var templateRoot = Path.Combine(TempFolder, "templates");
+            var localizedTemplateDirectory = Path.Combine(templateRoot, "en-US");
+
+            Assert.IsFalse(DynamoViewModel.IsPathInTemplateDirectoryTree(
+                Path.Combine(TempFolder, "templates-other", "Template.dyn"), localizedTemplateDirectory));
+            Assert.IsFalse(DynamoViewModel.IsPathInTemplateDirectoryTree(
+                Path.Combine(TempFolder, "Template.dyn"), localizedTemplateDirectory));
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void TemplateSavePathCheckUsesCustomTemplateFolderAsRoot()
+        {
+            var customTemplateDirectory = Path.Combine(TempFolder, "CustomTemplates");
+
+            Assert.IsTrue(DynamoViewModel.IsPathInTemplateDirectoryTree(
+                Path.Combine(customTemplateDirectory, "Template.dyn"), customTemplateDirectory));
+            Assert.IsTrue(DynamoViewModel.IsPathInTemplateDirectoryTree(
+                Path.Combine(customTemplateDirectory, "Nested", "Template.dyn"), customTemplateDirectory));
+            Assert.IsFalse(DynamoViewModel.IsPathInTemplateDirectoryTree(
+                Path.Combine(TempFolder, "Template.dyn"), customTemplateDirectory));
+        }
+
+        [Test]
+        [Category("UnitTests")]
         public void CanOpenLegacyXmlTemplateAsNewWorkspace()
         {
             var templatePath = Path.Combine(TestDirectory, @"core\math", "Round.dyn");


### PR DESCRIPTION

### Purpose

This PR addresses [DYN-10540](https://autodesk.atlassian.net/browse/DYN-10540).

The changes in the code aim to to prevent users from saving Dynamo graphs anywhere inside the shipped Templates folder tree.
Previously, Dynamo only blocked saves inside the currently resolved localized template folder, for example templates\en-US. This meant users could still save files directly into the parent templates folder or into another localized subfolder such as templates\en-GB.
The update changes the save validation so Dynamo checks against the full template root instead of only the active localized folder. It also normalizes paths before comparing them, so unrelated folders with similar names are not blocked by accident. Custom template locations are still handled as their own template root.

<img width="1280" height="720" alt="DYN-10540 gif" src="https://github.com/user-attachments/assets/ca5d0789-09cb-4ac4-85c8-f17a902a145d" />

Changes :

-Updated the save validation so Dynamo blocks saves anywhere inside the full templates folder tree, not only the active localized folder such as templates\en-US.
-Added path normalization before comparing save paths, so similarly named folders outside the template tree are not blocked accidentally.
-Preserved custom template location behavior by treating the configured custom template folder as its own root.
-Added unit tests covering saves into the template root, active localized folder, sibling localized folders, unrelated folders, and custom template paths.

Note : 

One related behaviour came up during testing: Dynamo remembers the last save location and uses it as the initial folder the next time a template workspace is saved. In ShowSaveDialogAndSaveResult, template workspaces use LastSavedLocation for the Save As dialog. After the user selects a path, LastSavedLocation is updated from _fileDialog.FileName immediately after calling SaveAs(...).

This means that if a user tries to save a template into the blocked templates folder tree, the save is prevented, but that selected folder can still become the last saved location. The next time the user presses Ctrl+S, Dynamo may open Save As in the same blocked folder again, causing the warning to appear repeatedly unless the user manually chooses another location.

This is separate from the current PR’s scope and may need follow-up work so LastSavedLocation and IsTemplate are only updated after a save actually succeeds.


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Improved template save validation so Dynamo no longer allows saving graphs inside the shipped Templates folder tree.

### Reviewers

@zeusongit
@DynamoDS/eidos


### FYIs

@dnenov
@johnpierson
@jnealb 
@jasonstratton 
