### PR TITLE
DYN-10701: Update Curve_Validate library category from Standards to Templates

### DIFF
--- a/doc/distrib/Definitions/Curve_Validate.dyf
+++ b/doc/distrib/Definitions/Curve_Validate.dyf
@@ -1,7 +1,7 @@
 {
   "Uuid": "53ada2b0-5178-45ab-9346-72cb13065dfc",
   "IsCustomNode": true,
-  "Category": "Standards.Curve",
+  "Category": "Templates.Curve",
   "Description": "Validates curve geometry by checking nulls, type, length tolerance, and optional closure. Returns valid/invalid curves, boolean mask, and failure reasons.",
   "Name": "Curve_Validate",
   "ElementResolver": {
@@ -2317,7 +2317,7 @@
       },
       {
         "Id": "a4e7bab50f804226a58b34748879b6eb",
-        "Title": "ADDITIONAL COMMENTS\n_____________________________________________________ \n\nCustom nodes are typically found in the Add-ons section of the Library.\r\nThis custom node is located under:\r\nAdd-ons → Standards → Curve → Curve_Validate\r\n\r\nIf it does not appear:\r\n\r\nCheck that the .dyf file is in your custom nodes folder\r\n\r\nGo to:\r\nPackages → Package Manager → Package Settings → Package/Library Search Paths\r\nVerify the folder path is listed or add a new path\r\nRestart Dynamo after adding new custom nodes\n",
+        "Title": "ADDITIONAL COMMENTS\n_____________________________________________________ \n\nCustom nodes are typically found in the Add-ons section of the Library.\r\nThis custom node is located under:\r\nAdd-ons → Templates → Curve → Curve_Validate\r\n\r\nIf it does not appear:\r\n\r\nCheck that the .dyf file is in your custom nodes folder\r\n\r\nGo to:\r\nPackages → Package Manager → Package Settings → Package/Library Search Paths\r\nVerify the folder path is listed or add a new path\r\nRestart Dynamo after adding new custom nodes\n",
         "DescriptionText": null,
         "IsExpanded": true,
         "WidthAdjustment": 0.0,

--- a/doc/distrib/Templates/en-US/Make a Custom Node.dyn
+++ b/doc/distrib/Templates/en-US/Make a Custom Node.dyn
@@ -3612,7 +3612,7 @@
       },
       {
         "Id": "c58f8dba2e78425780e476a1cf51e11e",
-        "Title": "ASSOCIATED FILE(S)\n_____________________________________________________ \n\nCurveValidate.dyf\n",
+        "Title": "ASSOCIATED FILE(S)\n_____________________________________________________ \n\nCurve_Validate.dyf\n",
         "DescriptionText": null,
         "IsExpanded": true,
         "WidthAdjustment": 0.0,
@@ -3672,7 +3672,7 @@
       },
       {
         "Id": "3a1bbb44014c4cbaa7946c1d55a5aaf7",
-        "Title": "ADDITIONAL COMMENTS\n_____________________________________________________ \n\nCustom nodes are typically found in the Add-ons section of the Library.\r\nThis custom node is located under:\r\nAdd-ons → Standards → Curve → Curve_Validate\r\n\r\nIf it does not appear:\r\n\r\nCheck that the .dyf file is in your custom nodes folder\r\n\r\nGo to:\r\nPackages → Package Manager → Package Settings → Package/Lirary Search Paths\r\nVerify the folder path is listed or add a new path\r\nRestart Dynamo after adding new custom nodes\n",
+        "Title": "ADDITIONAL COMMENTS\n_____________________________________________________ \n\nCustom nodes are typically found in the Add-ons section of the Library.\r\nThis custom node is located under:\r\nAdd-ons → Templates → Curve → Curve_Validate\r\n\r\nIf it does not appear:\r\n\r\nCheck that the .dyf file is in your custom nodes folder\r\n\r\nGo to:\r\nPackages → Package Manager → Package Settings → Package/Library Search Paths\r\nVerify the folder path is listed or add a new path\r\nRestart Dynamo after adding new custom nodes\n",
         "DescriptionText": null,
         "IsExpanded": true,
         "WidthAdjustment": 0.0,


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-10701](https://autodesk.atlassian.net/browse/DYN-10701).

This update renames the Add-ons category for the Curve_Validate custom node from Standards to Templates, and updates the en-US Make a Custom Node template additional Comments to match.

<img width="1921" height="1150" alt="Template add-ons name " src="https://github.com/user-attachments/assets/4f116c7c-1186-45af-810c-568cbd285dac" />

changes : 

- Moved Curve_Validate.dyf library category from `Standards.Curve to Templates.Curve so it appears under Add-ons → Templates → Curve → Curve_Validate
- Updated Additional Comments in `Make a Custom Node.dyn (en-US)  and dyf to reference Templates instead of Standards
- Minor cleanup fixes (typo and naming)


### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Updated the Curve_Validate custom node category to Templates and corrected related Make a Custom Node template notes.

### Reviewers

@zeusongit
@DynamoDS/eidos


### FYIs

@dnenov
@johnpierson
@jnealb 
@jasonstratton 