### PR TITLE
DYN-10693: Report unresolved calls in Code Block Node function bodies

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -48,6 +48,11 @@ namespace Dynamo.Graph.Nodes
         private bool shouldFocus = true;
         internal ParseParam ParseParam { get; private set; }
 
+        // Function calls inside this CBN's function bodies that could not be resolved during the
+        // first-pass compile. They are captured here and re-checked during the second pass
+        // (RecompileCodeBlockAST), once every function definition has been registered. See DYN-10693.
+        private IList<ProtoCore.Core.DeferredFunctionResolution> deferredFunctionResolutions;
+
         /// <summary>
         /// The NodeType property provides a name which maps to the 
         /// server type for the node. This property should only be
@@ -724,6 +729,13 @@ namespace Dynamo.Graph.Nodes
 
                 buildStatus = CompilerUtils.PreCompile(string.Empty, core, codeblock, out blockId);
 
+                // Re-check function calls that were deferred during the first pass now that every
+                // function definition has been registered, and warn about any still unresolved. This
+                // reports unresolved calls inside function bodies - which are only compiled in the
+                // first pass - while leaving genuine forward references unwarned. See DYN-10693.
+                core.LogUnresolvedDeferredFunctionWarnings(deferredFunctionResolutions);
+                deferredFunctionResolutions = null;
+
                 core.IsParsingCodeBlockNode = parsingCbnFlag;
                 core.IsParsingPreloadedAssembly = parsingPreloadFlag;
 
@@ -788,6 +800,11 @@ namespace Dynamo.Graph.Nodes
 
             try
             {
+                // Start each compile with an empty deferred-resolution buffer so unresolved-call
+                // candidates never leak across code block nodes (e.g. if a prior compile bailed out
+                // before draining it). See DYN-10693.
+                libraryServices?.LibraryManagementCore?.DeferredFunctionResolutions.Clear();
+
                 var priorNames = libraryServices.GetPriorNames();
 
                 if (CompilerUtils.PreCompileCodeBlock(libraryServices.LibraryManagementCore, ParseParam, priorNames))
@@ -854,6 +871,16 @@ namespace Dynamo.Graph.Nodes
                         warningMessage = string.Join("\n", warnings.Select(m => m.Message));
                     }
                 }
+
+                // Capture any function calls this CBN deferred during a first-pass compile (unresolved
+                // calls inside function bodies) so they can be re-checked during the second pass, once
+                // all function definitions have been registered. The buffer is transient scratch space
+                // shared by the compile core, so drain it into this node and clear it. See DYN-10693.
+                var precompileCore = libraryServices.LibraryManagementCore;
+                deferredFunctionResolutions = precompileCore.DeferredFunctionResolutions.Count > 0
+                    ? precompileCore.DeferredFunctionResolutions.ToList()
+                    : null;
+                precompileCore.DeferredFunctionResolutions.Clear();
 
                 if (ParseParam.UnboundIdentifiers != null)
                 {

--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -1798,13 +1798,33 @@ namespace ProtoAssociative
                     }
                     else
                     {
-                        // Log "function not found" warning for CBNs only after compiling all function definition nodes in the first pass
-                        // in CodeBlockNode.RecompileCodeBlockAST(). If not compiling CBNs log these warnings by default.
+                        string message = String.Format(ProtoCore.Properties.Resources.kMethodNotFound, procName);
+                        // If not compiling CBNs, log the "function not found" warning by default. When
+                        // compiling CBNs, only log it directly once the first pass is over (in
+                        // CodeBlockNode.RecompileCodeBlockAST).
                         if (core.IsParsingCodeBlockNode && !core.IsCodeBlockNodeFirstPass ||
                             !core.IsParsingCodeBlockNode)
                         {
-                            string message = String.Format(ProtoCore.Properties.Resources.kMethodNotFound, procName);
                             buildStatus.LogWarning(WarningID.FunctionNotFound, message, core.CurrentDSFileName, funcCall.line, funcCall.col, graphNode);
+                        }
+                        else if (globalProcIndex != Constants.kGlobalScope)
+                        {
+                            // First pass of a CBN compile, inside a function body: the callee might be
+                            // defined later in this CBN or in a sibling CBN not compiled yet. Function
+                            // bodies are only compiled in this pass, so instead of suppressing the
+                            // warning (which would drop it forever) defer it and re-check once every
+                            // definition has been registered. Top-level calls are not deferred here -
+                            // they are re-checked when the statements are recompiled in the second
+                            // pass. See DYN-10693.
+                            core.DeferredFunctionResolutions.Add(new Core.DeferredFunctionResolution
+                            {
+                                FunctionName = procName,
+                                ArgumentTypes = new List<ProtoCore.Type>(arglist),
+                                Message = message,
+                                FileName = core.CurrentDSFileName,
+                                Line = funcCall.line,
+                                Column = funcCall.col
+                            });
                         }
                     }
 

