### PR TITLE
DYN-9707: Harden graph locking against corrupt lock files and improve Save As safety

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/Locking/GraphLockFile.cs
+++ b/src/DynamoCore/Graph/Workspaces/Locking/GraphLockFile.cs
@@ -9,6 +9,17 @@ using Newtonsoft.Json;
 namespace Dynamo.Graph.Workspaces.Locking
 {
     /// <summary>
+    /// Describes the outcome of a <see cref="GraphLockFile.TryRead"/> call.
+    /// </summary>
+    internal enum GraphLockReadResult
+    {
+        NotFound,
+        Ok,
+        Corrupt,
+        TransientFailure
+    }
+
+    /// <summary>
     /// Provides file-system operations for graph lock sidecar files.
     /// </summary>
     internal static class GraphLockFile
@@ -23,6 +34,12 @@ namespace Dynamo.Graph.Workspaces.Locking
             NullValueHandling = NullValueHandling.Ignore,
             TypeNameHandling = TypeNameHandling.None
         });
+
+        private static bool IsValidLockInfo(GraphLockInfo info) =>
+            info != null
+            && info.SessionId != Guid.Empty
+            && !string.IsNullOrEmpty(info.GraphPath)
+            && info.ProcessId > 0;
 
         /// <summary>
         /// Gets the sidecar lock path for a graph file.
@@ -65,9 +82,12 @@ namespace Dynamo.Graph.Workspaces.Locking
         /// <param name="sidecarPath">The sidecar lock file path.</param>
         /// <param name="info">The parsed lock metadata when reading succeeds.</param>
         /// <returns>True if metadata was read; otherwise false.</returns>
-        internal static bool TryRead(string sidecarPath, out GraphLockInfo info)
+        internal static GraphLockReadResult TryRead(string sidecarPath, out GraphLockInfo info)
         {
             info = null;
+
+            if (!File.Exists(sidecarPath))
+                return GraphLockReadResult.NotFound;
 
             const int maxAttempts = 2;
             for (var attempt = 0; attempt < maxAttempts; attempt++)
@@ -81,29 +101,25 @@ namespace Dynamo.Graph.Workspaces.Locking
                         info = Serializer.Deserialize<GraphLockInfo>(jsonReader);
                     }
 
-                    return info != null;
+                    return IsValidLockInfo(info) ? GraphLockReadResult.Ok : GraphLockReadResult.Corrupt;
                 }
-                catch (Exception ex) when (ex is IOException || ex is JsonException)
+                catch (Exception ex) when (ex is JsonException)
+                {
+                    return GraphLockReadResult.Corrupt;
+                }
+                catch (Exception ex) when (ex is IOException)
                 {
                     if (attempt == maxAttempts - 1)
-                    {
-                        return false;
-                    }
-
-                    // Wait for 50 milliseconds before retrying
+                        return GraphLockReadResult.TransientFailure;
                     Thread.Sleep(50);
                 }
-                catch (UnauthorizedAccessException)
+                catch (Exception ex) when (ex is UnauthorizedAccessException || ex is SecurityException)
                 {
-                    return false;
-                }
-                catch (SecurityException)
-                {
-                    return false;
+                    return GraphLockReadResult.TransientFailure;
                 }
             }
 
-            return false;
+            return GraphLockReadResult.TransientFailure;
         }
 
         /// <summary>

--- a/src/DynamoCore/Graph/Workspaces/Locking/GraphLockManager.cs
+++ b/src/DynamoCore/Graph/Workspaces/Locking/GraphLockManager.cs
@@ -194,22 +194,28 @@ namespace Dynamo.Graph.Workspaces.Locking
                     }
 
                     // A lock file already exists: read it to find out who owns it
-                    GraphLockInfo existingLock;
-                    var readable = GraphLockFile.TryRead(sidecarPath, out existingLock);
+                    var readResult = GraphLockFile.TryRead(sidecarPath, out var existingLock);
 
-                    var lockResult = TryAcquireReadableLock(normalizedPath, sidecarPath, info, workspace, readable, existingLock);
+                    if (readResult == GraphLockReadResult.NotFound)
+                    {
+                        // The sidecar was deleted between TryCreateNewLockFile failing and TryRead.
+                        // Retry the loop — TryCreateNewLockFile will succeed on the next attempt.
+                        continue;
+                    }
+
+                    var lockResult = TryAcquireReadableLock(normalizedPath, sidecarPath, info, workspace, readResult, existingLock);
                     if (lockResult != null)
                     {
                         return lockResult;
                     }
 
-                    // ExistingLock is readable and live — a real conflict with another session.
+                    // ExistingLock is Ok and live — a real conflict with another session.
                     return ResolveLockConflict(normalizedPath, allowPromptUI, workspace, existingLock);
                 }
                 catch (Exception ex) when (ex is UnauthorizedAccessException || ex is SecurityException || ex is IOException)
                 {
                     dynamoModel.Logger?.Log("GraphLock unavailable: " + ex.Message);
-                }                
+                }
             }
 
             return GraphLockAcquireResult.Unavailable(normalizedPath);
@@ -220,20 +226,26 @@ namespace Dynamo.Graph.Workspaces.Locking
             string sidecarPath,
             GraphLockInfo info,
             WorkspaceModel workspace,
