### PR TITLE
DYN-4783: Do not allow non integer input in integer slider node 

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -291,7 +291,7 @@ namespace CoreNodeModels.Input
         }
 
         // If the value field in the slider has a number greater than
-        // long.Maxvalue (or MinValue), the value will be changed to long.MaxValue (or MinValue)
+        // long.MaxValue (or MinValue), the value will be changed to long.MaxValue (or MinValue)
         // The property setter is overridden here to update the UI, in case the value is changed. 
         public override long Value
         {
@@ -313,21 +313,20 @@ namespace CoreNodeModels.Input
 
             switch (name)
             {
-                case "Min":
+                case nameof(Min):
                 case "MinText":
-                case "Max":
+                case nameof(Max):
                 case "MaxText":
-                case "Step":
+                case nameof(Step):
                 case "StepText":
-                case "Value":
+                case nameof(Value):
                 case "ValueText":
                     if (string.IsNullOrEmpty(value))
                         return false;
 
-                    // Only accept strict 64-bit integer literals (no decimal point, no thousands
-                    // separators). Distinguish "not an integer" from "integer literal outside the
-                    // Int64 range" so the user gets an accurate message for each, and reject the
-                    // edit (keep the last valid value) in both cases.
+                    // Reject anything that isn't a strict Int64 literal (no decimals/thousands
+                    // separators). Distinguish out-of-range from non-numeric so the user gets
+                    // an accurate error message; both cases keep the last valid value.
                     if (!TryParseInt64(value, out long parsed, out bool isOutOfRange))
                     {
                         Info(Resources.IntegerSliderNonIntegerInputMessage, true);

--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -313,37 +313,106 @@ namespace CoreNodeModels.Input
 
             switch (name)
             {
-                case nameof(Min):
+                case "Min":
                 case "MinText":
-                    Min = ConvertStringToInt64(value);
-                    return true; // UpdateValueCore handled.
-                case nameof(Max):
+                case "Max":
                 case "MaxText":
-                    Max = ConvertStringToInt64(value);
-                    return true; // UpdateValueCore handled.
-                case nameof(Value):
-                case "ValueText":
-                    UpdateNodeInfo(value);
-                    Value = ConvertStringToInt64(value);
-                    return true; // UpdateValueCore handled.
-                case nameof(Step):
+                case "Step":
                 case "StepText":
-                    Step = ConvertStringToInt64(value);
-                    return true;
+                case "Value":
+                case "ValueText":
+                    if (string.IsNullOrEmpty(value))
+                        return false;
+
+                    // Only accept strict 64-bit integer literals (no decimal point, no thousands
+                    // separators). Distinguish "not an integer" from "integer literal outside the
+                    // Int64 range" so the user gets an accurate message for each, and reject the
+                    // edit (keep the last valid value) in both cases.
+                    if (!TryParseInt64(value, out long parsed, out bool isOutOfRange))
+                    {
+                        Info(isOutOfRange
+                            ? Resources.IntegerSliderInfoMessage
+                            : Resources.IntegerSliderNonIntegerInputMessage, true);
+
+                        // The textbox is OneWay-bound and already displays the rejected text.
+                        // Nothing reverts it automatically since Min/Max/Step/Value never changed.
+                        // Re-raise the change notification for the canonical property so
+                        // SliderViewModel re-reads the last valid value and the stale, invalid
+                        // text the user typed is visibly replaced.
+                        RaisePropertyChanged(ToCanonicalPropertyName(name));
+                        return false;
+                    }
+
+                    ClearInfoMessages();
+
+                    switch (name)
+                    {
+                        case nameof(Min):
+                        case "MinText":
+                            Min = parsed;
+                            return true;
+                        case nameof(Max):
+                        case "MaxText":
+                            Max = parsed;
+                            return true;
+                        case nameof(Step):
+                        case "StepText":
+                            Step = parsed;
+                            return true;
+                        case nameof(Value):
+                        case "ValueText":
+                            Value = parsed;
+                            return true;
+                    }
+                    break;
             }
 
             return base.UpdateValueCore(updateValueParams);
         }
 
-        private void UpdateNodeInfo(string value)
+        /// <summary>
+        /// Attempts to parse a strict 64-bit integer literal. If <paramref name="value"/> is a
+        /// well-formed integer (optional sign followed only by digits) that exceeds the Int64
+        /// range, <paramref name="isOutOfRange"/> is set to true; the method still returns false
+        /// in that case so the caller can tell "not an integer" apart from "integer too large".
+        /// </summary>
+        private static bool TryParseInt64(string value, out long result, out bool isOutOfRange)
         {
-            if (IsValueInt64(value))
+            isOutOfRange = false;
+
+            if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out result))
+                return true;
+
+            var start = value.Length > 0 && (value[0] == '-' || value[0] == '+') ? 1 : 0;
+            if (start < value.Length && value.Skip(start).All(char.IsDigit))
             {
-                ClearInfoMessages();
+                isOutOfRange = true;
             }
-            else
+
+            result = 0;
+            return false;
+        }
+
+        /// <summary>
+        /// Maps a text-box property name (e.g. "MinText") to the canonical model property
+        /// name (e.g. "Min") that <see cref="SliderViewModel{T}"/> listens for when deciding
+        /// which bound text (MinText/MaxText/StepText/ValueText) to refresh.
+        /// </summary>
+        private static string ToCanonicalPropertyName(string name)
+        {
+            switch (name)
             {
-                Info(Resources.IntegerSliderInfoMessage, true);
+                case nameof(Min):
+                case "MinText":
+                    return "Min";
+                case nameof(Max):
+                case "MaxText":
+                    return "Max";
+                case nameof(Step):
+                case "StepText":
+                    return "Step";
+                default:
+                    return "Value";
             }
         }
 

