### PR TITLE
DYN-10207: Bump DynamoVisualProgramming.Analytics to 4.2.4.12843

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00016" />
     <PackageReference Include="Lucene.Net.QueryParser" Version="4.8.0-beta00016" />
     <PackageReference Include="DynamoVisualProgramming.PythonEngine.PythonNet3" Version="1.4.8" GeneratePathProperty="true" ExcludeAssets="all" />
-    <PackageReference Include="DynamoVisualProgramming.Analytics" Version="4.2.4.11548" />
+    <PackageReference Include="DynamoVisualProgramming.Analytics" Version="4.2.4.12843" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Engine\GraphLayout\GraphLayout.csproj">

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -28,7 +28,7 @@
         <PackageReference Include="coverlet.collector" Version="3.1.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" ExcludeAssets="none" />
         <PackageReference Include="JunitXml.TestLogger" Version="3.0.124" />
-        <PackageReference Include="DynamoVisualProgramming.Analytics" Version="4.2.4.11548">
+        <PackageReference Include="DynamoVisualProgramming.Analytics" Version="4.2.4.12843">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
### Purpose

Updates the `DynamoVisualProgramming.Analytics` (Analytics.NET) package reference from `4.2.4.11548` to the latest published version `4.2.4.12843`.

Changes are in:
- `src/DynamoCore/DynamoCore.csproj`
- `test/DynamoCoreTests/DynamoCoreTests.csproj`

Tracking task: [DYN-10207](https://autodesk.atlassian.net/browse/DYN-10207)

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Updated the Analytics.NET package to version 4.2.4.12843.

### Reviewers

(FILL ME IN)

### FYIs

N/A
