### PR TITLE
DYN-10652: Bump DynamoMCP built-in package to 0.4.2

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2219,7 +2219,7 @@
     different DynamoVisualProgramming.* API. Bump in lockstep with the DynamoMCP release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.4.1]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.4.2]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
     The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_DynamoMCP)\bin IS


### PR DESCRIPTION
### Purpose

Consumes the DynamoMCP `0.4.2` NuGet as the built-in package. This release addresses [DYN-10652](https://autodesk.atlassian.net/browse/DYN-10652): `instructions.md` no longer ships in the package `bin\` folder — it is now embedded as a resource in the MCP server assembly and read via `Assembly.GetManifestResourceStream` instead of `File.ReadAllText`. This removes the file-system coupling and stops exposing the AI behavioral guidance (product-naming guard, tool conventions) in the public NuGet layout.

The pin is a single-line hard-pinned version bump in [DynamoCoreWpf.csproj](src/DynamoCoreWpf/DynamoCoreWpf.csproj), kept in lockstep with the DynamoMCP release per the surrounding comment.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Updated the built-in DynamoMCP package to 0.4.2, which no longer bundles instructions.md in the package folder.

### Reviewers

(FILL ME IN)

### FYIs

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)