### PR TITLE
DYN-10604: Bump DynamoVisualProgramming.DynamoAssistant to [0.3.2]

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2243,7 +2243,7 @@
     different DynamoVisualProgramming.* API. Bump in lockstep with the AA release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.DynamoAssistant" Version="[0.3.1]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.DynamoAssistant" Version="[0.3.2]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
     The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_DynamoAssistant)\bin IS


### PR DESCRIPTION
## Purpose

Consume the **0.3.2** release of the Autodesk Assistant built-in package (`DynamoVisualProgramming.DynamoAssistant`), now published to nuget.org.

Bumps the exact-version bracket pin in `DynamoCoreWpf.csproj` from `[0.3.1]` → `[0.3.2]`, in lockstep with the Dynamo-AutodeskAssistant `0.3.2` release (matches the DynamoMCP pin convention).

### What's in 0.3.2
- DYN-10604: Disable the Autodesk Assistant toolbar button when no graph is open (DynamoSandbox).
- DYN-10692: New approved Autodesk Assistant brand logo.

## Reviewers

## FYIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)