--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -330,9 +330,7 @@ namespace CoreNodeModels.Input
                     // edit (keep the last valid value) in both cases.
                     if (!TryParseInt64(value, out long parsed, out bool isOutOfRange))
                     {
-                        Info(isOutOfRange
-                            ? Resources.IntegerSliderInfoMessage
-                            : Resources.IntegerSliderNonIntegerInputMessage, true);
+                        Info(Resources.IntegerSliderNonIntegerInputMessage, true);
 
                         // The textbox is OneWay-bound and already displays the rejected text.
                         // Nothing reverts it automatically since Min/Max/Step/Value never changed.
@@ -343,7 +341,14 @@ namespace CoreNodeModels.Input
                         return false;
                     }
 
-                    ClearInfoMessages();
+                    if (isOutOfRange)
+                    {
+                        Info(Resources.IntegerSliderInfoMessage, true);
+                    }
+                    else
+                    {
+                        ClearInfoMessages();
+                    }
 
                     switch (name)
                     {
@@ -371,10 +376,12 @@ namespace CoreNodeModels.Input
         }
 
         /// <summary>
-        /// Attempts to parse a strict 64-bit integer literal. If <paramref name="value"/> is a
-        /// well-formed integer (optional sign followed only by digits) that exceeds the Int64
-        /// range, <paramref name="isOutOfRange"/> is set to true; the method still returns false
-        /// in that case so the caller can tell "not an integer" apart from "integer too large".
+        /// Attempts to parse a strict 64-bit integer literal. Returns false only when
+        /// <paramref name="value"/> is not an integer literal at all (contains a decimal point,
+        /// letters, etc.). If <paramref name="value"/> is a well-formed integer (optional sign
+        /// followed only by digits) that exceeds the Int64 range, <paramref name="isOutOfRange"/>
+        /// is set to true and <paramref name="result"/> is clamped to Int64.MaxValue/MinValue,
+        /// matching how the slider already clamps values dragged or set past Min/Max.
         /// </summary>
         private static bool TryParseInt64(string value, out long result, out bool isOutOfRange)
         {
@@ -387,6 +394,8 @@ namespace CoreNodeModels.Input
             if (start < value.Length && value.Skip(start).All(char.IsDigit))
             {
                 isOutOfRange = true;
+                result = value[0] == '-' ? long.MinValue : long.MaxValue;
+                return true;
             }
 
             result = 0;

--- a/src/Libraries/CoreNodeModels/Input/SliderBase.cs
+++ b/src/Libraries/CoreNodeModels/Input/SliderBase.cs
@@ -160,23 +160,5 @@ namespace CoreNodeModels.Input
             }
             return result;
         }
