### PR TITLE
DYN-9702: Log when shared definitions folder is missing

### DIFF
--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -225,6 +225,12 @@ namespace Dynamo.Core
                 {
                     definitionDirectories.Add(commonDefinitionsDirectory);
                 }
+                else if (!Directory.Exists(commonDefinitionsDirectory))
+                {
+                    // Diagnostic only: log the missing shared definitions folder so the omission
+                    // is visible. Does not change the returned directories.
+                    Trace.TraceWarning("Expected shared definitions folder not found at: " + commonDefinitionsDirectory);
+                }
 
                 return definitionDirectories;
             }


### PR DESCRIPTION
### Purpose

[DYN-9702](https://jira.autodesk.com/browse/DYN-9702) introduced a shared "definitions" folder (shipped with a built-in custom node, `Curve_Validate.dyf`) that `DynamoCore.csproj` copies next to `DynamoCore.dll` at build time, and that `PathManager.DefinitionDirectories` surfaces to the rest of Dynamo.

**Regression introduced in:** [#17201](https://github.com/DynamoDS/Dynamo/pull/17201), 2026-07-13.

If that folder is ever missing at runtime, `DefinitionDirectories` silently omits it from its returned list with no error or log line -- this exact silent-drop is what caused `PackageManagerTests.PackageLoaderTests.BuiltInPackagesIsNotExposedInPathManager` to fail deterministically on every daily CBCI build since 2026-07-14, with no visibility into why.

This is a small, standalone fix: add a diagnostic warning when the folder is expected but not found. It intentionally does **not** change behavior (the folder is not created, the returned list is unchanged) -- it only makes the omission observable. We have not yet root-caused why the folder is missing specifically in the CBCI build environment (it is present in every local build); that investigation is ongoing and a follow-up commit/PR will land the actual fix once identified.

Key changes:
- `PathManager.DefinitionDirectories` now logs via `Trace.TraceWarning` when the shared definitions folder doesn't exist at the expected path. `PathManager` has no injected logger, so this follows the existing low-level `Trace`-based diagnostic precedent already used elsewhere in `DynamoCore` (e.g. `AscSDKWrapper.cs`) rather than adding a new logging dependency.

### Declarations

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

N/A -- diagnostic logging only, no user-facing or behavioral change.

### Reviewers

(FILL ME IN) Reviewer 1

### FYIs

(FILL ME IN, Optional)