### PR TITLE
DYN-10709: Consume DynamoVisualProgramming.AutodeskAssistant 0.3.4 built-in package

### DIFF
--- a/.github/scripts/check_file_version.ps1
+++ b/.github/scripts/check_file_version.ps1
@@ -82,7 +82,7 @@ $excludedFiles = @(
     "JsonPointer.Net.dll",
     "Json.More.dll",
     "DynamoPlayer.*.dll",
-    # DynamoAssistant built-in package (DYN-10450) — versioned independently of Dynamo, signed in its own pipeline.
+    # AutodeskAssistant built-in package (DYN-10450) — versioned independently of Dynamo, signed in its own pipeline.
     "AutodeskAssistantViewExtension.dll",
     "AutodeskAssistantViewExtension.resources.dll",
     "AdpSDKCSharpWrapper.dll",

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2234,7 +2234,7 @@
     <Copy SourceFiles="@(DynamoMcpPkg)" DestinationFolder="$(DynamoMcpDestRoot)%(RecursiveDir)" SkipUnchangedFiles="True" />
   </Target>
   <!--
-    DynamoAssistant (Autodesk Assistant) built-in package (DYN-10450). Consumed as a signed NuGet
+    AutodeskAssistant (Autodesk Assistant) built-in package (DYN-10450). Consumed as a signed NuGet
     (id DynamoVisualProgramming.AutodeskAssistant) published by the Dynamo-AutodeskAssistant repo to
     nuget.org (mirrors DynamoMCP / PythonNet3Engine's NuGet-consume pattern):
       * ExcludeAssets="all"      -> files only, no compile/runtime refs
@@ -2243,20 +2243,20 @@
     different DynamoVisualProgramming.* API. Bump in lockstep with the AA release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.AutodeskAssistant" Version="[0.3.3]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.AutodeskAssistant" Version="[0.3.4]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
     The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_AutodeskAssistant)\bin IS
     the package layout (pkg.json + bin\ + extra\). Copy it verbatim into Built-In Packages.
   -->
-  <Target Name="BuildDynamoAssistantDynamoPackage" AfterTargets="Build">
+  <Target Name="BuildAutodeskAssistantDynamoPackage" AfterTargets="Build">
     <PropertyGroup>
-      <DynamoAssistantDestRoot>$(OutputPath)\Built-In Packages\packages\DynamoAssistant\</DynamoAssistantDestRoot>
+      <AutodeskAssistantDestRoot>$(OutputPath)\Built-In Packages\packages\AutodeskAssistant\</AutodeskAssistantDestRoot>
     </PropertyGroup>
     <ItemGroup>
-      <DynamoAssistantPkg Include="$(PkgDynamoVisualProgramming_AutodeskAssistant)\bin\**\*" />
+      <AutodeskAssistantPkg Include="$(PkgDynamoVisualProgramming_AutodeskAssistant)\bin\**\*" />
     </ItemGroup>
-    <Copy SourceFiles="@(DynamoAssistantPkg)" DestinationFolder="$(DynamoAssistantDestRoot)%(RecursiveDir)" SkipUnchangedFiles="True" />
+    <Copy SourceFiles="@(AutodeskAssistantPkg)" DestinationFolder="$(AutodeskAssistantDestRoot)%(RecursiveDir)" SkipUnchangedFiles="True" />
   </Target>
   <Target Name="CopyPMWizardHtmlFiles" AfterTargets="Build">
     <ItemGroup>

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2235,18 +2235,18 @@
   </Target>
   <!--
     DynamoAssistant (Autodesk Assistant) built-in package (DYN-10450). Consumed as a signed NuGet
-    (id DynamoVisualProgramming.DynamoAssistant) published by the Dynamo-AutodeskAssistant repo to
+    (id DynamoVisualProgramming.AutodeskAssistant) published by the Dynamo-AutodeskAssistant repo to
     nuget.org (mirrors DynamoMCP / PythonNet3Engine's NuGet-consume pattern):
       * ExcludeAssets="all"      -> files only, no compile/runtime refs
-      * GeneratePathProperty="true" -> exposes $(PkgDynamoVisualProgramming_DynamoAssistant)
+      * GeneratePathProperty="true" -> exposes $(PkgDynamoVisualProgramming_AutodeskAssistant)
     Hard-pinned to an exact version so a transitive bump can't pull an AA built against a
     different DynamoVisualProgramming.* API. Bump in lockstep with the AA release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.DynamoAssistant" Version="[0.3.2]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.AutodeskAssistant" Version="[0.3.3]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
-    The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_DynamoAssistant)\bin IS
+    The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_AutodeskAssistant)\bin IS
     the package layout (pkg.json + bin\ + extra\). Copy it verbatim into Built-In Packages.
   -->
   <Target Name="BuildDynamoAssistantDynamoPackage" AfterTargets="Build">
@@ -2254,7 +2254,7 @@
       <DynamoAssistantDestRoot>$(OutputPath)\Built-In Packages\packages\DynamoAssistant\</DynamoAssistantDestRoot>
     </PropertyGroup>
     <ItemGroup>
-      <DynamoAssistantPkg Include="$(PkgDynamoVisualProgramming_DynamoAssistant)\bin\**\*" />
+      <DynamoAssistantPkg Include="$(PkgDynamoVisualProgramming_AutodeskAssistant)\bin\**\*" />
     </ItemGroup>
     <Copy SourceFiles="@(DynamoAssistantPkg)" DestinationFolder="$(DynamoAssistantDestRoot)%(RecursiveDir)" SkipUnchangedFiles="True" />
   </Target>


### PR DESCRIPTION
### Purpose

Update the Autodesk Assistant built-in package consumption to the renamed NuGet id and package identity published by the Dynamo-AutodeskAssistant repo (tracking task: DYN-10709).

The Autodesk Assistant built-in package was renamed upstream in two steps:
1. The **NuGet id** `DynamoVisualProgramming.DynamoAssistant` → `DynamoVisualProgramming.AutodeskAssistant`.
2. The **built-in package identity** (`pkg.json` `name`) `DynamoAssistant` → `AutodeskAssistant` (published in AA `0.3.4`).

This PR points `DynamoCoreWpf` at the new package and keeps the on-disk built-in package folder consistent with the package's declared name.

Changes:
- `src/DynamoCoreWpf/DynamoCoreWpf.csproj`:
  - `PackageReference` id → `DynamoVisualProgramming.AutodeskAssistant`, pinned `[0.3.4]`.
  - Copy target uses the generated `$(PkgDynamoVisualProgramming_AutodeskAssistant)` path property.
  - Copy destination → `Built-In Packages\packages\AutodeskAssistant` (matches the package's `pkg.json` `name`).
  - Local MSBuild target/property/item identifiers renamed to `AutodeskAssistant*`.
- `.github/scripts/check_file_version.ps1`: updated the built-in-package comment (the excluded DLL list is unchanged).

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document. (No public API changes — build/packaging only.)

### Release Notes

N/A — build/packaging change only. Updates which NuGet the Autodesk Assistant built-in package is consumed from and the on-disk folder name; no user-facing behavior change.

### Reviewers

(FILL ME IN) — please assign the appropriate Dynamo reviewer.

### FYIs

(FILL ME IN, Optional)