-
-        /// <summary>
-        /// check if the value is within int64 range
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        protected static bool IsValueInt64(string value)
-        {
-            try
-            {
-                var result = Convert.ToInt64(value);
-                return true;
-            }
-            catch (OverflowException)
-            {
-                return false;
-            }
-        }
     }
 }

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -988,6 +988,15 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The input must be an integer..
+        /// </summary>
+        public static string IntegerSliderNonIntegerInputMessage {
+            get {
+                return ResourceManager.GetString("IntegerSliderNonIntegerInputMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to integerslider;.
         /// </summary>
         public static string IntegerSliderSearchTags {

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -754,4 +754,7 @@ double[]</value>
   <data name="CurveMapperInfoMessage" xml:space="preserve">
     <value>When mapping numbers along the curve, some Y values fall outside the specified Y-value domain range.</value>
   </data>
+  <data name="IntegerSliderNonIntegerInputMessage" xml:space="preserve">
+    <value>The input must be an integer.</value>
+  </data>
 </root>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -754,4 +754,7 @@ double[]</value>
   <data name="CurveMapperInfoMessage" xml:space="preserve">
     <value>When mapping numbers along the curve, some Y values fall outside the specified Y-value domain range.</value>
   </data>
+  <data name="IntegerSliderNonIntegerInputMessage" xml:space="preserve">
+    <value>The input must be an integer.</value>
+  </data>
 </root>

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml.cs
@@ -6,6 +6,9 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.UI;
 using Dynamo.ViewModels;
+using System.Text.RegularExpressions;
+using System.Windows;
+using CoreNodeModels.Input;
 
 namespace CoreNodeModelsWpf.Controls
 {
@@ -29,6 +32,57 @@ namespace CoreNodeModelsWpf.Controls
                 nodeUI.ViewModel.DynamoViewModel.OnRequestReturnFocusToView();
             };
 
+            // DynamoSlider is shared with DoubleSlider, which still needs the decimal point,
+            // so the integer-only keystroke/paste filter is only applied for integer sliders.
+            if (nodeModel is IntegerSlider64Bit)
+            {
+                RestrictToIntegerInput(MinTb);
+                RestrictToIntegerInput(MaxTb);
+                RestrictToIntegerInput(StepTb);
+                RestrictToIntegerInput(ValTb);
+            }
+        }
+
+        private static readonly Regex IntegerInputPattern = new Regex(@"^-?\d*$", RegexOptions.Compiled);
+        private void RestrictToIntegerInput(TextBox textBox)
+        {
+            textBox.PreviewTextInput += IntegerTextBox_PreviewTextInput;
+            DataObject.AddPastingHandler(textBox, IntegerTextBox_Pasting);
+        }
+
+        private void IntegerTextBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
+        {
+            var textBox = sender as TextBox;
+            if (textBox == null) return;
+
+            e.Handled = !IsValidIntegerText(GetProposedText(textBox, e.Text));
+        }
+
+        private void IntegerTextBox_Pasting(object sender, DataObjectPastingEventArgs e)
+        {
+            var textBox = sender as TextBox;
+            if (textBox == null || !e.DataObject.GetDataPresent(typeof(string)))
+            {
+                e.CancelCommand();
+                return;
+            }
+
+            var pastedText = (string)e.DataObject.GetData(typeof(string));
+            if (!IsValidIntegerText(GetProposedText(textBox, pastedText)))
+            {
+                e.CancelCommand();
+            }
+        }
+
+        private static string GetProposedText(TextBox textBox, string newText)
+        {
+            var text = textBox.Text.Remove(textBox.SelectionStart, textBox.SelectionLength);
+            return text.Insert(textBox.SelectionStart, newText);
+        }
+
+        private static bool IsValidIntegerText(string text)
+        {
+            return IntegerInputPattern.IsMatch(text);
         }
 
         #region Event Handlers

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml.cs
@@ -6,6 +6,7 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.UI;
 using Dynamo.ViewModels;
+using System;
 using System.Text.RegularExpressions;
 using System.Windows;
 using CoreNodeModels.Input;
@@ -43,14 +44,15 @@ namespace CoreNodeModelsWpf.Controls
             }
         }
 
-        private static readonly Regex IntegerInputPattern = new Regex(@"^-?\d*$", RegexOptions.Compiled);
-        private void RestrictToIntegerInput(TextBox textBox)
+        private static readonly Regex IntegerInputPattern = new Regex(@"^-?\d*$", RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
+
+        private static void RestrictToIntegerInput(TextBox textBox)
         {
             textBox.PreviewTextInput += IntegerTextBox_PreviewTextInput;
             DataObject.AddPastingHandler(textBox, IntegerTextBox_Pasting);
         }
 
-        private void IntegerTextBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
+        private static void IntegerTextBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
         {
             var textBox = sender as TextBox;
             if (textBox == null) return;
@@ -58,7 +60,7 @@ namespace CoreNodeModelsWpf.Controls
             e.Handled = !IsValidIntegerText(GetProposedText(textBox, e.Text));
         }
 
-        private void IntegerTextBox_Pasting(object sender, DataObjectPastingEventArgs e)
+        private static void IntegerTextBox_Pasting(object sender, DataObjectPastingEventArgs e)
         {
             var textBox = sender as TextBox;
             if (textBox == null || !e.DataObject.GetDataPresent(typeof(string)))

--- a/test/DynamoCoreWpf3Tests/SliderTests.cs
+++ b/test/DynamoCoreWpf3Tests/SliderTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Reflection;
 using System.Xml;
 using CoreNodeModels.Input;
+using CoreNodeModels.Properties;
 using Dynamo.Graph;
 using Dynamo.Models;
 using NUnit.Framework;
@@ -148,6 +149,80 @@ namespace DynamoCoreWpfTests
             //Recovers slider from xml
             slider.Deserialize(xmlElement, SaveContext.None);
             Assert.AreEqual(10, slider.Min);
+        }
+
+        [Test]
+        public void WhenValueTextIsDecimalThenInputIsRejectedAndValueUnchanged()
+        {
+            var slider = new IntegerSlider64Bit();
+            Assert.NotNull(slider);
+
+            var handled = slider.UpdateValue(new UpdateValueParams("ValueText", "3.5"));
+
+            Assert.IsFalse(handled);
+            Assert.AreEqual(1, slider.Value);
+            Assert.AreEqual(1, slider.Infos.Count);
+            Assert.IsTrue(slider.Infos.Any(i => i.Message.Equals(Resources.IntegerSliderNonIntegerInputMessage)));
+        }
+
+        [Test]
+        public void WhenValueTextIsNonNumericThenInputIsRejectedAndValueUnchanged()
+        {
+            var slider = new IntegerSlider64Bit();
+
+            var handled = slider.UpdateValue(new UpdateValueParams("ValueText", "abc"));
+
+            Assert.IsFalse(handled);
+            Assert.AreEqual(1, slider.Value);
+            Assert.IsTrue(slider.Infos.Any(i => i.Message.Equals(Resources.IntegerSliderNonIntegerInputMessage)));
+        }
+
+        [Test]
+        public void WhenValidIntegerFollowsRejectedInputThenInfoIsCleared()
+        {
+            var slider = new IntegerSlider64Bit();
+            slider.UpdateValue(new UpdateValueParams("ValueText", "3.5"));
+            Assert.AreEqual(1, slider.Infos.Count);
+
+            var handled = slider.UpdateValue(new UpdateValueParams("ValueText", "42"));
+
+            Assert.IsTrue(handled);
+            Assert.AreEqual(42, slider.Value);
+            Assert.AreEqual(0, slider.Infos.Count);
+        }
+
+        [Test]
+        public void WhenMinTextIsDecimalThenMinIsUnchanged()
+        {
+            var slider = new IntegerSlider64Bit();
+
+            var handled = slider.UpdateValue(new UpdateValueParams("MinText", "0.5"));
+
+            Assert.IsFalse(handled);
+            Assert.AreEqual(0, slider.Min);
+        }
+
+        [Test]
+        public void WhenMaxIsDecimalThenMaxIsUnchanged()
+        {
+            // "Max" (no "Text" suffix) is the property name sent by IntegerSliderSettingsControl.
+            var slider = new IntegerSlider64Bit();
+
+            var handled = slider.UpdateValue(new UpdateValueParams("Max", "100.5"));
+
+            Assert.IsFalse(handled);
+            Assert.AreEqual(100, slider.Max);
+        }
+
+        [Test]
+        public void WhenStepTextIsNonNumericThenStepIsUnchanged()
+        {
+            var slider = new IntegerSlider64Bit();
+
+            var handled = slider.UpdateValue(new UpdateValueParams("StepText", "one"));
+
+            Assert.IsFalse(handled);
+            Assert.AreEqual(1, slider.Step);
         }
     }
 }