--- a/src/Engine/ProtoCore/Core.cs
+++ b/src/Engine/ProtoCore/Core.cs
@@ -170,7 +170,58 @@ namespace ProtoCore
         /// This flag is set true when we recompile CBNs after function definitions are compiled.
         /// </summary>
         internal bool IsCodeBlockNodeFirstPass { get; set; }
-        
+
+        /// <summary>
+        /// A global function call inside a code block node that could not be resolved while its
+        /// containing function definition was compiled during the first pass. Function bodies are
+        /// only compiled in the first pass, where "function not found" warnings are suppressed so
+        /// that forward references to functions defined later or in sibling CBNs do not warn. Such
+        /// candidates are buffered here and re-checked once every definition has been registered,
+        /// so genuinely undefined calls are still reported. See DYN-10693.
+        /// </summary>
+        internal class DeferredFunctionResolution
+        {
+            internal string FunctionName { get; set; }
+            internal List<Type> ArgumentTypes { get; set; }
+            internal string Message { get; set; }
+            internal string FileName { get; set; }
+            internal int Line { get; set; }
+            internal int Column { get; set; }
+        }
+
+        /// <summary>
+        /// Buffer of unresolved function calls encountered while compiling code block node function
+        /// bodies during the first pass. These are re-evaluated (see
+        /// <see cref="LogUnresolvedDeferredFunctionWarnings"/>) after all function definitions are
+        /// registered. See DYN-10693.
+        /// </summary>
+        internal IList<DeferredFunctionResolution> DeferredFunctionResolutions { get; } = new List<DeferredFunctionResolution>();
+
+        /// <summary>
+        /// Re-evaluates the supplied unresolved function-call candidates now that every function
+        /// definition has been registered, logging a <see cref="BuildData.WarningID.FunctionNotFound"/>
+        /// warning for each one that still cannot be resolved. Candidates that now resolve are
+        /// legitimate forward references and are silently discarded. See DYN-10693.
+        /// </summary>
+        /// <param name="candidates">The deferred candidates captured during the first pass.</param>
+        internal void LogUnresolvedDeferredFunctionWarnings(IEnumerable<DeferredFunctionResolution> candidates)
+        {
+            if (candidates == null)
+                return;
+
+            var searchBlock = CodeBlockList.Count > 0 ? CodeBlockList[0] : null;
+            foreach (var candidate in candidates)
+            {
+                var procNode = ProtoCore.Utils.CoreUtils.GetFunctionBySignature(
+                    candidate.FunctionName, candidate.ArgumentTypes, searchBlock);
+                if (procNode == null)
+                {
+                    BuildStatus.LogWarning(BuildData.WarningID.FunctionNotFound, candidate.Message,
+                        candidate.FileName, candidate.Line, candidate.Column);
+                }
+            }
+        }
+
         // THe ImportModuleHandler owned by the temporary core used in Graph UI precompilation
         // needed to detect if the same assembly is not being imported more than once
         public ImportModuleHandler ImportHandler { get; set; }

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -504,13 +504,33 @@ namespace ProtoImperative
                             }
                             else
                             {
-                                // Log "function not found" warning for CBNs only after compiling all function definition nodes in the first pass
-                                // in CodeBlockNode.RecompileCodeBlockAST(). If not compiling CBNs log these warnings by default.
+                                string message = String.Format(ProtoCore.Properties.Resources.kMethodNotFound, procName);
+                                // If not compiling CBNs, log the "function not found" warning by default.
+                                // When compiling CBNs, only log it directly once the first pass is over
+                                // (in CodeBlockNode.RecompileCodeBlockAST).
                                 if (core.IsParsingCodeBlockNode && !core.IsCodeBlockNodeFirstPass ||
                                     !core.IsParsingCodeBlockNode)
                                 {
-                                    string message = String.Format(ProtoCore.Properties.Resources.kMethodNotFound, procName);
                                     buildStatus.LogWarning(WarningID.FunctionNotFound, message, core.CurrentDSFileName, funcCall.line, funcCall.col, graphNode);
+                                }
+                                else if (globalProcIndex != Constants.kGlobalScope)
+                                {
+                                    // First pass of a CBN compile, inside a function body: the callee
+                                    // might be defined later in this CBN or in a sibling CBN not compiled
+                                    // yet. Function bodies are only compiled in this pass, so instead of
+                                    // suppressing the warning (which would drop it forever) defer it and
+                                    // re-check once every definition has been registered. Top-level calls
+                                    // are not deferred here - they are re-checked when the statements are
+                                    // recompiled in the second pass. See DYN-10693.
+                                    core.DeferredFunctionResolutions.Add(new Core.DeferredFunctionResolution
+                                    {
+                                        FunctionName = procName,
+                                        ArgumentTypes = new List<ProtoCore.Type>(arglist),
+                                        Message = message,
+                                        FileName = core.CurrentDSFileName,
+                                        Line = funcCall.line,
+                                        Column = funcCall.col
+                                    });
                                 }
                             }
                         }

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -397,6 +397,72 @@ b = c[w][x][y][z];";
 
         [Test]
         [Category("UnitTests")]
