### PR TITLE
DYN-10642 WebView2 Crash NoNetworkMode

### DIFF
--- a/doc/distrib/no-network-mode.md
+++ b/doc/distrib/no-network-mode.md
@@ -62,6 +62,25 @@ The SplashScreen is the first WebView2 surface shown and is constructed **before
 starts. Surfaces created after the model exists (HomePage, Library, DocumentationBrowser) read
 `NoNetworkMode` from the model / `ViewStartupParams`.
 
+### Isolated profile folder for no-network launches
+
+The Edge browser process is keyed by its **user data folder**, and WebView2 refuses to create two
+environments on the same folder with different `AdditionalBrowserArguments`. When a default-args
+`msedgewebview2.exe` process is already holding a folder — most commonly **another Dynamo instance
+running in normal mode**, but also a lingering process from a prior launch — creating a hardened
+no-network environment on that same folder fails with HRESULT `0x8007139F` (`ERROR_INVALID_STATE`).
+This affects every WebView2 surface, not just the ones sharing `GetTempDirectory` (SplashScreen,
+HomePage, PackageManagerWizard); the Library and DocumentationBrowser surfaces derive their own
+per-extension folders and collide the same way across instances.
+
+`ApplyNoNetworkPolicy` therefore also **redirects the profile** in no-network mode: it rewrites
+`CoreWebView2CreationProperties.UserDataFolder` to an isolated sibling via
+`WebView2Utilities.GetNoNetworkUserDataFolder` (the folder name gets a `-NoNetwork` suffix, e.g.
+`…\WebView2` → `…\WebView2-NoNetwork`). Because every startup surface already calls
+`ApplyNoNetworkPolicy` right after setting its `UserDataFolder`, the isolation is centralized in one
+place and the hardened and default profiles never share a folder. WebView2 creates the isolated
+folder on first use.
+
 ## Known limitations (out of process scope)
 
 These are OS-managed and cannot be controlled by an in-process gate:

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -41,6 +41,7 @@ Dynamo.Wpf.Utilities.DynamoWebView2.ConfigureSettings(bool enableZoomControl = f
 Dynamo.UI.Views.SplashScreen.SplashScreen(bool enableSignInButton, bool noNetworkMode) -> void
 static Dynamo.Wpf.Utilities.WebView2Utilities.ApplyNoNetworkPolicy(Microsoft.Web.WebView2.Wpf.CoreWebView2CreationProperties creationProperties, bool noNetworkMode, System.Action<string> logFn = null) -> void
 static Dynamo.Wpf.Utilities.WebView2Utilities.GetNoNetworkBrowserArguments(bool noNetworkMode) -> string
+static Dynamo.Wpf.Utilities.WebView2Utilities.GetNoNetworkUserDataFolder(string userDataFolder) -> string
 static readonly Dynamo.Wpf.Utilities.WebView2Utilities.NoNetworkAdditionalBrowserArguments -> string
 Dynamo.Wpf.Views.GuidedTour.RealTimeInfoWindow.FileLinkUri.get -> System.Uri
 Dynamo.Wpf.Views.GuidedTour.RealTimeInfoWindow.FileLinkUri.set -> void

--- a/src/DynamoCoreWpf/Utilities/WebView2Utilities.cs
+++ b/src/DynamoCoreWpf/Utilities/WebView2Utilities.cs
@@ -229,7 +229,8 @@ namespace Dynamo.Wpf.Utilities
             if (!string.Equals(isolatedFolder, creationProperties.UserDataFolder, StringComparison.Ordinal))
             {
                 creationProperties.UserDataFolder = isolatedFolder;
-                logFn?.Invoke($"[NoNetworkMode] Redirected WebView2 user data folder to isolated profile: {isolatedFolder}");
+                // Log only the leaf folder name (not the absolute path) to avoid recording the user-profile path.
+                logFn?.Invoke($"[NoNetworkMode] Redirected WebView2 user data folder to isolated profile: {Path.GetFileName(isolatedFolder)}");
             }
 
             logFn?.Invoke($"[NoNetworkMode] Applied hardened WebView2 startup policy: {NoNetworkAdditionalBrowserArguments}");
@@ -263,12 +264,16 @@ namespace Dynamo.Wpf.Utilities
         }
 
         /// <summary>
-        /// Returns the user data folder path for WebView2 (used in SplashScreen, HomePage, PackageManagerWizard)
+        /// Returns the fixed WebView2 user data folder shared by every startup surface (SplashScreen,
+        /// HomePage, PackageManagerWizard) AND every Dynamo instance on the machine. It is NOT per-process
+        /// or per-instance. WebView2 requires all environments sharing a user data folder to use matching
+        /// <see cref="CoreWebView2CreationProperties.AdditionalBrowserArguments"/>, so callers needing an
+        /// isolated profile (e.g. no-network mode) must redirect via <see cref="GetNoNetworkUserDataFolder"/>
+        /// instead of assuming this path is exclusive to them.
         /// </summary>
