### PR TITLE
DYN-8957: Fix no-network tooltip on custom node Publish context menu …

### DIFF
--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Threading;
 using Dynamo.Controls;
 using Dynamo.Graph.Nodes.CustomNodes;
@@ -61,6 +63,22 @@ namespace Dynamo.Wpf
 
             publishCustomNodeItem.Command = nodeView.ViewModel.DynamoViewModel.PublishSelectedNodesCommand;
             publishCustomNodeItem.CommandParameter = functionNodeModel;
+
+            ToolTipService.SetShowOnDisabled(publishCustomNodeItem, true);
+            var tooltipStyle = new Style(typeof(ToolTip));
+            tooltipStyle.Setters.Add(new Setter(UIElement.VisibilityProperty, Visibility.Collapsed));
+            var disabledTrigger = new DataTrigger
+            {
+                Binding = new Binding("PlacementTarget.IsEnabled")
+                {
+                    RelativeSource = new RelativeSource(RelativeSourceMode.Self)
+                },
+                Value = false
+            };
+            disabledTrigger.Setters.Add(new Setter(UIElement.VisibilityProperty, Visibility.Visible));
+            disabledTrigger.Setters.Add(new Setter(ContentControl.ContentProperty, Resources.PackageManagerNoNetworkModeToolTip));
+            tooltipStyle.Triggers.Add(disabledTrigger);
+            publishCustomNodeItem.ToolTip = new ToolTip { Style = tooltipStyle };
         }
 
         private void EditCustomNodeProperties()

--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
@@ -64,20 +64,26 @@ namespace Dynamo.Wpf
             publishCustomNodeItem.Command = nodeView.ViewModel.DynamoViewModel.PublishSelectedNodesCommand;
             publishCustomNodeItem.CommandParameter = functionNodeModel;
 
+            // Tag carries the NoNetworkMode flag so the tooltip trigger is scoped to that
+            // specific reason. Triggering on IsEnabled alone would show a misleading
+            // "no-network" message when the command is disabled for other reasons
+            // (e.g. no auth provider, empty selection).
+            publishCustomNodeItem.Tag = dynamoViewModel.NoNetworkMode;
+
             ToolTipService.SetShowOnDisabled(publishCustomNodeItem, true);
             var tooltipStyle = new Style(typeof(ToolTip));
             tooltipStyle.Setters.Add(new Setter(UIElement.VisibilityProperty, Visibility.Collapsed));
-            var disabledTrigger = new DataTrigger
+            var noNetworkTrigger = new DataTrigger
             {
-                Binding = new Binding("PlacementTarget.IsEnabled")
+                Binding = new Binding("PlacementTarget.Tag")
                 {
                     RelativeSource = new RelativeSource(RelativeSourceMode.Self)
                 },
-                Value = false
+                Value = true
             };
-            disabledTrigger.Setters.Add(new Setter(UIElement.VisibilityProperty, Visibility.Visible));
-            disabledTrigger.Setters.Add(new Setter(ContentControl.ContentProperty, Resources.PackageManagerNoNetworkModeToolTip));
-            tooltipStyle.Triggers.Add(disabledTrigger);
+            noNetworkTrigger.Setters.Add(new Setter(UIElement.VisibilityProperty, Visibility.Visible));
+            noNetworkTrigger.Setters.Add(new Setter(ContentControl.ContentProperty, Resources.PackageManagerNoNetworkModeToolTip));
+            tooltipStyle.Triggers.Add(noNetworkTrigger);
             publishCustomNodeItem.ToolTip = new ToolTip { Style = tooltipStyle };
         }
 

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -763,7 +763,7 @@
                                     <Style TargetType="ToolTip" BasedOn="{StaticResource GenericToolTipLight}">
                                         <Setter Property="Visibility" Value="Collapsed" />
                                         <Style.Triggers>
-                                            <DataTrigger Binding="{Binding PlacementTarget.DataContext.DynamoViewModel.NoNetworkMode, RelativeSource={RelativeSource Self}}" Value="True">
+                                            <DataTrigger Binding="{Binding PlacementTarget.IsEnabled, RelativeSource={RelativeSource Self}}" Value="False">
                                                 <Setter Property="Visibility" Value="Visible" />
                                                 <Setter Property="Content" Value="{x:Static p:Resources.PackageManagerNoNetworkModeToolTip}" />
                                             </DataTrigger>

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -755,6 +755,7 @@
                     <MenuItem Name="Publish"
                               Command="{Binding DynamoViewModel.PublishCurrentWorkspaceCommand}"
                               Header="{x:Static p:Resources.ContextMenuPublishCustomNode}"
+                              Tag="{Binding DynamoViewModel.NoNetworkMode}"
                               ToolTipService.ShowOnDisabled="True"
                               Visibility="{Binding Path=IsHomeSpace, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}">
                         <MenuItem.ToolTip>
@@ -763,7 +764,7 @@
                                     <Style TargetType="ToolTip" BasedOn="{StaticResource GenericToolTipLight}">
                                         <Setter Property="Visibility" Value="Collapsed" />
                                         <Style.Triggers>
-                                            <DataTrigger Binding="{Binding PlacementTarget.IsEnabled, RelativeSource={RelativeSource Self}}" Value="False">
+                                            <DataTrigger Binding="{Binding PlacementTarget.Tag, RelativeSource={RelativeSource Self}}" Value="True">
                                                 <Setter Property="Visibility" Value="Visible" />
                                                 <Setter Property="Content" Value="{x:Static p:Resources.PackageManagerNoNetworkModeToolTip}" />
                                             </DataTrigger>


### PR DESCRIPTION
### Purpose

Fixes [DYN-8957](https://jira.autodesk.com/browse/DYN-8957). Follow-up to #17149, which introduced the no-network tooltip UI for Package Manager entry points.

The "no network" tooltip on the Publish context-menu item never appeared, because the `DataTrigger` bound through a multi-hop CLR chain (`PlacementTarget.DataContext.DynamoViewModel.NoNetworkMode`) that WPF does not reliably re-evaluate when `PlacementTarget` is first set at ToolTip-open time — the tooltip stayed permanently `Visibility=Collapsed`.

This PR:
- Fixes the tooltip on the custom-node workspace context menu's Publish item (`WorkspaceView.xaml`).
- Adds the same tooltip to the Publish item on a custom node's own right-click context menu (`FunctionNodeViewCustomization.cs`), which had no tooltip at all.
- Binds both triggers to a dedicated `Tag` property carrying `NoNetworkMode` specifically (rather than `PlacementTarget.IsEnabled`), so the tooltip only appears when Publish is disabled *because* of no-network mode — not when it's disabled for unrelated reasons (no auth provider, non-custom-node selection).

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixed an issue where the "Enable Network Mode..." tooltip did not appear when hovering a disabled Publish item in custom node context menus while Dynamo runs in no-network mode.

### Reviewers

@RobertGlobant20

### FYIs

@jasonstratton
