### PR TITLE
Bump DynamoMCP built-in package to 0.5.1

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2218,7 +2218,7 @@
     different DynamoVisualProgramming.* API. Bump in lockstep with the DynamoMCP release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.5.0]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.5.1]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
     The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_DynamoMCP)\bin IS


### PR DESCRIPTION
## Summary
- Bumps DynamoMCP package reference from 0.5.0 to 0.5.1

## Test plan
- [ ] Verify DynamoMCP 0.5.1 package is consumed correctly
- [ ] Run DynamoCore tests to ensure no regressions

## Release Notes
Upgraded DynamoMCP built-in package to 0.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)