-        /// <returns>user data folder path for WebView2</returns>
+        /// <returns>The shared WebView2 user data folder path.</returns>
         internal static string GetTempDirectory()
         {
-            // Create a temp folder unique to this Dynamo instance based on process id
             string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
             string tmpDataFolder = Path.Combine(
                 localAppData,

--- a/src/DynamoCoreWpf/Utilities/WebView2Utilities.cs
+++ b/src/DynamoCoreWpf/Utilities/WebView2Utilities.cs
@@ -148,6 +148,12 @@ namespace Dynamo.Wpf.Utilities
             "--disable-features=OptimizationGuideModelDownloading,MediaRouter";
 
         /// <summary>
+        /// Suffix appended to a WebView2 user data folder when Dynamo runs in no-network mode so the
+        /// hardened Edge profile is isolated from the default (non-hardened) profile.
+        /// </summary>
+        internal const string NoNetworkUserDataFolderSuffix = "-NoNetwork";
+
+        /// <summary>
         /// Returns the additional browser arguments to apply to a WebView2 surface for the supplied
         /// no-network state. Returns <see cref="NoNetworkAdditionalBrowserArguments"/> when
         /// <paramref name="noNetworkMode"/> is true, otherwise null (WebView2 default behavior).
@@ -160,13 +166,44 @@ namespace Dynamo.Wpf.Utilities
         }
 
         /// <summary>
+        /// Returns an isolated sibling of <paramref name="userDataFolder"/> dedicated to no-network launches
+        /// (the folder name gets the <see cref="NoNetworkUserDataFolderSuffix"/> suffix). This keeps the
+        /// hardened WebView2 profile from sharing a user data folder with a default (non-hardened) profile.
+        ///
+        /// The Edge browser process is keyed by its user data folder, and WebView2 forbids two environments
+        /// on the same folder from being created with different
+        /// <see cref="CoreWebView2CreationProperties.AdditionalBrowserArguments"/>. When a default-args
+        /// msedgewebview2.exe process (for example another Dynamo instance running in normal mode) is already
+        /// holding the folder, creating the hardened environment on it fails with HRESULT 0x8007139F
+        /// (ERROR_INVALID_STATE). Using a separate folder avoids the collision.
+        /// </summary>
+        /// <param name="userDataFolder">The base user data folder. Returned unchanged when null or empty.</param>
+        /// <returns>The isolated no-network user data folder path.</returns>
+        public static string GetNoNetworkUserDataFolder(string userDataFolder)
+        {
+            if (string.IsNullOrEmpty(userDataFolder))
+            {
+                return userDataFolder;
+            }
+
+            // Suffix the folder name (not a nested segment) so the result is a sibling of the default profile.
+            var trimmed = userDataFolder.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            return trimmed + NoNetworkUserDataFolderSuffix;
+        }
+
+        /// <summary>
         /// Centralized entry point that applies the no-network WebView2 policy to the supplied creation
         /// properties. When <paramref name="noNetworkMode"/> is true the hardened Edge command-line
         /// switches are set on <see cref="CoreWebView2CreationProperties.AdditionalBrowserArguments"/>
-        /// so they take effect before the CoreWebView2 environment is created. When false the properties
-        /// are left untouched, preserving default startup behavior.
+        /// so they take effect before the CoreWebView2 environment is created, and the
+        /// <see cref="CoreWebView2CreationProperties.UserDataFolder"/> is redirected to an isolated
+        /// no-network profile (see <see cref="GetNoNetworkUserDataFolder"/>) so the hardened arguments
+        /// cannot collide with a default (non-hardened) environment sharing the same folder - a collision
+        /// that otherwise fails CoreWebView2 creation with HRESULT 0x8007139F (ERROR_INVALID_STATE).
+        /// When false the properties are left untouched, preserving default startup behavior.
         ///
-        /// Use this from every startup WebView2 surface to avoid per-view drift.
+        /// Use this from every startup WebView2 surface (call it after setting UserDataFolder) to avoid
+        /// per-view drift.
         /// </summary>
         /// <param name="creationProperties">The creation properties to configure. Must not be null.</param>
         /// <param name="noNetworkMode">Whether Dynamo was started in no-network mode.</param>
@@ -184,6 +221,17 @@ namespace Dynamo.Wpf.Utilities
             }
 
             creationProperties.AdditionalBrowserArguments = NoNetworkAdditionalBrowserArguments;
+
+            // Isolate the WebView2 profile so the hardened arguments never share a user data folder with a
+            // default-args environment (e.g. another Dynamo instance in normal mode). Sharing one folder
+            // with mismatched arguments fails CoreWebView2 creation with 0x8007139F (ERROR_INVALID_STATE).
+            var isolatedFolder = GetNoNetworkUserDataFolder(creationProperties.UserDataFolder);
+            if (!string.Equals(isolatedFolder, creationProperties.UserDataFolder, StringComparison.Ordinal))
+            {
+                creationProperties.UserDataFolder = isolatedFolder;
+                logFn?.Invoke($"[NoNetworkMode] Redirected WebView2 user data folder to isolated profile: {isolatedFolder}");
+            }
+
             logFn?.Invoke($"[NoNetworkMode] Applied hardened WebView2 startup policy: {NoNetworkAdditionalBrowserArguments}");
         }
 

