### PR TITLE
DYN-10659: Bump DynamoMCP built-in package to 0.5.0

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2219,7 +2219,7 @@
     different DynamoVisualProgramming.* API. Bump in lockstep with the DynamoMCP release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.4.1]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.5.0]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
     The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_DynamoMCP)\bin IS


### PR DESCRIPTION
### Purpose

Consumes the DynamoMCP `0.5.0` NuGet as the built-in package (single-line hard-pinned bump in [DynamoCoreWpf.csproj](src/DynamoCoreWpf/DynamoCoreWpf.csproj), kept in lockstep with the DynamoMCP release per the surrounding comment).

This bump brings in:

- **[DYN-10659](https://autodesk.atlassian.net/browse/DYN-10659)** — Fixes `run_workspace` / `set_node_value` throwing `MissingMethodException` (surfaced as the opaque `Exception has been thrown by the target of an invocation.`) on Dynamo 4.2+. DynamoMCP's compile-time Dynamo SDK was bumped to `4.2.0-beta5417`. **DynamoMCP now requires Dynamo 4.2.0 or later.**
- **[DYN-10666](https://autodesk.atlassian.net/browse/DYN-10666)** — Adds the `dynamo://designscript-guidance` MCP resource so generated Code Block code is correct and modern (Dynamo 2.0+ syntax — square-bracket list literals, statement semicolons).
- **[DYN-10652](https://autodesk.atlassian.net/browse/DYN-10652)** — `instructions.md` no longer ships in the package `bin\` folder; it is embedded as a resource in the MCP server assembly. (This shipped in 0.4.2, whose Dynamo pin PR #17204 was never merged, so it lands here.)

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Updated the built-in DynamoMCP package to 0.5.0.

### Reviewers

(FILL ME IN)

### FYIs

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
