### PR TITLE
DYN-9702: Fix flaky PackageLoaderTests broken by shipped definitions folder

### DIFF
--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -595,7 +595,7 @@ namespace Dynamo.PackageManager.Tests
             var matchingNodes = CurrentDynamoModel.CustomNodeManager.NodeInfos.Where(x =>
             {
                 Console.WriteLine($"val {x.Value}, name {x.Value.Name}, pkginfo {x.Value.PackageInfo}, packagemember {x.Value.IsPackageMember}");
-                return x.Value.PackageInfo.Equals(packageInfo);
+                return x.Value.PackageInfo != null && x.Value.PackageInfo.Equals(packageInfo);
             }
             ).ToList();
             //the node should have the correct package info and should be marked a packageMember.
@@ -763,7 +763,7 @@ namespace Dynamo.PackageManager.Tests
             var matchingNodes = CurrentDynamoModel.CustomNodeManager.NodeInfos.Where(x =>
             {
                 Console.WriteLine($"val{x.Value}, name{x.Value.Name}, pkginfo{x.Value.PackageInfo}, packagemember{x.Value.IsPackageMember}");
-                return x.Value.PackageInfo.Equals(packageInfo);
+                return x.Value.PackageInfo != null && x.Value.PackageInfo.Equals(packageInfo);
             }
             ).ToList();
             //the node should have the correct package info and should be marked a packageMember.
@@ -773,7 +773,7 @@ namespace Dynamo.PackageManager.Tests
             var cninst = CurrentDynamoModel.CustomNodeManager.CreateCustomNodeInstance(matchingNodes.FirstOrDefault().Key, null, true);
             this.CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(cninst);
 
-            matchingNodes = CurrentDynamoModel.CustomNodeManager.NodeInfos.Where(x => x.Value.PackageInfo.Equals(packageInfo)).ToList();
+            matchingNodes = CurrentDynamoModel.CustomNodeManager.NodeInfos.Where(x => x.Value.PackageInfo != null && x.Value.PackageInfo.Equals(packageInfo)).ToList();
             Assert.AreEqual(1, matchingNodes.Count);
             Assert.IsTrue(matchingNodes.All(x => x.Value.IsPackageMember == true));
 


### PR DESCRIPTION
### Purpose

[DYN-9702](https://autodesk.atlassian.net/browse/DYN-9702) ([#17201](https://github.com/DynamoDS/Dynamo/pull/17201)) added a shipped `definitions/` folder (containing `Curve_Validate.dyf`) and changed `PathManager.DefinitionDirectories` to include the common definitions directory. As a result, `Curve_Validate.dyf` is now loaded at model startup as a **non-package** custom node, leaving `PackageInfo == null` in `CustomNodeManager.NodeInfos`.

Two tests iterate all of `NodeInfos` with an unguarded `x.Value.PackageInfo.Equals(packageInfo)` predicate, which throws a `NullReferenceException` on the non-package node:

- `LoadingCustomNodeFromPackageSetsNodeInfoPackageInfoCorrectly`
- `PlacingCustomNodeInstanceFromPackageRetainsCorrectPackageInfoState`

The DYN-9702 change made the failure deterministic in CI whenever the definitions folder is present. This PR null-guards the comparison so non-package nodes are skipped before `Equals` is called.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

N/A -- test-only fix; no user-facing or behavioral change.

### Reviewers

(FILL ME IN) Reviewer 1

### FYIs

(FILL ME IN, Optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)