### PR TITLE
Revert "10450: Revert "DYN-10553: Consume DynamoMCP NuGet as a built-…

### DIFF
--- a/.github/scripts/check_file_version.ps1
+++ b/.github/scripts/check_file_version.ps1
@@ -73,7 +73,15 @@ $excludedFiles = @(
     "DSPythonNet3.resources.dll",
     "DSPythonNet3Extension.dll",
     "DSPythonNet3Empty.dll",
-    "DSPythonNet3Wheels.dll"
+    "DSPythonNet3Wheels.dll",
+    # DynamoMCP built-in package (DYN-10553) — versioned independently of Dynamo, signed in its own pipeline.
+    "MCPExtension.dll",
+    "MCPServer.dll",
+    "ModelContextProtocol*.dll",
+    "JsonSchema.Net.dll",
+    "JsonPointer.Net.dll",
+    "Json.More.dll",
+    "DynamoPlayer.*.dll"
 )
 $noVersion = @()
 $wrongVersion = @()

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2210,6 +2210,30 @@
     <Copy SourceFiles="@(ExternTuneUpPkg)" DestinationFolder="$(OutputPath)\Built-In Packages\packages\TuneUp\%(RecursiveDir)" />
 	<Copy SourceFiles="@(DistribSamples)" DestinationFolder="$(OutputPath)\Samples" SkipUnchangedFiles="True" />
   </Target>
+  <!--
+    DynamoMCP built-in package (DYN-10553). Consumed as a signed NuGet (id DynamoVisualProgramming.DynamoMCP)
+    published by the DynamoMCP repo to nuget.org (mirrors PythonNet3Engine's NuGet-consume pattern):
+      * ExcludeAssets="all"      -> files only, no compile/runtime refs (preserves MCPServer's isolated ALC)
+      * GeneratePathProperty="true" -> exposes $(PkgDynamoVisualProgramming_DynamoMCP)
+    Hard-pinned to an exact version so a transitive bump can't pull a DynamoMCP built against a
+    different DynamoVisualProgramming.* API. Bump in lockstep with the DynamoMCP release for this line.
+  -->
+  <ItemGroup>
+    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.4.0]" GeneratePathProperty="true" ExcludeAssets="all" />
+  </ItemGroup>
+  <!--
+    The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_DynamoMCP)\bin IS
+    the package layout (pkg.json + bin\ + bin\mcp_server\ + extra\). Copy it verbatim into Built-In Packages.
+  -->
+  <Target Name="BuildDynamoMcpDynamoPackage" AfterTargets="Build">
+    <PropertyGroup>
+      <DynamoMcpDestRoot>$(OutputPath)\Built-In Packages\packages\DynamoMCP\</DynamoMcpDestRoot>
+    </PropertyGroup>
+    <ItemGroup>
+      <DynamoMcpPkg Include="$(PkgDynamoVisualProgramming_DynamoMCP)\bin\**\*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(DynamoMcpPkg)" DestinationFolder="$(DynamoMcpDestRoot)%(RecursiveDir)" SkipUnchangedFiles="True" />
+  </Target>
   <Target Name="CopyPMWizardHtmlFiles" AfterTargets="Build">
     <ItemGroup>
       <HtmlAndBundleFiles Include="Packages\PackageManagerWizard\dist\index.html" />

--- a/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerExtensionLoadingTests.cs
+++ b/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerExtensionLoadingTests.cs
@@ -61,6 +61,7 @@ namespace DynamoCoreWpfTests.PackageManager
                     new List<string>
                     {
                         "Documentation Browser",
+                        "Dynamo MCP View Extension",
                         "DynamoManipulationExtension",
                         "Graph Node Manager",
                         "Graph Status",

--- a/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
@@ -38,7 +38,7 @@ namespace DynamoCoreWpfTests.PackageManager
 
         internal string BuiltinPackagesTestDir { get { return Path.Combine(TestDirectory, "builtinpackages testdir", "Packages"); } }
 
-        internal int ExpectedNumberOfBuiltInPackages { get { return 2; } }
+        internal int ExpectedNumberOfBuiltInPackages { get { return 3; } }
 
         #region Utility functions
 

--- a/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerViewExtensionTests.cs
+++ b/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerViewExtensionTests.cs
@@ -159,7 +159,7 @@ namespace DynamoCoreWpfTests.PackageManager
         public void PackageManagerViewExtensionHasCorrectNumberOfRequestedExtensions()
         {
             var pkgViewExtension = View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault();
-            Assert.AreEqual(pkgViewExtension.RequestedExtensions.Count(), 2);
+            Assert.AreEqual(pkgViewExtension.RequestedExtensions.Count(), 3);
         }
 
         [Test]
@@ -208,7 +208,7 @@ namespace DynamoCoreWpfTests.PackageManager
                 var pkg = loader.ScanPackageDirectory(pkgDir);
                 loader.LoadPackages(new List<Package> { pkg });
                 Assert.AreEqual(1, loader.RequestedExtensions.Count());
-                Assert.AreEqual(3, View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault().RequestedExtensions.Count());
+                Assert.AreEqual(4, View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault().RequestedExtensions.Count());
                 Assert.IsTrue(viewExtensionLoadStart);
                 Assert.IsTrue(viewExtensionAdd);
                 Assert.IsTrue(viewExtensionLoaded);


### PR DESCRIPTION
### Purpose

Re-applying changes already approved in this PR https://github.com/DynamoDS/Dynamo/pull/17165

This reverts commit c835a882266c1c370f146f9d702d7f4c87f048bb.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Re-applying changes already approved in this PR https://github.com/DynamoDS/Dynamo/pull/17165

### Reviewers

@jasonstratton 

### FYIs

