### PR TITLE
DYN-10667: Revert unintended PackageManagerWizard version bump to 0.0.28

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -94,7 +94,7 @@
 
     <Target Name="NpmRunBuildPMWizard" BeforeTargets="BeforeBuild">
         <PropertyGroup>
-            <PackageVersion>0.0.28</PackageVersion>
+            <PackageVersion>0.0.27</PackageVersion>
             <PackageName>PackageManagerWizard</PackageName>
         </PropertyGroup>
         <Exec Command="$(PowerShellCommand) -ExecutionPolicy Bypass -File &quot;$(SolutionDir)pkgexist.ps1&quot; &quot;$(PackageName)&quot; &quot;$(PackageVersion)&quot;" ConsoleToMSBuild="true">


### PR DESCRIPTION
**This unblocks the current issue with the Dynamo build.**

### Purpose

PR #17200 ([DYN-6107](https://jira.autodesk.com/browse/DYN-6107)) bundled an unrelated bump of the `PackageManagerWizard` npm package version in `src/DynamoCoreWpf/DynamoCoreWpf.csproj` from `0.0.27` to `0.0.28`, alongside its actual fix. The `0.0.28` bump is currently blocking the Dynamo build, so this PR reverts that single line back to `0.0.27`.

[DYN-10667](https://jira.autodesk.com/browse/DYN-10667)

This PR contains **only** the version revert — no other changes from #17200 are touched.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

N/A

### Reviewers

(please assign)

### FYIs