### PR TITLE
DYN-10553: Bump DynamoMCP built-in package to 0.4.1

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2219,7 +2219,7 @@
     different DynamoVisualProgramming.* API. Bump in lockstep with the DynamoMCP release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.4.0]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.4.1]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
     The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_DynamoMCP)\bin IS


### PR DESCRIPTION
### Purpose

Bumps the DynamoMCP built-in package from 0.4.0 to 0.4.1.

[DYN-10553](https://jira.autodesk.com/browse/DYN-10553)

Key changes:
- `DynamoVisualProgramming.DynamoMCP` `PackageReference` in `src/DynamoCoreWpf/DynamoCoreWpf.csproj` updated from `[0.4.0]` to `[0.4.1]`
- The post-build copy target (`BuildDynamoMcpDynamoPackage`) picks up the new version automatically on rebuild — no other changes required

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

N/A

### Reviewers

@DynamoDS/eidos

### FYIs