+        public void FunctionCall_ThrowsWarning_WhenUnresolvedCallInsideFunctionBody()
+        {
+            // Regression test for DYN-10693: an unresolved function call inside a function
+            // definition body must be reported when the graph is opened, just like an
+            // unresolved call at the code block top level. Previously the warning was
+            // silently suppressed because function bodies were only compiled in the first
+            // pass (where the "function not found" warning is deliberately gated off).
+            string openPath = Path.Combine(TestDirectory,
+                @"core\dsevaluation\testfunction_nodefn_in_body.dyn");
+            OpenModelInManualMode(openPath);
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+
+            var guid = "fc9995f7-4e98-4e9d-81d3-877f9fe6a329";
+            var cbn = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<CodeBlockNodeModel>(
+                Guid.Parse(guid));
+
+            Assert.IsNotNull(cbn);
+            Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
+            Assert.AreEqual(1, cbn.Infos.Count);
+            Assert.True(cbn.Infos.Any(x => x.State == ElementState.PersistentWarning
+                && x.Message.Contains("MissingFunc")));
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void FunctionCall_NoWarning_WhenForwardReferenceInsideFunctionBody()
+        {
+            // Regression guard for DYN-10693: a call inside a function definition body to a
+            // function defined in another code block node is a valid forward reference and
+            // must not raise a "function not found" warning once all definitions are compiled.
+            string openPath = Path.Combine(TestDirectory,
+                @"core\dsevaluation\testfunction_forwardref_in_body.dyn");
+            OpenModelInManualMode(openPath);
+            Assert.AreEqual(2, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+
+            var guid = "fc9995f7-4e98-4e9d-81d3-877f9fe6a329";
+            var cbn = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<CodeBlockNodeModel>(
+                Guid.Parse(guid));
+
+            Assert.IsNotNull(cbn);
+            Assert.AreEqual(ElementState.Active, cbn.State);
+            Assert.AreEqual(0, cbn.Infos.Count);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void FunctionCall_NoWarning_WhenForwardReferenceWithinSameCodeBlock()
+        {
+            // Regression guard for DYN-10693: a function body that calls another function defined
+            // later in the same code block node is a valid forward reference and must not warn.
+            string openPath = Path.Combine(TestDirectory,
+                @"core\dsevaluation\testfunction_forwardref_samecbn.dyn");
+            OpenModelInManualMode(openPath);
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+
+            var guid = "fc9995f7-4e98-4e9d-81d3-877f9fe6a329";
+            var cbn = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<CodeBlockNodeModel>(
+                Guid.Parse(guid));
+
+            Assert.IsNotNull(cbn);
+            Assert.AreEqual(ElementState.Active, cbn.State);
+            Assert.AreEqual(0, cbn.Infos.Count);
+        }
+
+        [Test]
+        [Category("UnitTests")]
         public void ImperativeFunctionCall_ThrowsWarning_WithoutFunctionDef()
         {
             string openPath = Path.Combine(TestDirectory,

--- a/test/core/dsevaluation/testfunction_forwardref_in_body.dyn
+++ b/test/core/dsevaluation/testfunction_forwardref_in_body.dyn
@@ -1,0 +1,96 @@
+{
+  "Uuid": "3efc1be5-f03e-4e84-a981-4204973528f2",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "testfunction_forwardref_in_body",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "def caller(x)\n{\nreturn = callee(x);\n};\ncaller(5);",
+      "Id": "fc9995f74e984e9d81d3877f9fe6a329",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "1f37b9fbf60441d1bb860c5a88fca16c",
+          "Name": "",
+          "Description": "Value of expression at line 5",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "def callee(x)\n{\nreturn = x + 1;\n};",
+      "Id": "50ce1dea0fa647358e4cbe58bcdd63f2",
+      "Inputs": [],
+      "Outputs": [],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "ExtensionWorkspaceData": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.11.0.4075",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "fc9995f74e984e9d81d3877f9fe6a329",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 231.0,
+        "Y": 381.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "50ce1dea0fa647358e4cbe58bcdd63f2",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 327.0,
+        "Y": 518.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/dsevaluation/testfunction_forwardref_samecbn.dyn
+++ b/test/core/dsevaluation/testfunction_forwardref_samecbn.dyn
@@ -1,0 +1,76 @@
+{
+  "Uuid": "4efc1be5-f03e-4e84-a981-4204973528f3",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "testfunction_forwardref_samecbn",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "def a()\n{\nreturn = b();\n};\ndef b()\n{\nreturn = 42;\n};\na();",
+      "Id": "fc9995f74e984e9d81d3877f9fe6a329",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "1f37b9fbf60441d1bb860c5a88fca16c",
+          "Name": "",
+          "Description": "Value of expression at line 9",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "ExtensionWorkspaceData": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.11.0.4075",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "fc9995f74e984e9d81d3877f9fe6a329",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 231.0,
+        "Y": 381.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/dsevaluation/testfunction_nodefn_in_body.dyn
+++ b/test/core/dsevaluation/testfunction_nodefn_in_body.dyn
@@ -1,0 +1,76 @@
+{
+  "Uuid": "2efc1be5-f03e-4e84-a981-4204973528f1",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "testfunction_nodefn_in_body",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "def tostr(x)\n{\nreturn = MissingFunc(x);\n};\ntostr(3.1415);",
+      "Id": "fc9995f74e984e9d81d3877f9fe6a329",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "1f37b9fbf60441d1bb860c5a88fca16c",
+          "Name": "",
+          "Description": "Value of expression at line 5",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "ExtensionWorkspaceData": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.11.0.4075",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "fc9995f74e984e9d81d3877f9fe6a329",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 231.0,
+        "Y": 381.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

Fixes [DYN-10693](https://autodesk.atlassian.net/browse/DYN-10693).

A function call that cannot be resolved **inside a Code Block Node (CBN) function definition body** was silently dropped instead of raising a *"Method '&lt;name&gt;()' not found"* warning. The node just returned `null` with no feedback, while the identical call at the CBN top level warned correctly.

**Root cause:** CBNs compile in two passes. `def` function *bodies* are only ever compiled during the first pass (`IsCodeBlockNodeFirstPass == true`), where the `FunctionNotFound` warning is deliberately suppressed so that forward references (to functions defined later in the same CBN or in a sibling CBN not yet compiled) do not produce false positives. Because function bodies are never revisited in the second pass, a genuinely unresolved call inside a body never surfaced a warning.

**Fix — defer the warning decision instead of suppressing it.** During the first pass, an unresolved call inside a function body is buffered on `Core` (name, argument types, message, location) rather than dropped. Once every function definition has been registered (in `CodeBlockNodeModel.RecompileCodeBlockAST`), each buffered candidate is re-resolved against the now-complete function table via `CoreUtils.GetFunctionBySignature`:

- still unresolved → log the `FunctionNotFound` warning;
- now resolves → it was a legitimate forward reference, discard it silently.

Only calls **inside function bodies** are deferred; top-level calls keep the existing suppress-then-recompile behavior (the second pass already re-checks them), which avoids duplicate warnings. The change is mirrored in the associative and imperative code paths, and is inert outside CBN first-pass compilation, so runtime graph evaluation is unaffected.

**Note on approach:** an earlier iteration fixed this by recompiling the function definitions in the second pass. That approach was **discarded** in favor of the one in this PR after analyzing the implementation suggestion in the DYN-10693 comments (deferring the warning decision), which is lower risk: it stays confined to warning-emission bookkeeping and does not re-run codegen or mutate the function table. The only refinement over that suggestion is scoping the deferral to function bodies (via `globalProcIndex != kGlobalScope`) to prevent double-warning top-level calls.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

No public API changes — all new members (`Core.DeferredFunctionResolution`, `Core.DeferredFunctionResolutions`, `Core.LogUnresolvedDeferredFunctionWarnings`) are `internal`.

### Release Notes

Code Block Nodes now report a "function not found" warning when a function body calls a function that does not exist, instead of silently returning null.

### Reviewers

@QilongTang (or as assigned by the team). FYI @jasonstratton — this implements the deferred-warning approach suggested in the DYN-10693 comments.

### FYIs

Test coverage added in `CodeBlockNodeTests`:
- unresolved call inside a function body → warns;
- forward reference to a function defined later in the **same** CBN → no warning;
- forward reference to a function defined in a **sibling** CBN → no warning.

The imperative path shares the same mirrored code and is covered by the existing `ImperativeFunctionCall_*` regression tests.
