### PR TITLE
DYN-: Dyn 9663 fix missing data from node help data documentation

### DIFF
--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -473,17 +473,19 @@ namespace Dynamo.Graph.Nodes
         {
             if (PortType == PortType.Output) return null;
 
-            if (Owner is DSFunction ztNode)
+            if (Owner is DSFunctionBase ztNode)
             {
                 var fd = ztNode.Controller.Definition;
                 string type;
+                var parameters = fd.Parameters.ToList();
                 // In the case of a node for an instance method, the first port
                 // type is the declaring class type of the method itself.
                 if (fd.Type == FunctionType.InstanceMethod || fd.Type == FunctionType.InstanceProperty)
                 {
                     if (Index > 0)
                     {
-                        var param = fd.Parameters.ElementAt(Index - 1);
+                        var paramIndex = ztNode is DSVarArgFunction ? Math.Min(Index - 1, parameters.Count - 1) : Index - 1;
+                        var param = parameters.ElementAt(paramIndex);
                         type = param.Type.ToString();
                     }
                     else
@@ -493,7 +495,8 @@ namespace Dynamo.Graph.Nodes
                 }
                 else
                 {
-                    var param = fd.Parameters.ElementAt(Index);
+                    var paramIndex = ztNode is DSVarArgFunction ? Math.Min(Index, parameters.Count - 1) : Index;
+                    var param = parameters.ElementAt(paramIndex);
                     type = param.Type.ToString();
                 }
                 return type;
@@ -548,7 +551,7 @@ namespace Dynamo.Graph.Nodes
         {
             if (PortType == PortType.Input) return null;
 
-            if (Owner is DSFunction ztNode)
+            if (Owner is DSFunctionBase ztNode)
             {
                 var fd = ztNode.Controller.Definition;
 

--- a/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
+++ b/src/Libraries/CoreNodeModels/CurveMapperNodeModel.cs
@@ -20,6 +20,7 @@ namespace CoreNodeModels
     [NodeSearchTags("CurveMapperSearchTags", typeof(Properties.Resources))]
     [InPortNames("x-MinLimit", "x-MaxLimit", "y-MinLimit", "y-MaxLimit", "values")]
     [InPortTypes("int", "int", "int", "int", "double")]
+    [OutPortTypes("double[]", "double[]")]
 
     public class CurveMapperNodeModel : NodeModel
     {

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -19,6 +19,7 @@ namespace CoreNodeModels.Input
     [NodeName("String")]
     [NodeCategory(BuiltinNodeCategories.CORE_INPUT)]
     [NodeDescription("StringInputNodeDescription", typeof(Resources))]
+    [OutPortTypes("string")]
     [IsDesignScriptCompatible]
     [AlsoKnownAs("Dynamo.Nodes.StringInput", "Dynamo.Nodes.dynStringInput", "DSCoreNodesUI.Input.StringInput")]
     public class StringInput : String

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -703,6 +703,24 @@ namespace Dynamo.Tests
             {
                 CurrentDynamoModel.Paste(); // Nope, paste should not crash Dynamo.
             });
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void DSVarArgFunctionPortsReportInputAndOutputTypes()
+        {
+            var concatNode = new DSVarArgFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("DSCore.String.Concat@string[]"));
+
+            Assert.AreEqual("string[]", concatNode.InPorts[0].GetInputPortType());
+            Assert.AreEqual("string", concatNode.OutPorts[0].GetOutPortType());
+
+            var joinNode = new DSVarArgFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("DSCore.String.Join@string,string[]"));
+            joinNode.VarInputController.AddInputToModel();
+
+            Assert.AreEqual("string", joinNode.InPorts[0].GetInputPortType());
+            Assert.AreEqual("string[]", joinNode.InPorts[1].GetInputPortType());
+            Assert.AreEqual("string[]", joinNode.InPorts[2].GetInputPortType());
+            Assert.AreEqual("string", joinNode.OutPorts[0].GetOutPortType());
         }
 
         /// <summary>

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -723,6 +723,16 @@ namespace Dynamo.Tests
             Assert.AreEqual("string", joinNode.OutPorts[0].GetOutPortType());
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void CurveMapperOutputsReportPortTypes()
+        {
+            var curveMapperNode = new CurveMapperNodeModel();
+
+            Assert.AreEqual("double[]", curveMapperNode.OutPorts[0].GetOutPortType());
+            Assert.AreEqual("double[]", curveMapperNode.OutPorts[1].GetOutPortType());
+        }
+
         /// <summary>
         ///     Pasting an Input or Output node into the Home Workspace converts them
         ///     to a Code Block node.

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -733,6 +733,15 @@ namespace Dynamo.Tests
             Assert.AreEqual("double[]", curveMapperNode.OutPorts[1].GetOutPortType());
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void StringInputOutputReportsPortType()
+        {
+            var stringNode = new StringInput();
+
+            Assert.AreEqual("string", stringNode.OutPorts[0].GetOutPortType());
+        }
+
         /// <summary>
         ///     Pasting an Input or Output node into the Home Workspace converts them
         ///     to a Code Block node.


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-9663](https://autodesk.atlassian.net/browse/DYN-9663).

The changes in the code aim to ensure output port types are resolved correctly when building OpenNodeAnnotationEventArgs for the Documentation Browser. PortModel.GetInputPortType() and GetOutPortType() are the source of InputTypes / OutputTypes; when they returned null, the inputs/outputs tables showed blank type cells.

**Before** :  

<img width="2048" height="1152" alt="missingType" src="https://github.com/user-attachments/assets/41ecf52a-5348-44e7-a79f-257afa6c970c" />



**After** : **String.Concat and String.Join**

<img width="2548" height="1401" alt="string concat example" src="https://github.com/user-attachments/assets/a5ff42b2-1fbd-4016-9b77-7bfa6cc6163c" />

**Curve Mapper :** 

<img width="2548" height="1401" alt="curve mapper fix" src="https://github.com/user-attachments/assets/f62d5132-c04a-4ef0-924a-d4bd06e6370f" />


String  : 

<img width="2560" height="1392" alt="string fix" src="https://github.com/user-attachments/assets/6425290f-fb9b-4ba7-8f2d-547640412d01" />

changes : 

Update PortModel.GetInputPortType() and GetOutPortType() to handle DSFunctionBase (not only DSFunction), so variadic zero-touch nodes such as String.Concat and String.Join are included.
For DSVarArgFunction nodes, map extra UI ports to the last parameter’s type when port index does not match the underlying FunctionDescriptor parameter list (e.g. multiple string inputs backed by a single string[] parameter).
Add [OutPortTypes("double[]", "double[]")] to CurveMapperNodeModel so both output ports report their data type in node documentation.
Add [OutPortTypes("string")] to the String input node so its output Data type appears in the Documentation Browser.
Add unit tests DSVarArgFunctionPortsReportInputAndOutputTypes, CurveMapperOutputsReportPortTypes, and StringInputOutputReportsPortType in CoreTests.cs to cover the same port-type resolution path used by the Documentation Browser.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixed missing input and output data types in the Documentation Browser for variadic library nodes such as String.Concat, and String.Join and Curve Mapper, and String input node

### Reviewers

@zeusongit
@DynamoDS/eidos


### FYIs

@dnenov
@johnpierson
@jnealb 
@jasonstratton 