### PR TITLE
DYN-6107: Disable publish online option for non package owner

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -94,7 +94,7 @@
 
     <Target Name="NpmRunBuildPMWizard" BeforeTargets="BeforeBuild">
         <PropertyGroup>
-            <PackageVersion>0.0.27</PackageVersion>
+            <PackageVersion>0.0.28</PackageVersion>
             <PackageName>PackageManagerWizard</PackageName>
         </PropertyGroup>
         <Exec Command="$(PowerShellCommand) -ExecutionPolicy Bypass -File &quot;$(SolutionDir)pkgexist.ps1&quot; &quot;$(PackageName)&quot; &quot;$(PackageVersion)&quot;" ConsoleToMSBuild="true">

--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -543,7 +543,6 @@ namespace Dynamo.UI.Views
             var jsonSerializer = Newtonsoft.Json.JsonSerializer.Create(jsonSerializerSettings);
             var rootObj = JObject.FromObject(payload, jsonSerializer);
 
-            // Include payload.versions[*].compatibility_matrix for the "Copy from" dropdown.
             try
             {
                 var header = await TryGetPackageHeaderAsync(vm);
@@ -553,6 +552,10 @@ namespace Dynamo.UI.Views
                     {
                         payloadObj["versions"] = header.versions != null
                             ? JToken.FromObject(header.versions, jsonSerializer)
+                            : new JArray();
+
+                        payloadObj["maintainers"] = header.maintainers != null
+                            ? JToken.FromObject(header.maintainers, jsonSerializer)
                             : new JArray();
                     }
                 }

--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -543,26 +543,30 @@ namespace Dynamo.UI.Views
             var jsonSerializer = Newtonsoft.Json.JsonSerializer.Create(jsonSerializerSettings);
             var rootObj = JObject.FromObject(payload, jsonSerializer);
 
-            try
+            if (rootObj["payload"] is JObject payloadObj)
             {
-                var header = await TryGetPackageHeaderAsync(vm);
-                if (header != null)
+                // Present with safe defaults so the frontend always has a consistent shape
+                payloadObj["versions"] = new JArray();
+                payloadObj["maintainers"] = new JArray();
+
+                try
                 {
-                    if (rootObj["payload"] is JObject payloadObj)
+                    var header = await TryGetPackageHeaderAsync(vm);
+                    if (header != null)
                     {
                         payloadObj["versions"] = header.versions != null
-                            ? JToken.FromObject(header.versions, jsonSerializer)
-                            : new JArray();
+                                ? JToken.FromObject(header.versions, jsonSerializer)
+                                : new JArray();
 
                         payloadObj["maintainers"] = header.maintainers != null
                             ? JToken.FromObject(header.maintainers, jsonSerializer)
                             : new JArray();
                     }
                 }
-            }
-            catch (Exception ex)
-            {
-                LogMessage(ex);
+                catch (Exception ex)
+                {
+                    LogMessage(ex);
+                }
             }
 
             var jsonPayload = rootObj.ToString(Newtonsoft.Json.Formatting.None);


### PR DESCRIPTION
### Purpose



**Blocked** by [PackagePublishWizard#75](https://git.autodesk.com/Dynamo/PackagePublishWizard/pull/75) - the `@dynamods/dynamo-pm-wizard@0.0.28` npm package must be published before this PR can build successfully.



This PR aims to address [DYN-6107](https://autodesk.atlassian.net/browse/DYN-6107?atlOrigin=eyJpIjoiNGYyOTY0M2VmZDMyNDgxY2E4ODQ1NjVhNjVlZTkwZWUiLCJwIjoiaiJ9): Pass package maintainers list to the Package Manager Wizard frontend so it can disable the "Publish Online" option for users who are not owners of the package.

Previously, when a non-owner opened the Publish Package dialog for a locally installed package, the "Publish Online" button was active but would error on click. The backend had no way to communicate ownership to the wizard frontend.

Key changes:
- `SendPackageUpdates` in `PackageManagerWizard.xaml.cs` now includes a `maintainers` array (objects with `_id` and `username`) in the `receiveUpdatedPackageDetails` payload. The data comes from the `PackageHeader` already fetched by `TryGetPackageHeaderAsync` - no additional network call.
- Bumped `PackageManagerWizard` npm package version in `DynamoCoreWpf.csproj` to pick up the frontend changes that consume the new field.

<img width="800" height="450" alt="DYN-6107-Fix" src="https://github.com/user-attachments/assets/c9f655a1-6650-4973-b279-eac30039089d" />


### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

The Publish Online button in Package Manager is now disabled for non package owners(maintainers).

### Reviewers

@DynamoDS/eidos
@jasonstratton
@johnpierson

### FYIs

@dnenov