### PR DESCRIPTION
### Purpose

[DYN-4783](https://autodesk.atlassian.net/browse/DYN-4783): Do not allow non-integer input in Integer Slider node.

`IntegerSlider64Bit`'s Min/Max/Step/Value fields currently accept decimals and letters without validation (silently coercing or parsing with a too-narrow `int.TryParse`), with no feedback to the user. This PR fixes that with two changes:

1. `IntegerSlider64Bit.UpdateValueCore` : strict integer-literal validation. Non-integer input (decimals, letters) is rejected: the last valid value is kept. A well-formed integer literal that's simply too large/small for `Int64` is still accepted and clamped to `Int64.MaxValue`/`MinValue` (preserving existing behavior), with the existing range-overflow message.
2. `DynamoSlider.xaml.cs` : blocks non-integer keystrokes/paste at the UI level, scoped to `IntegerSlider64Bit` only (this control is shared with `DoubleSlider` and the legacy 32-bit `IntegerSlider`, both intentionally left unaffected).

Changes:
- `src/Libraries/CoreNodeModels/Input/IntegerSlider.cs` (`IntegerSlider64Bit` only) : validation/clamp logic above; removed dead code (`UpdateNodeInfo`, `SliderBase.IsValueInt64`).
- `src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml.cs` : keystroke/paste filter.
- New resource `IntegerSliderNonIntegerInputMessage` : "The input must be an integer.".
- Tests added in `test/DynamoCoreWpf3Tests/SliderTests.cs` and new `test/DynamoCoreWpf3Tests/DynamoSliderTests.cs`. Existing `SliderMaxResetsToIntMax`/`SliderMinResetsToIntMin`/`TestIntSliderInfoState` still pass unmodified since clamping is preserved.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Integer Slider no longer accepts decimal or non-numeric text in its Min/Max/Step/Value fields; invalid input is blocked and an info message is shown. Values that are valid integers but exceed the supported range are still clamped to the nearest supported value, as before.

### Reviewers

@DynamoDS/eidos
@johnpierson
@RobertGlobant20

### FYIs

@dnenov 
@jnealb
@eamiri

