### PR TITLE
DYN-4739: No signifier for a long list of group styles

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -94,7 +94,7 @@
 
     <Target Name="NpmRunBuildPMWizard" BeforeTargets="BeforeBuild">
         <PropertyGroup>
-            <PackageVersion>0.0.28</PackageVersion>
+            <PackageVersion>0.0.27</PackageVersion>
             <PackageName>PackageManagerWizard</PackageName>
         </PropertyGroup>
         <Exec Command="$(PowerShellCommand) -ExecutionPolicy Bypass -File &quot;$(SolutionDir)pkgexist.ps1&quot; &quot;$(PackageName)&quot; &quot;$(PackageVersion)&quot;" ConsoleToMSBuild="true">

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -2188,11 +2188,31 @@ namespace Dynamo.Nodes
                 stack.Children.Add(border);
             }
 
+            // Hardcoded to fit ~10 items. Calculating dynamically adds noise
+            // with little benefit since item height rarely changes.
+            const int maxHeight = 200;
+            stack.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+            bool needsScroll = stack.DesiredSize.Height > maxHeight;
+
+            UIElement content;
+            if (needsScroll)
+            {
+                content = new ScrollViewer
+                {
+                    MaxHeight = maxHeight,
+                    Content = stack,
+                };
+            }
+            else
+            {
+                content = stack;
+            }
+
             return new Border
             {
                 Background = _midGreyBrush,
-                Padding = new Thickness(10),
-                Child = stack
+                Padding = new Thickness(10,10,!needsScroll ? 10 : 1,10),
+                Child = content
             };
         }
 

--- a/test/DynamoCoreWpfTests/GroupStylesTests.cs
+++ b/test/DynamoCoreWpfTests/GroupStylesTests.cs
@@ -462,5 +462,102 @@ namespace DynamoCoreWpfTests
 
             Assert.AreEqual(GroupStyleItem.DefaultGroupStyleItems.Count, restoredStylesCount);
         }