-            bool readable,
+            GraphLockReadResult readResult,
             GraphLockInfo existingLock)
         {
-            if (!readable)
+            if (readResult == GraphLockReadResult.Corrupt)
             {
-                // The lock file exists but could not be parsed after all retry attempts.
-                // This indicates a corrupt file rather than a live owner.
-                // Treat it the same as a stale lock: overwrite and take ownership.
+                // Definitively unreadable — not evidence of a live owner.
+                // Safe to overwrite and take ownership.
                 GraphLockFile.WriteHeartbeat(sidecarPath, info);
                 RegisterOwnedLock(normalizedPath, sidecarPath, info, workspace);
                 return GraphLockAcquireResult.Acquired(normalizedPath);
             }
 
-            // It is our own lock (same machine + process): reuse it
+            if (readResult == GraphLockReadResult.TransientFailure)
+            {
+                // Could not read due to IO/permissions — a live owner may exist.
+                // Do not steal the lock. Redirect to copy to be safe.
+                dynamoModel.Logger?.Log( "GraphLock: could not read sidecar due to transient failure, redirecting to copy: " + sidecarPath);
+                return GraphLockAcquireResult.Unavailable(normalizedPath);
+            }
+
             if (IsOwnedByThisSession(existingLock))
             {
                 RegisterOwnedLock(normalizedPath, sidecarPath, existingLock, workspace);
@@ -241,10 +253,7 @@ namespace Dynamo.Graph.Workspaces.Locking
             }
 
             // The lock is expired (no recent heartbeat) or owned by a process on this machine
-            // that is no longer running. In these cases the previous owner is gone, so we
-            // silently take the lock over. A present but unreadable lock is not reclaimed here,
-            // it is treated as a real conflict below, so that a transient read failure cannot
-            // make us steal a lock that a live instance still owns.
+            // that is no longer running. Silently take ownership.
             if (IsStale(existingLock) || IsDeadLocalProcess(existingLock))
             {
                 GraphLockFile.WriteHeartbeat(sidecarPath, info);
@@ -304,13 +313,13 @@ namespace Dynamo.Graph.Workspaces.Locking
                 else
                 {
                     GraphLockInfo saveAsLock;
-                    var readable = GraphLockFile.TryRead(sidecarPath, out saveAsLock);
-                    if (readable && IsOwnedByThisSession(saveAsLock))
+                    var saveAsReadResult = GraphLockFile.TryRead(sidecarPath, out saveAsLock);
+                    if (saveAsReadResult == GraphLockReadResult.Ok && IsOwnedByThisSession(saveAsLock))
                     {
                         info = saveAsLock;
                         ownsSaveAsLock = true;
                     }
-                    else if (!readable || IsStale(saveAsLock) || IsDeadLocalProcess(saveAsLock))
+                    else if (saveAsReadResult == GraphLockReadResult.Corrupt || IsStale(saveAsLock) || IsDeadLocalProcess(saveAsLock))
                     {
                         GraphLockFile.WriteHeartbeat(sidecarPath, info);
                         ownsSaveAsLock = true;
@@ -348,7 +357,7 @@ namespace Dynamo.Graph.Workspaces.Locking
             };
         }
 
-        private void RefreshHeartbeats(object state)
+        internal void RefreshHeartbeats(object state = null)
         {
             foreach (var pair in locks.ToList())
             {
@@ -356,7 +365,7 @@ namespace Dynamo.Graph.Workspaces.Locking
                 try
                 {
                     GraphLockInfo current;
-                    if (!GraphLockFile.TryRead(owned.SidecarPath, out current))
+                    if (GraphLockFile.TryRead(owned.SidecarPath, out current) != GraphLockReadResult.Ok)
                     {
                         // Transient IO failure (antivirus, NAS hiccup) — don't drop the lock immediately.
                         // Only abandon after MaxConsecutiveReadFailures consecutive misses.                        
@@ -403,7 +412,7 @@ namespace Dynamo.Graph.Workspaces.Locking
             try
             {
                 GraphLockInfo current;
-                if (GraphLockFile.TryRead(owned.SidecarPath, out current) &&
+                if (GraphLockFile.TryRead(owned.SidecarPath, out current) == GraphLockReadResult.Ok &&
                     current.SessionId == owned.Info.SessionId)
                 {
                     GraphLockFile.TryDelete(owned.SidecarPath);

--- a/src/DynamoCore/Graph/Workspaces/Locking/GraphLockManager.cs
+++ b/src/DynamoCore/Graph/Workspaces/Locking/GraphLockManager.cs
@@ -15,8 +15,9 @@ namespace Dynamo.Graph.Workspaces.Locking
     /// </summary>
     internal sealed class GraphLockManager : IDisposable
     {
-        internal const int DefaultHeartbeatMilliseconds = 30000;
+        internal const int DefaultHeartbeatMilliseconds = 15000;
         private const int StaleFactor = 3;
+        private const int MaxConsecutiveReadFailures = 3;
 
         private readonly DynamoModel dynamoModel;
         private readonly StringComparer pathComparer;
@@ -37,6 +38,7 @@ namespace Dynamo.Graph.Workspaces.Locking
             internal string SidecarPath { get; set; }
             internal GraphLockInfo Info { get; set; }
             internal WorkspaceModel Workspace { get; set; }
+            internal int ConsecutiveReadFailures { get; set; }
         }
 
         /// <summary>
@@ -201,7 +203,7 @@ namespace Dynamo.Graph.Workspaces.Locking
                         return lockResult;
                     }
 
-                    // A live (or currently unreadable) lock owns the path.
+                    // ExistingLock is readable and live — a real conflict with another session.
                     return ResolveLockConflict(normalizedPath, allowPromptUI, workspace, existingLock);
                 }
                 catch (Exception ex) when (ex is UnauthorizedAccessException || ex is SecurityException || ex is IOException)
@@ -223,7 +225,12 @@ namespace Dynamo.Graph.Workspaces.Locking
         {
             if (!readable)
             {
-                return null;
+                // The lock file exists but could not be parsed after all retry attempts.
+                // This indicates a corrupt file rather than a live owner.
+                // Treat it the same as a stale lock: overwrite and take ownership.
+                GraphLockFile.WriteHeartbeat(sidecarPath, info);
+                RegisterOwnedLock(normalizedPath, sidecarPath, info, workspace);
+                return GraphLockAcquireResult.Acquired(normalizedPath);
             }
 
             // It is our own lock (same machine + process): reuse it
@@ -349,9 +356,34 @@ namespace Dynamo.Graph.Workspaces.Locking
                 try
                 {
                     GraphLockInfo current;
-                    if (!GraphLockFile.TryRead(owned.SidecarPath, out current) ||
-                        current.SessionId != owned.Info.SessionId)
+                    if (!GraphLockFile.TryRead(owned.SidecarPath, out current))
                     {
+                        // Transient IO failure (antivirus, NAS hiccup) — don't drop the lock immediately.
+                        // Only abandon after MaxConsecutiveReadFailures consecutive misses.                        
+                        owned.ConsecutiveReadFailures++;
+
+                        if (owned.ConsecutiveReadFailures >= MaxConsecutiveReadFailures)
+                        {
+                            dynamoModel.Logger?.Log(
+                                $"GraphLock heartbeat read failed {MaxConsecutiveReadFailures} consecutive times, " +
+                                $"dropping lock: {owned.SidecarPath}");
+                            locks.TryRemove(pair.Key, out _);
+                        }
+                        else
+                        {
+                            dynamoModel.Logger?.Log(
+                                $"GraphLock heartbeat read failed (attempt {owned.ConsecutiveReadFailures}), " +
+                                $"will retry: {owned.SidecarPath}");
+                        }
+                        continue;
+                    }
+
+                    // Successful read — reset the failure counter
+                    owned.ConsecutiveReadFailures = 0;
+
+                    if (current.SessionId != owned.Info.SessionId)
+                    {
+                        // Lock was genuinely stolen by another instance — stop tracking
                         locks.TryRemove(pair.Key, out _);
                         continue;
                     }

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -520,8 +520,8 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to  already exists.
-        /// Do you want to replace it?.
+        ///   Looks up a localized string similar to  {0} already exists.
+        ///Do you want to replace it?.
         /// </summary>
         public static string ConfirmReplaceFileMessage {
             get {
@@ -3792,7 +3792,7 @@ namespace Dynamo.Wpf.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to This file is currently open in another instance of Dynamo.
-        /// To avoid data loss or corruption, please choose a different file name..
+        ///To avoid data loss or corruption, please choose a different file name..
         /// </summary>
         public static string GraphLockSaveAsSameFileMessage {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -520,6 +520,25 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to  already exists.
+        /// Do you want to replace it?.
+        /// </summary>
+        public static string ConfirmReplaceFileMessage {
+            get {
+                return ResourceManager.GetString("ConfirmReplaceFileMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Confirm Save As.
+        /// </summary>
+        public static string ConfirmReplaceFileTitle {
+            get {
+                return ResourceManager.GetString("ConfirmReplaceFileTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Break Connection.
         /// </summary>
         public static string ConnectorContextMenuHeaderBreakConnection {
@@ -3768,6 +3787,16 @@ namespace Dynamo.Wpf.Properties {
         public static string GraphLockSaveAsButton {
             get {
                 return ResourceManager.GetString("GraphLockSaveAsButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This file is currently open in another instance of Dynamo.
+        /// To avoid data loss or corruption, please choose a different file name..
+        /// </summary>
+        public static string GraphLockSaveAsSameFileMessage {
+            get {
+                return ResourceManager.GetString("GraphLockSaveAsSameFileMessage", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -4315,7 +4315,7 @@ To avoid data loss or corruption, please choose one of the following actions:
 To avoid data loss or corruption, please choose a different file name.</value>
   </data>
   <data name="ConfirmReplaceFileMessage" xml:space="preserve">
-    <value> already exists.
+    <value> {0} already exists.
 Do you want to replace it?</value>
   </data>
   <data name="ConfirmReplaceFileTitle" xml:space="preserve">

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -4310,4 +4310,15 @@ To avoid data loss or corruption, please choose one of the following actions:
   <data name="GraphLockSaveAsButton" xml:space="preserve">
     <value>Save As</value>
   </data>
+  <data name="GraphLockSaveAsSameFileMessage" xml:space="preserve">
+    <value>This file is currently open in another instance of Dynamo.
+To avoid data loss or corruption, please choose a different file name.</value>
+  </data>
+  <data name="ConfirmReplaceFileMessage" xml:space="preserve">
+    <value> already exists.
+Do you want to replace it?</value>
+  </data>
+  <data name="ConfirmReplaceFileTitle" xml:space="preserve">
+    <value>Confirm Save As</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -4302,7 +4302,7 @@ To avoid data loss or corruption, please choose one of the following actions:
 To avoid data loss or corruption, please choose a different file name.</value>
   </data>
   <data name="ConfirmReplaceFileMessage" xml:space="preserve">
-    <value> already exists.
+    <value> {0} already exists.
 Do you want to replace it?</value>
   </data>
   <data name="ConfirmReplaceFileTitle" xml:space="preserve">

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -4297,4 +4297,15 @@ To avoid data loss or corruption, please choose one of the following actions:
   <data name="GraphLockSaveAsButton" xml:space="preserve">
     <value>Save As</value>
   </data>
+  <data name="GraphLockSaveAsSameFileMessage" xml:space="preserve">
+    <value>This file is currently open in another instance of Dynamo.
+To avoid data loss or corruption, please choose a different file name.</value>
+  </data>
+  <data name="ConfirmReplaceFileMessage" xml:space="preserve">
+    <value> already exists.
+Do you want to replace it?</value>
+  </data>
+  <data name="ConfirmReplaceFileTitle" xml:space="preserve">
+    <value>Confirm Save As</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -33,6 +33,9 @@ Dynamo.ViewModels.PreferencesViewModel.AutoSyncDocumentBrowserIsChecked.get -> b
 Dynamo.ViewModels.PreferencesViewModel.AutoSyncDocumentBrowserIsChecked.set -> void
 Dynamo.ViewModels.PreferencesViewModel.ShowPythonAutoMigrationNotificationIsChecked.get -> bool
 Dynamo.ViewModels.PreferencesViewModel.ShowPythonAutoMigrationNotificationIsChecked.set -> void
+Dynamo.Wpf.UI.CustomSaveFileDialog.FileOk -> event System.ComponentModel.CancelEventHandler
+Dynamo.Wpf.UI.CustomSaveFileDialog.OverwritePrompt.get -> bool
+Dynamo.Wpf.UI.CustomSaveFileDialog.OverwritePrompt.set -> void
 Dynamo.Wpf.UI.ToastManager
 Dynamo.Wpf.UI.ToastManager.CloseRealTimeInfoWindow() -> void
 Dynamo.Wpf.UI.ToastManager.CreateRealTimeInfoWindow(string content, bool stayOpen = false, string headerText = "", string hyperlinkText = "", System.Uri hyperlinkUri = null, System.Uri fileLinkUri = null) -> void

--- a/src/DynamoCoreWpf/Services/WpfGraphLockUserPrompt.cs
+++ b/src/DynamoCoreWpf/Services/WpfGraphLockUserPrompt.cs
@@ -23,16 +23,17 @@ namespace Dynamo.Wpf.Services
         /// Initializes a WPF graph-lock prompt.
         /// </summary>
         /// <param name="ownerProvider">Provides the owner window when a prompt is shown.</param>
-        /// <param name="productNameProvider">Provides the product name for save-dialog filters.</param>
+        /// <param name="productName">The product name for save-dialog filters.</param>
         /// <param name="dialogFactory">Optional factory for the save dialog; defaults to <see cref="CustomSaveFileDialog"/>.</param>
         /// <param name="showMessageBox">Optional message box function used for conflict and overwrite prompts.</param>
+        internal WpfGraphLockUserPrompt(
             Func<Window> ownerProvider,
-            string productNameProvider,
+            string productName,
             Func<IFileSaver> dialogFactory = null,
             Func<string, string, MessageBoxButtons, MessageBoxIcon, DialogResult> showMessageBox = null)
         {
             this.ownerProvider = ownerProvider;
-            this.productNameProvider = productNameProvider;
+            this.productNameProvider = productName;
             this.dialogFactory = dialogFactory ?? (() => new CustomSaveFileDialog());
             this.showMessageBox = showMessageBox ?? System.Windows.Forms.MessageBox.Show;
         }
@@ -114,7 +115,7 @@ namespace Dynamo.Wpf.Services
                 if (File.Exists(chosenPath))
                 {
                     var confirm = showMessageBox(
-                        Path.GetFileName(chosenPath) + Resources.ConfirmReplaceFileMessage,
+                        string.Format(Resources.ConfirmReplaceFileMessage, Path.GetFileName(chosenPath)),
                         Resources.ConfirmReplaceFileTitle,
                         MessageBoxButtons.YesNo,
                         MessageBoxIcon.Warning);

--- a/src/DynamoCoreWpf/Services/WpfGraphLockUserPrompt.cs
+++ b/src/DynamoCoreWpf/Services/WpfGraphLockUserPrompt.cs
@@ -25,8 +25,7 @@ namespace Dynamo.Wpf.Services
         /// <param name="ownerProvider">Provides the owner window when a prompt is shown.</param>
         /// <param name="productNameProvider">Provides the product name for save-dialog filters.</param>
         /// <param name="dialogFactory">Optional factory for the save dialog; defaults to <see cref="CustomSaveFileDialog"/>.</param>
-        /// <param name="showMessageBox">Optional message box function used for conflict and overwrite prompts/>.</param>
-        internal WpfGraphLockUserPrompt(
+        /// <param name="showMessageBox">Optional message box function used for conflict and overwrite prompts.</param>
             Func<Window> ownerProvider,
             string productNameProvider,
             Func<IFileSaver> dialogFactory = null,

--- a/src/DynamoCoreWpf/Services/WpfGraphLockUserPrompt.cs
+++ b/src/DynamoCoreWpf/Services/WpfGraphLockUserPrompt.cs
@@ -5,6 +5,7 @@ using Dynamo.Wpf.UI;
 using System;
 using System.IO;
 using System.Windows;
+using System.Windows.Forms;
 
 namespace Dynamo.Wpf.Services
 {
@@ -75,12 +76,27 @@ namespace Dynamo.Wpf.Services
                 DefaultExt = defaultExt,
                 Filter = filter,
                 FileName = Path.GetFileName(graphPath),
+                OverwritePrompt = false,
             };
 
             if (Directory.Exists(directory))
             {
                 dialog.InitialDirectory = directory;
             }
+
+            // Prevent the dialog from closing as long as the chosen path matches the original.
+            dialog.FileOk += (sender, e) =>
+            {
+                if (string.Equals(dialog.FileName, graphPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    System.Windows.Forms.MessageBox.Show(
+                        "This file is currently open in another instance of Dynamo.\nTo avoid data loss or corruption, please choose a different file name.",
+                        "File already open in another Dynamo instance",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Warning);
+                    e.Cancel = true;
+                }
+            };
 
             return dialog.ShowDialog() == true ? dialog.FileName : null;
         }

--- a/src/DynamoCoreWpf/Services/WpfGraphLockUserPrompt.cs
+++ b/src/DynamoCoreWpf/Services/WpfGraphLockUserPrompt.cs
@@ -17,6 +17,7 @@ namespace Dynamo.Wpf.Services
         private readonly Func<Window> ownerProvider;
         private readonly string productNameProvider;
         private readonly Func<IFileSaver> dialogFactory;
+        private readonly Func<string, string, MessageBoxButtons, MessageBoxIcon, DialogResult> showMessageBox;
 
         /// <summary>
         /// Initializes a WPF graph-lock prompt.
@@ -24,11 +25,17 @@ namespace Dynamo.Wpf.Services
         /// <param name="ownerProvider">Provides the owner window when a prompt is shown.</param>
         /// <param name="productNameProvider">Provides the product name for save-dialog filters.</param>
         /// <param name="dialogFactory">Optional factory for the save dialog; defaults to <see cref="CustomSaveFileDialog"/>.</param>
-        internal WpfGraphLockUserPrompt(Func<Window> ownerProvider, string productNameProvider, Func<IFileSaver> dialogFactory = null)
+        /// <param name="showMessageBox">Optional message box function used for conflict and overwrite prompts/>.</param>
+        internal WpfGraphLockUserPrompt(
+            Func<Window> ownerProvider,
+            string productNameProvider,
+            Func<IFileSaver> dialogFactory = null,
+            Func<string, string, MessageBoxButtons, MessageBoxIcon, DialogResult> showMessageBox = null)
         {
             this.ownerProvider = ownerProvider;
             this.productNameProvider = productNameProvider;
             this.dialogFactory = dialogFactory ?? (() => new CustomSaveFileDialog());
+            this.showMessageBox = showMessageBox ?? System.Windows.Forms.MessageBox.Show;
         }
 
         /// <summary>
@@ -62,7 +69,7 @@ namespace Dynamo.Wpf.Services
         }
 
         // Shows a Save As dialog for the copy path, matching the graph file extension
-        private string ShowSaveAsDialog(string graphPath)
+        internal string ShowSaveAsDialog(string graphPath)
         {
             var extension = Path.GetExtension(graphPath);
             var directory = Path.GetDirectoryName(graphPath);
@@ -94,7 +101,7 @@ namespace Dynamo.Wpf.Services
                 // Block saving over the locked source file
                 if (string.Equals(chosenPath, normalizedSourcePath, StringComparison.OrdinalIgnoreCase))
                 {
-                    System.Windows.Forms.MessageBox.Show(
+                    showMessageBox(
                         Resources.GraphLockSaveAsSameFileMessage,
                         Resources.GraphLockFileAlreadyOpenTitle,
                         MessageBoxButtons.OK,
@@ -107,7 +114,7 @@ namespace Dynamo.Wpf.Services
                 // for any other existing file the user may have chosen.
                 if (File.Exists(chosenPath))
                 {
-                    var confirm = System.Windows.Forms.MessageBox.Show(
+                    var confirm = showMessageBox(
                         Path.GetFileName(chosenPath) + Resources.ConfirmReplaceFileMessage,
                         Resources.ConfirmReplaceFileTitle,
                         MessageBoxButtons.YesNo,

--- a/src/DynamoCoreWpf/Services/WpfGraphLockUserPrompt.cs
+++ b/src/DynamoCoreWpf/Services/WpfGraphLockUserPrompt.cs
@@ -16,16 +16,19 @@ namespace Dynamo.Wpf.Services
     {
         private readonly Func<Window> ownerProvider;
         private readonly string productNameProvider;
+        private readonly Func<IFileSaver> dialogFactory;
 
         /// <summary>
         /// Initializes a WPF graph-lock prompt.
         /// </summary>
         /// <param name="ownerProvider">Provides the owner window when a prompt is shown.</param>
         /// <param name="productNameProvider">Provides the product name for save-dialog filters.</param>
-        internal WpfGraphLockUserPrompt(Func<Window> ownerProvider, string productNameProvider)
+        /// <param name="dialogFactory">Optional factory for the save dialog; defaults to <see cref="CustomSaveFileDialog"/>.</param>
+        internal WpfGraphLockUserPrompt(Func<Window> ownerProvider, string productNameProvider, Func<IFileSaver> dialogFactory = null)
         {
             this.ownerProvider = ownerProvider;
             this.productNameProvider = productNameProvider;
+            this.dialogFactory = dialogFactory ?? (() => new CustomSaveFileDialog());
         }
 
         /// <summary>
@@ -70,31 +73,49 @@ namespace Dynamo.Wpf.Services
                 ? string.Format(Resources.FileDialogDynamoCustomNode, productName, "*.dyf")
                 : string.Format(Resources.FileDialogDynamoWorkspace, productName, "*.dyn");
 
-            var dialog = new CustomSaveFileDialog
-            {
-                AddExtension = true,
-                DefaultExt = defaultExt,
-                Filter = filter,
-                FileName = Path.GetFileName(graphPath),
-                OverwritePrompt = false,
-            };
+            var normalizedSourcePath = Path.GetFullPath(graphPath);
+
+            var dialog = dialogFactory();
+            dialog.AddExtension = true;
+            dialog.DefaultExt = defaultExt;
+            dialog.Filter = filter;
+            dialog.FileName = Path.GetFileName(graphPath);
+            dialog.OverwritePrompt = false;
 
             if (Directory.Exists(directory))
             {
                 dialog.InitialDirectory = directory;
             }
 
-            // Prevent the dialog from closing as long as the chosen path matches the original.
             dialog.FileOk += (sender, e) =>
             {
-                if (string.Equals(dialog.FileName, graphPath, StringComparison.OrdinalIgnoreCase))
+                var chosenPath = Path.GetFullPath(dialog.FileName);
+
+                // Block saving over the locked source file
+                if (string.Equals(chosenPath, normalizedSourcePath, StringComparison.OrdinalIgnoreCase))
                 {
                     System.Windows.Forms.MessageBox.Show(
-                        "This file is currently open in another instance of Dynamo.\nTo avoid data loss or corruption, please choose a different file name.",
-                        "File already open in another Dynamo instance",
+                        Resources.GraphLockSaveAsSameFileMessage,
+                        Resources.GraphLockFileAlreadyOpenTitle,
                         MessageBoxButtons.OK,
                         MessageBoxIcon.Warning);
                     e.Cancel = true;
+                    return;
+                }
+
+                // OverwritePrompt is false so we must replicate the OS overwrite warning
+                // for any other existing file the user may have chosen.
+                if (File.Exists(chosenPath))
+                {
+                    var confirm = System.Windows.Forms.MessageBox.Show(
+                        Path.GetFileName(chosenPath) + Resources.ConfirmReplaceFileMessage,
+                        Resources.ConfirmReplaceFileTitle,
+                        MessageBoxButtons.YesNo,
+                        MessageBoxIcon.Warning);
+                    if (confirm != DialogResult.Yes)
+                    {
+                        e.Cancel = true;
+                    }
                 }
             };
 

--- a/src/DynamoCoreWpf/UI/CustomSaveFileDialog.cs
+++ b/src/DynamoCoreWpf/UI/CustomSaveFileDialog.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Windows.Forms;
 
 namespace Dynamo.Wpf.UI
@@ -12,7 +13,9 @@ namespace Dynamo.Wpf.UI
         string FileName { get; set; }
         public bool AddExtension { get; set; }
         public string InitialDirectory { get; set; }
-        bool? ShowDialog(); // Returns true if OK, false if Cancel, null for other cases
+        event CancelEventHandler FileOk;
+        bool OverwritePrompt { get; set; }
+        bool? ShowDialog(); // Returns true if OK, false if Cancel, null for other cases        
     }
 
     /// <summary>
@@ -52,6 +55,18 @@ namespace Dynamo.Wpf.UI
             set => _dialog.InitialDirectory = value;
         }
       
+        public event CancelEventHandler FileOk
+        {
+            add => _dialog.FileOk += value;
+            remove => _dialog.FileOk -= value;
+        }
+
+        public bool OverwritePrompt
+        {
+            get => _dialog.OverwritePrompt;
+            set => _dialog.OverwritePrompt = value;
+        }
+
         public bool? ShowDialog()
         {
             DialogResult result = _dialog.ShowDialog();

--- a/test/DynamoCoreTests/Graph/Workspaces/GraphLockManagerTests.cs
+++ b/test/DynamoCoreTests/Graph/Workspaces/GraphLockManagerTests.cs
@@ -208,5 +208,110 @@ namespace Dynamo.Tests
                 return response;
             }
         }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenLockFileIsCorruptThenAcquireSucceedsWithoutPrompt()
+        {
+            // Arrange - write a sidecar that cannot be parsed as JSON so TryRead returns false
+            var graphPath = CreateGraphFile("corrupt-lock.dyn");
+            var lockPath = GraphLockFile.GetLockFilePath(graphPath);
+            File.WriteAllText(lockPath, "{ this is not valid json {{{{");
+            var prompt = new TestGraphLockUserPrompt(GraphLockUserResponse.Cancel());
+
+            using (var manager = CreateManager(prompt))
+            {
+                // Act
+                var result = manager.AcquireLock(graphPath, true);
+
+                // Assert - corrupt sidecar is treated as stale, not shown to the user as a conflict
+                Assert.AreEqual(GraphLockOutcome.Opened, result.Conflict);
+                Assert.IsTrue(result.ShouldOpen);
+                Assert.AreEqual(0, prompt.CallCount, "Prompt must not fire for a corrupt lock file");
+
+                manager.CompleteOpen(graphPath, true);
+                manager.Release(graphPath);
+            }
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenLockFileIsCorruptThenOwnershipIsTransferredToCurrentSession()
+        {
+            // Arrange
+            var graphPath = CreateGraphFile("corrupt-lock-ownership.dyn");
+            var lockPath = GraphLockFile.GetLockFilePath(graphPath);
+            File.WriteAllText(lockPath, "not valid json at all");
+
+            using (var manager = CreateManager())
+            {
+                // Act
+                var result = manager.AcquireLock(graphPath, true);
+                manager.CompleteOpen(graphPath, true);
+
+                // Assert - sidecar is overwritten with a valid lock owned by this session
+                Assert.AreEqual(GraphLockOutcome.Opened, result.Conflict);
+                var lockInfo = ReadLockInfo(lockPath);
+                Assert.AreEqual(Path.GetFullPath(graphPath), lockInfo.GraphPath);
+                Assert.That(lockInfo.SessionId, Is.Not.EqualTo(Guid.Empty));
+                Assert.That(lockInfo.LastHeartbeatUtc, Is.GreaterThan(DateTime.UtcNow.AddSeconds(-5)));
+
+                manager.Release(graphPath);
+            }
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenHeartbeatDetectsSessionMismatchThenForeignLockIsNotDeleted()
+        {
+            // Arrange - acquire, then simulate another instance overwriting the sidecar
+            var graphPath = CreateGraphFile("heartbeat-mismatch.dyn");
+            var lockPath = GraphLockFile.GetLockFilePath(graphPath);
+            var stolenLock = CreateForeignLockInfo(graphPath, DateTime.UtcNow);
+
+            using (var manager = CreateManager(heartbeatMilliseconds: 100))
+            {
+                var result = manager.AcquireLock(graphPath, true);
+                manager.CompleteOpen(graphPath, true);
+                Assert.AreEqual(GraphLockOutcome.Opened, result.Conflict);
+
+                // Overwrite the sidecar to simulate another instance stealing the lock
+                GraphLockFile.WriteHeartbeat(lockPath, stolenLock);
+
+                // Wait for at least two heartbeat ticks so the mismatch is detected
+                System.Threading.Thread.Sleep(350);
+            }
+
+            // Assert - manager must not delete a sidecar it no longer owns
+            Assert.IsTrue(File.Exists(lockPath));
+            Assert.IsTrue(GraphLockFile.TryRead(lockPath, out var remaining));
+            Assert.AreEqual(stolenLock.SessionId, remaining.SessionId);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenLiveLockExistsOnRemoteMachineThenPromptIsCalledWithNonNullLockInfo()
+        {
+            // Arrange - verifies that ResolveLockConflict only fires with a fully readable lock,
+            // guarding against the null-prompt bug from a corrupt sidecar
+            var graphPath = CreateGraphFile("live-remote-lock.dyn");
+            var lockPath = GraphLockFile.GetLockFilePath(graphPath);
+            var existingLock = CreateForeignLockInfo(graphPath, DateTime.UtcNow);
+            Assert.IsTrue(GraphLockFile.TryCreateNewLockFile(lockPath, existingLock));
+
+            var prompt = new TestGraphLockUserPrompt(GraphLockUserResponse.Cancel());
+
+            using (var manager = CreateManager(prompt))
+            {
+                // Act
+                manager.AcquireLock(graphPath, true);
+                manager.CompleteOpen(graphPath, false);
+            }
+
+            // Assert - prompt received a non-null, readable lock (not null from a corrupt file)
+            Assert.AreEqual(1, prompt.CallCount);
+            Assert.IsNotNull(prompt.ExistingLock, "Prompt must never receive a null ExistingLock");
+            Assert.AreEqual(existingLock.SessionId, prompt.ExistingLock.SessionId);
+        }
     }
 }

--- a/test/DynamoCoreTests/Graph/Workspaces/GraphLockManagerTests.cs
+++ b/test/DynamoCoreTests/Graph/Workspaces/GraphLockManagerTests.cs
@@ -181,7 +181,8 @@ namespace Dynamo.Tests
 
         private static GraphLockInfo ReadLockInfo(string lockPath)
         {
-            Assert.IsTrue(GraphLockFile.TryRead(lockPath, out var lockInfo));
+            Assert.AreEqual(GraphLockReadResult.Ok, GraphLockFile.TryRead(lockPath, out var lockInfo),
+                "Expected lock file to be readable at: " + lockPath);
             return lockInfo;
         }
 
@@ -269,22 +270,23 @@ namespace Dynamo.Tests
             var lockPath = GraphLockFile.GetLockFilePath(graphPath);
             var stolenLock = CreateForeignLockInfo(graphPath, DateTime.UtcNow);
 
-            using (var manager = CreateManager(heartbeatMilliseconds: 100))
+            using (var manager = CreateManager(heartbeatMilliseconds: int.MaxValue))
             {
                 var result = manager.AcquireLock(graphPath, true);
                 manager.CompleteOpen(graphPath, true);
                 Assert.AreEqual(GraphLockOutcome.Opened, result.Conflict);
 
-                // Overwrite the sidecar to simulate another instance stealing the lock
+                // Simulate another instance overwriting our sidecar
                 GraphLockFile.WriteHeartbeat(lockPath, stolenLock);
 
-                // Wait for at least two heartbeat ticks so the mismatch is detected
-                System.Threading.Thread.Sleep(350);
+                // Trigger one heartbeat cycle directly
+                manager.RefreshHeartbeats();
             }
 
             // Assert - manager must not delete a sidecar it no longer owns
             Assert.IsTrue(File.Exists(lockPath));
-            Assert.IsTrue(GraphLockFile.TryRead(lockPath, out var remaining));
+            Assert.AreEqual(GraphLockReadResult.Ok, GraphLockFile.TryRead(lockPath, out var remaining),
+                "Expected stolen lock sidecar to still be readable after session mismatch.");
             Assert.AreEqual(stolenLock.SessionId, remaining.SessionId);
         }
 

--- a/test/DynamoCoreWpfTests/WpfGraphLockUserPromptTests.cs
+++ b/test/DynamoCoreWpfTests/WpfGraphLockUserPromptTests.cs
@@ -36,7 +36,7 @@ namespace DynamoCoreWpfTests
         {
             return new WpfGraphLockUserPrompt(
                 ownerProvider: () => null,
-                productNameProvider: "Dynamo",
+                productName: "Dynamo",
                 dialogFactory: () => dialog,
                 showMessageBox: msgBox ?? ((_, __, ___, ____) => DialogResult.OK));
         }

--- a/test/DynamoCoreWpfTests/WpfGraphLockUserPromptTests.cs
+++ b/test/DynamoCoreWpfTests/WpfGraphLockUserPromptTests.cs
@@ -1,0 +1,179 @@
+using Dynamo.Graph.Workspaces.Locking;
+using Dynamo.Wpf.Services;
+using Dynamo.Wpf.UI;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Windows.Forms;
+
+namespace DynamoCoreWpfTests
+{
+    [TestFixture]
+    [Category("UnitTests")]
+    public class WpfGraphLockUserPromptTests
+    {
+        private string tempDir;
+
+        [SetUp]
+        public void SetUp()
+        {
+            tempDir = Path.Combine(Path.GetTempPath(), System.Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+
+        private string FilePath(string name) => Path.Combine(tempDir, name);
+
+        private WpfGraphLockUserPrompt CreatePrompt(
+            IFileSaver dialog,
+            Func<string, string, MessageBoxButtons, MessageBoxIcon, DialogResult> msgBox = null)
+        {
+            return new WpfGraphLockUserPrompt(
+                ownerProvider: () => null,
+                productNameProvider: "Dynamo",
+                dialogFactory: () => dialog,
+                showMessageBox: msgBox ?? ((_, __, ___, ____) => DialogResult.OK));
+        }
+
+        [Test]
+        public void WhenUserPicksLockedSourceFileThenSaveIsBlocked()
+        {
+            // Arrange
+            var graphPath = FilePath("locked.dyn");
+            File.WriteAllText(graphPath, "graph");
+            var dialog = new MockFileSaver { FileToSelect = graphPath };
+            var prompt = CreatePrompt(dialog);
+
+            // Act
+            var result = prompt.ShowSaveAsDialog(graphPath);
+
+            // Assert
+            Assert.IsNull(result, "Picking the locked source file must cancel the save");
+        }
+
+        [Test]
+        public void WhenUserPicksLockedSourceFileWithDifferentCasingThenSaveIsBlocked()
+        {
+            // Arrange - validates the Path.GetFullPath normalisation fix
+            var graphPath = FilePath("MyGraph.dyn");
+            File.WriteAllText(graphPath, "graph");
+            var dialog = new MockFileSaver { FileToSelect = graphPath.ToUpperInvariant() };
+            var prompt = CreatePrompt(dialog);
+
+            // Act
+            var result = prompt.ShowSaveAsDialog(graphPath);
+
+            // Assert
+            Assert.IsNull(result, "Case-insensitive path match must still block the save");
+        }
+
+        [Test]
+        public void WhenUserPicksNewNonExistingFileThenSaveProceeds()
+        {
+            // Arrange
+            var graphPath = FilePath("source.dyn");
+            var savePath = FilePath("new-copy.dyn");
+            File.WriteAllText(graphPath, "graph");
+            // savePath intentionally does not exist
+            var dialog = new MockFileSaver { FileToSelect = savePath };
+            var prompt = CreatePrompt(dialog);
+
+            // Act
+            var result = prompt.ShowSaveAsDialog(graphPath);
+
+            // Assert
+            Assert.AreEqual(savePath, result, "Picking a new path should proceed without any prompt");
+        }
+
+        [Test]
+        public void WhenUserPicksExistingFileAndConfirmsThenSaveProceeds()
+        {
+            // Arrange
+            var graphPath = FilePath("source.dyn");
+            var existingPath = FilePath("existing.dyn");
+            File.WriteAllText(graphPath, "graph");
+            File.WriteAllText(existingPath, "other graph");
+
+            var dialog = new MockFileSaver { FileToSelect = existingPath };
+            var prompt = CreatePrompt(dialog, (_, __, ___, ____) => DialogResult.Yes);
+
+            // Act
+            var result = prompt.ShowSaveAsDialog(graphPath);
+
+            // Assert
+            Assert.AreEqual(existingPath, result, "Confirming overwrite should allow the save");
+        }
+
+        [Test]
+        public void WhenUserPicksExistingFileAndDeclinesOverwriteThenSaveIsBlocked()
+        {
+            // Arrange
+            var graphPath = FilePath("source.dyn");
+            var existingPath = FilePath("existing.dyn");
+            File.WriteAllText(graphPath, "graph");
+            File.WriteAllText(existingPath, "other graph");
+
+            var dialog = new MockFileSaver { FileToSelect = existingPath };
+            var prompt = CreatePrompt(dialog, (_, __, ___, ____) => DialogResult.No);
+
+            // Act
+            var result = prompt.ShowSaveAsDialog(graphPath);
+
+            // Assert
+            Assert.IsNull(result, "Declining the overwrite confirmation must cancel the save");
+        }
+
+        [Test]
+        public void WhenUserCancelsDialogThenSaveIsBlocked()
+        {
+            // Arrange - user presses Cancel without picking any file
+            var graphPath = FilePath("source.dyn");
+            File.WriteAllText(graphPath, "graph");
+            var dialog = new MockFileSaver { SimulatedShowDialogResult = false };
+            var prompt = CreatePrompt(dialog);
+
+            // Act
+            var result = prompt.ShowSaveAsDialog(graphPath);
+
+            // Assert
+            Assert.IsNull(result, "Cancelling the dialog should return null");
+        }
+
+        private sealed class MockFileSaver : IFileSaver
+        {
+            public string Filter { get; set; }
+            public string DefaultExt { get; set; }
+            public string FileName { get; set; }
+            public bool AddExtension { get; set; }
+            public string InitialDirectory { get; set; }
+            public bool OverwritePrompt { get; set; }
+
+            internal string FileToSelect { get; set; }
+            internal bool? SimulatedShowDialogResult { get; set; } = true;
+
+            private System.ComponentModel.CancelEventHandler fileOkHandler;
+            public event System.ComponentModel.CancelEventHandler FileOk
+            {
+                add => fileOkHandler += value;
+                remove => fileOkHandler -= value;
+            }
+
+            public bool? ShowDialog()
+            {
+                if (FileToSelect != null)
+                    FileName = FileToSelect;
+
+                var args = new System.ComponentModel.CancelEventArgs();
+                fileOkHandler?.Invoke(this, args);
+
+                return args.Cancel ? false : SimulatedShowDialogResult;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

This PR is related to [DYN-9707](https://autodesk.atlassian.net/browse/DYN-9707?atlOrigin=eyJpIjoiMTE5MDM1ZGM3YjU0NDEyOTg5Yzc3NTU1ZDg3NDY3MDciLCJwIjoiaiJ9) and addresses [this](https://autodesk.atlassian.net/browse/DYN-9707?focusedCommentId=24031241) post plus a comment from a recent catchup. The changes improve the behaviour of the graph locking mechanism that prevents two Dynamo instances from opening and editing the same `.dyn` or `.dyf` file at the same time.

When Dynamo opens a graph file it writes a small sidecar file (`.dynlock`) to signal that the file is in use. If another Dynamo instance detects that sidecar, it shows a prompt asking the user to either cancel or save a copy of the graph to work on instead. Several edge cases in that flow were not handled correctly and are addressed here.

Improvements to previous logic:

- Corrupt lock files no longer block the user:
A `.dynlock` file that cannot be read (e.g. left behind by a crash or a disk error) was previously treated the same as a live lock, triggering the conflict prompt with no useful owner information. It is now treated as abandoned and silently overwritten, so the graph opens normally.

- Transient read failures no longer drop a valid lock:
If an antivirus scan or a network hiccup briefly prevents Dynamo from reading its own `.dynlock` during a heartbeat cycle, the lock is now retried rather than immediately abandoned. The lock is only released after three consecutive failures — at which point the file would already appear stale to other instances anyway.

- Lock freshness check is faster:
The heartbeat interval was halved from 30 seconds to 15 seconds, reducing the time another instance has to wait before it can safely take over a lock left behind by a crashed Dynamo (from 90 seconds down to 45 seconds).

- Save As dialog is safer:
When the user chooses to save a copy, the dialog now prevents them from accidentally picking the same file that is already locked. It also restores the standard "this file already exists, do you want to replace it?" warning for any other existing file they choose, which was inadvertently suppressed.

- All user-facing strings are now localizable:
The messages shown in the conflict dialogs have been moved from hardcoded English text into resource files.

- Regression tests cover the new behaviours: corrupt lock handling, heartbeat resilience, and the save-as dialog validation.

<img width="800" height="450" alt="DYN-9707-Improvements" src="https://github.com/user-attachments/assets/c96b5ddb-a61b-48ea-a958-f5ef711844bb" />


### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixed an issue where a corrupted graph lock file could incorrectly block a user from opening a graph.

### Reviewers

@DynamoDS/eidos
@jasonstratton
@johnpierson

### FYIs

@dnenov 