### PR TITLE
DYN-10705: Add DynamoMCP OSS attributions to ABOUT.txt

### DIFF
--- a/ABOUT.txt
+++ b/ABOUT.txt
@@ -887,7 +887,8 @@ ModelContextProtocol.Core v.1.3.0:
 https://github.com/modelcontextprotocol/csharp-sdk
 https://github.com/modelcontextprotocol/csharp-sdk/blob/main/LICENSE
 The MIT License (MIT)
-Copyright (c) 2024-2026 Model Context Protocol a Series of LF Projects, LLC.
+Copyright (c) 2023-present Model Context Protocol contributors
+Copyright (c) 2023-present Microsoft Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/ABOUT.txt
+++ b/ABOUT.txt
@@ -836,3 +836,75 @@ THE SOFTWARE.
 
 NUnit3TestAdapter v.4.2.1
 MIT License
+
+SharpGLTF.Core v.1.0.0:
+SharpGLTF.Runtime v.1.0.0:
+SharpGLTF.Toolkit v.1.0.0:
+https://github.com/vpenades/SharpGLTF
+https://github.com/vpenades/SharpGLTF/blob/master/LICENSE
+The MIT License (MIT)
+Copyright (c) 2019 Vicente Penades
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+BigGustave v.1.0.6:
+https://github.com/EliotJones/BigGustave
+https://github.com/EliotJones/BigGustave/blob/master/LICENSE
+The Unlicense (Public Domain)
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means.
+
+In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>
+
+Humanizer v.3.0.10:
+https://github.com/Humanizr/Humanizer
+https://github.com/Humanizr/Humanizer/blob/main/license.txt
+The MIT License (MIT)
+Copyright (c) .NET Foundation and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Humanizer also incorporates the following components:
+Inflector (https://github.com/srkirkland/Inflector) - The MIT License (MIT), Copyright (c) 2013 Scott Kirkland
+ByteSize (https://github.com/omar/ByteSize) - The MIT License (MIT), Copyright (c) 2013-2014 Omar Khudeira (http://omar.io)
+
+ModelContextProtocol v.1.3.0:
+ModelContextProtocol.Core v.1.3.0:
+https://github.com/modelcontextprotocol/csharp-sdk
+https://github.com/modelcontextprotocol/csharp-sdk/blob/main/LICENSE
+The MIT License (MIT)
+Copyright (c) 2024-2026 Model Context Protocol a Series of LF Projects, LLC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+JsonSchema.Net v.9.2.0:
+JsonPointer.Net v.7.0.1:
+Json.More.Net v.3.0.1:
+https://github.com/gregsdennis/json-everything
+https://github.com/gregsdennis/json-everything/blob/master/LICENSE
+The MIT License (MIT)
+Copyright (c) .NET Foundation and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
### Purpose

Resolves [DYN-10705](https://autodesk.atlassian.net/browse/DYN-10705). Follow-up to DYN-10704 / DynamoMCP PR #281, which added five OSS DLLs to the shipped DynamoMCP package without corresponding third-party attribution.

DynamoMCP bundles third-party open-source libraries in its shipped package. These must be disclosed in the canonical acknowledgements file, `ABOUT.txt`, under **"Third-Party Trademarks, Software Credits and Attributions"** (referenced from `doc/distrib/License.rtf` and shipped with the installer). None were listed.

This PR adds attribution entries, in the existing format, for the bundled OSS components:

| Library | Version | License |
| --- | --- | --- |
| SharpGLTF.Core / Runtime / Toolkit | 1.0.0 | MIT — © 2019 Vicente Penades |
| BigGustave | 1.0.6 | **The Unlicense** (public domain) |
| Humanizer (incl. Inflector, ByteSize) | 3.0.10 | MIT — © .NET Foundation and Contributors |
| ModelContextProtocol / .Core | 1.3.0 | MIT — © 2024-2026 Model Context Protocol a Series of LF Projects, LLC |
| JsonSchema.Net / JsonPointer.Net / Json.More.Net | 9.2.0 / 7.0.1 / 3.0.1 | MIT — © .NET Foundation and Contributors |

Every license name, copyright line, and license text was verified against the upstream LICENSE at authoring time. Notably, **BigGustave is The Unlicense (public domain)** — the originating ticket's provisional guess of Apache-2.0 was incorrect.

**Not covered by this PR (cross-repo / needs the DynamoMCP build output):**
- `Microsoft.Extensions.*` — the exact shipped DLL names/versions come from the DynamoMCP `bin/Release/net10.0/mcp_server` output and the `PkgDlls_McpServer` allowlist in `src/MCPExtension/MCPExtension.csproj` (DynamoMCP repo). `ABOUT.txt` already carries `Microsoft.Extensions.Configuration.Json` and generic .NET Foundation MIT blocks; a precise reconciliation needs that inventory.
- Full reconciliation against the SOC2 / Harmony (Black Duck) scan.
- The process note reminding maintainers to update `ABOUT.txt` when the DynamoMCP package allowlist changes belongs in the DynamoMCP repo.

Versions here follow the in-package inventory recorded on the ticket and should be sanity-checked against the shipped `mcp_server` folder at review time.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

<sub>Note: documentation-only change to a text file; no code, tests, or public API are affected.</sub>

### Release Notes

Added third-party open-source attribution entries to `ABOUT.txt` for the libraries bundled with DynamoMCP (SharpGLTF, BigGustave, Humanizer, ModelContextProtocol, and the json-everything packages).

### Reviewers


### FYIs

Craig Long (raised the attribution gap on DynamoMCP PR #281)