--- a/test/DynamoCoreWpfTests/WebView2NoNetworkPolicyTests.cs
+++ b/test/DynamoCoreWpfTests/WebView2NoNetworkPolicyTests.cs
@@ -98,5 +98,53 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(WebView2Utilities.NoNetworkAdditionalBrowserArguments, WebView2Utilities.GetNoNetworkBrowserArguments(true));
             Assert.IsNull(WebView2Utilities.GetNoNetworkBrowserArguments(false));
         }
+
+        [Test]
+        public void WhenNoNetworkModeEnabledThenUserDataFolderIsRedirectedToIsolatedProfile()
+        {
+            // Arrange
+            var creationProperties = new CoreWebView2CreationProperties
+            {
+                UserDataFolder = @"C:\Users\test\AppData\Local\Temp\Dynamo\WebView2"
+            };
+
+            // Act
+            WebView2Utilities.ApplyNoNetworkPolicy(creationProperties, noNetworkMode: true);
+
+            // Assert - the hardened profile must never share a folder with the default-args profile,
+            // otherwise CoreWebView2 creation fails with 0x8007139F when both are used at once.
+            Assert.AreEqual(@"C:\Users\test\AppData\Local\Temp\Dynamo\WebView2-NoNetwork", creationProperties.UserDataFolder);
+        }
+
+        [Test]
+        public void WhenNoNetworkModeDisabledThenUserDataFolderIsLeftUntouched()
+        {
+            // Arrange
+            const string original = @"C:\Users\test\AppData\Local\Temp\Dynamo\WebView2";
+            var creationProperties = new CoreWebView2CreationProperties { UserDataFolder = original };
+
+            // Act
+            WebView2Utilities.ApplyNoNetworkPolicy(creationProperties, noNetworkMode: false);
+
+            // Assert - default behavior must be preserved when the flag is off.
+            Assert.AreEqual(original, creationProperties.UserDataFolder);
+        }
+
+        [Test]
+        public void GetNoNetworkUserDataFolderReturnsIsolatedSiblingFolder()
+        {
+            // Assert
+            Assert.AreEqual(@"C:\data\WebView2-NoNetwork", WebView2Utilities.GetNoNetworkUserDataFolder(@"C:\data\WebView2"));
+            // A trailing separator must not produce a nested empty segment.
+            Assert.AreEqual(@"C:\data\WebView2-NoNetwork", WebView2Utilities.GetNoNetworkUserDataFolder(@"C:\data\WebView2\"));
+        }
+
+        [Test]
+        public void GetNoNetworkUserDataFolderReturnsInputWhenNullOrEmpty()
+        {
+            // Assert - a surface that never set a UserDataFolder must not gain a spurious one.
+            Assert.IsNull(WebView2Utilities.GetNoNetworkUserDataFolder(null));
+            Assert.AreEqual(string.Empty, WebView2Utilities.GetNoNetworkUserDataFolder(string.Empty));
+        }
     }
 }


### PR DESCRIPTION
### Purpose

Fixes the `--NoNetworkMode` startup crash (`0x8007139F` / `ERROR_INVALID_STATE`) introduced by PR #17212 (DYN-10642).

**Root cause:** The Edge browser process is keyed by its WebView2 **user data folder**, and WebView2 forbids two environments on the same folder from being created with different `AdditionalBrowserArguments`. PR #17212 applied hardened no-network arguments to WebView2 surfaces without isolating their profile folder, so when a default-args `msedgewebview2.exe` was already holding that folder — most commonly **another Dynamo instance running in normal mode**, or a lingering process from a prior launch — creating the hardened environment on it failed with `0x8007139F` and crashed startup. This affected every hardened surface (SplashScreen, HomePage, PackageManagerWizard sharing the fixed temp profile, plus Library and DocumentationBrowser sharing their per-user profile across instances).

**Fix:** Profile isolation is centralized in `WebView2Utilities.ApplyNoNetworkPolicy`. When no-network mode is on, in addition to setting the hardened `AdditionalBrowserArguments` it now redirects `CoreWebView2CreationProperties.UserDataFolder` to an isolated sibling profile via the new `GetNoNetworkUserDataFolder` helper (folder name gets a `-NoNetwork` suffix, e.g. `…\WebView2` → `…\WebView2-NoNetwork`). Because every startup surface already calls `ApplyNoNetworkPolicy` right after setting its `UserDataFolder`, all surfaces (including Library and DocumentationBrowser) are fixed with no per-view changes, and the hardened and default profiles can never share a folder. `GetTempDirectory` is unchanged — it still returns the shared default folder for normal launches.

Verified by launching a normal Dynamo instance and then a second instance with `--NoNetworkMode`: the second instance now starts without the crash.

### Declarations

Check these if you believe they are true

- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixed a startup crash when launching Dynamo in `--NoNetworkMode` while another Dynamo instance was already running.

### Reviewers

@jasonstratton 
@eamiri 
@edwin-vasquez-ucaldas 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of