### PR TITLE
Bump DynamoMCP built-in package to 0.5.3

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2218,7 +2218,7 @@
     different DynamoVisualProgramming.* API. Bump in lockstep with the DynamoMCP release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.5.2]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.5.3]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
     The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_DynamoMCP)\bin IS


### PR DESCRIPTION
### Purpose

Bumps the pinned `DynamoVisualProgramming.DynamoMCP` built-in package in `src/DynamoCoreWpf/DynamoCoreWpf.csproj` from `[0.5.2]` to `[0.5.3]`, in lockstep with the DynamoMCP 0.5.3 release. The version stays hard-pinned so a transitive bump can't pull a DynamoMCP built against a different `DynamoVisualProgramming.*` API.

Tracking: TBD

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Updated the bundled DynamoMCP built-in package to version 0.5.3.

### Reviewers

@dynamods

### FYIs

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)