+
+        /// <summary>
+        /// Validates that the Group Style submenu wraps its content in a ScrollViewer,
+        /// capped at 200px, once enough styles are present to exceed that height.
+        /// </summary>
+        [Test]
+        public void GroupStyleSubmenu_ShowsScrollViewer_WhenStyleCountExceedsMaxHeight()
+        {
+            Open(@"UI\GroupTest.dyn");
+
+            var preferencesSettings = (View.DataContext as DynamoViewModel).PreferenceSettings;
+
+            // 4 default styles alone fit within 200px; add enough custom styles to force wrapping
+            for (int i = 0; i < 15; i++)
+            {
+                preferencesSettings.GroupStyleItemsList.Add(
+                    new GroupStyleItem { Name = "Custom " + i, HexColorString = "FFFF00", IsDefault = false });
+            }
+
+            var annotationView = NodeViewWithGuid("a432d63f-7a36-45ad-b30a-7924beb20e90");
+
+            annotationView.CreateAndAttachAnnotationPopup();
+            annotationView.GroupContextMenuPopup.IsOpen = true;
+            DispatcherUtil.DoEvents();
+
+            var stylesSubmenu = annotationView.GroupStyleSelectorGrid as Grid;
+            Assert.IsNotNull(stylesSubmenu, "Styles sub-menu grid not found.");
+
+            var border = stylesSubmenu.Children.OfType<Border>().FirstOrDefault();
+            var popup = stylesSubmenu.Children.OfType<Popup>().FirstOrDefault();
+            Assert.IsNotNull(border, "Sub-menu border not found.");
+            Assert.IsNotNull(popup, "Sub-menu popup not found.");
+
+            border.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0)
+            {
+                RoutedEvent = Mouse.MouseEnterEvent
+            });
+            DispatcherUtil.DoEvents();
+
+            Assert.IsTrue(popup.IsOpen, "Popup did not open after MouseEnter.");
+            var wrapper = popup.Child as Border;
+            Assert.IsNotNull(wrapper, "Popup content is not a Border.");
+
+            var scrollViewer = wrapper.Child as ScrollViewer;
+            Assert.IsNotNull(scrollViewer, "Expected the group style list to be wrapped in a ScrollViewer.");
+            Assert.AreEqual(200, scrollViewer.MaxHeight, "ScrollViewer MaxHeight should be capped at 200.");
+
+            var stackPanel = scrollViewer.Content as StackPanel;
+            Assert.IsNotNull(stackPanel, "Could not find StackPanel inside ScrollViewer.");
+
+            var styleCount = stackPanel.Children
+                .OfType<Border>()
+                .Select(b => b.Child)
+                .OfType<StackPanel>()
+                .Count();
+            Assert.AreEqual(19, styleCount, "Expected 4 default + 15 custom styles.");
+
+            Assert.AreEqual(1, wrapper.Padding.Right, 0.001, "Right padding should shrink to make room for the scrollbar.");
+        }
+
+        /// <summary>
+        /// Validates that the Group Style submenu does NOT wrap its content in a ScrollViewer
+        /// when the default styles fit within the 200px max height.
+        /// </summary>
+        [Test]
+        public void GroupStyleSubmenu_DoesNotShowScrollViewer_WhenStyleCountFitsMaxHeight()
+        {
+            Open(@"UI\GroupTest.dyn");
+
+            var annotationView = NodeViewWithGuid("a432d63f-7a36-45ad-b30a-7924beb20e90");
+
+            annotationView.CreateAndAttachAnnotationPopup();
+            annotationView.GroupContextMenuPopup.IsOpen = true;
+            DispatcherUtil.DoEvents();
+
+            var stylesSubmenu = annotationView.GroupStyleSelectorGrid as Grid;
+            Assert.IsNotNull(stylesSubmenu, "Styles sub-menu grid not found.");
+
+            var border = stylesSubmenu.Children.OfType<Border>().FirstOrDefault();
+            var popup = stylesSubmenu.Children.OfType<Popup>().FirstOrDefault();
+            Assert.IsNotNull(border, "Sub-menu border not found.");
+            Assert.IsNotNull(popup, "Sub-menu popup not found.");
+
+            border.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0)
+            {
+                RoutedEvent = Mouse.MouseEnterEvent
+            });
+            DispatcherUtil.DoEvents();
+
+            Assert.IsTrue(popup.IsOpen, "Popup did not open after MouseEnter.");
+            var wrapper = popup.Child as Border;
+            Assert.IsNotNull(wrapper, "Popup content is not a Border.");
+
+            Assert.IsInstanceOf<StackPanel>(wrapper.Child, "Group style list should not be wrapped in a ScrollViewer.");
+            Assert.AreEqual(10, wrapper.Padding.Right, 0.001, "Right padding should remain 10 when no scrollbar is present.");
+        }
+
     }
 }


### PR DESCRIPTION
### Purpose

Small PR to address [DYN-4739](https://autodesk.atlassian.net/browse/DYN-4739?atlOrigin=eyJpIjoiMThlMTcyNjUwNDY3NDU1MWI4M2Q0ODdlOWQ3ODRkZjciLCJwIjoiaiJ9): The Group Style submenu had no visual signifier when the list of styles grew long, causing items to overflow without any indication or way to reach the ones below.

`CreateGroupStyleSelector()` in `AnnotationView.xaml.cs` now measures the built style list and, when its height exceeds a hardcoded 200px (~10 items), wraps it in a `ScrollViewer` capped at that same `MaxHeight`; the wrapping `Border`'s right padding is also reduced from 10 to 1 to make room for the scrollbar. When the list fits within 200px, behavior is unchanged.

Covered by two new tests in `GroupStylesTests.cs` verifying the submenu wraps its content in a scrollbar (with the expected `MaxHeight` and reduced padding) once enough styles are added to exceed the height threshold, and that it stays unwrapped with the original padding when only the default styles are present.

<img width="439" height="476" alt="Screenshot 2026-07-02 055241" src="https://github.com/user-attachments/assets/2ac236fe-1a62-4a8c-8e33-3ac23451f7c8" />

<img width="800" height="450" alt="DYN-4739-Fix" src="https://github.com/user-attachments/assets/45ecbb6b-0681-411c-bd89-2a1223201195" />


### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Long lists of group styles in the group context menu now scroll instead of being cut off.

### Reviewers

@DynamoDS/eidos
@jasonstratton
@johnpierson

### FYIs

@dnenov 

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
