### PR TITLE
DYN-10707: Correct and complete DynamoMCP third-party attribution in ABOUT.txt

### DIFF
--- a/ABOUT.txt
+++ b/ABOUT.txt
@@ -649,6 +649,29 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+Microsoft.Extensions.AI.Abstractions v10.5.2
+Microsoft.Extensions.Caching.Abstractions v10.0.8
+Microsoft.Extensions.Configuration.Abstractions v10.0.8
+Microsoft.Extensions.DependencyInjection.Abstractions v10.0.8
+Microsoft.Extensions.Diagnostics.Abstractions v10.0.8
+Microsoft.Extensions.FileProviders.Abstractions v10.0.8
+Microsoft.Extensions.Hosting.Abstractions v10.0.8
+Microsoft.Extensions.Logging.Abstractions v10.0.8
+Microsoft.Extensions.Options v10.0.8
+Microsoft.Extensions.Primitives v10.0.8
+The MIT License (MIT)
+https://github.com/dotnet/runtime/blob/main/LICENSE.TXT
+https://github.com/dotnet/extensions/blob/main/LICENSE
+
+Copyright (c) .NET Foundation and Contributors
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 CsvHelper v30.0.1
 Apache 2.0
 https://github.com/JoshClose/CsvHelper/blob/master/LICENSE.txt
@@ -885,16 +908,13 @@ ByteSize (https://github.com/omar/ByteSize) - The MIT License (MIT), Copyright (
 ModelContextProtocol v.1.3.0:
 ModelContextProtocol.Core v.1.3.0:
 https://github.com/modelcontextprotocol/csharp-sdk
-https://github.com/modelcontextprotocol/csharp-sdk/blob/main/LICENSE
-The MIT License (MIT)
-Copyright (c) 2023-present Model Context Protocol contributors
-Copyright (c) 2023-present Microsoft Corporation
+https://github.com/modelcontextprotocol/csharp-sdk/blob/v1.3.0/LICENSE
+Apache License, Version 2.0
+Copyright (c) 2024-2026 Model Context Protocol a Series of LF Projects, LLC.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The upstream project is transitioning from the MIT License to the Apache License, Version 2.0. New and relicensed contributions are Apache-2.0; contributions not yet relicensed remain under the MIT License. The packages consumed here declare Apache-2.0.
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
 
 JsonSchema.Net v.9.2.0:
 JsonPointer.Net v.7.0.1:

--- a/ABOUT.txt
+++ b/ABOUT.txt
@@ -660,8 +660,8 @@ Microsoft.Extensions.Logging.Abstractions v10.0.8
 Microsoft.Extensions.Options v10.0.8
 Microsoft.Extensions.Primitives v10.0.8
 The MIT License (MIT)
-https://github.com/dotnet/runtime/blob/main/LICENSE.TXT
-https://github.com/dotnet/extensions/blob/main/LICENSE
+https://github.com/dotnet/runtime/blob/v10.0.8/LICENSE.TXT
+https://github.com/dotnet/extensions/blob/2a86d759c251eee39274c191bd9f8e14c58f875a/LICENSE
 
 Copyright (c) .NET Foundation and Contributors
 All rights reserved.
@@ -915,6 +915,14 @@ Copyright (c) 2024-2026 Model Context Protocol a Series of LF Projects, LLC.
 The upstream project is transitioning from the MIT License to the Apache License, Version 2.0. New and relicensed contributions are Apache-2.0; contributions not yet relicensed remain under the MIT License. The packages consumed here declare Apache-2.0.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
+
+Portions not yet relicensed remain under the MIT License:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 JsonSchema.Net v.9.2.0:
 JsonPointer.Net v.7.0.1:


### PR DESCRIPTION
### Purpose

Fixes [DYN-10707](https://autodesk.atlassian.net/browse/DYN-10707). Corrects and completes the DynamoMCP third-party attributions added by #17228. Both issues in this PR were raised by @RobertGlobant20 during review of that PR.

**1. ModelContextProtocol and ModelContextProtocol.Core v1.3.0 were attributed as MIT, but upstream declares Apache-2.0.**

Verified against the pinned v1.3.0 tag rather than main:

| | Upstream csharp-sdk v1.3.0 | ABOUT.txt before this PR |
| --- | --- | --- |
| License | Apache-2.0, the declared SPDX expression in both nuspecs | The MIT License (MIT) |
| Copyright | Copyright (c) 2024-2026 Model Context Protocol a Series of LF Projects, LLC. | Copyright (c) 2023-present Model Context Protocol contributors, plus Copyright (c) 2023-present Microsoft Corporation |
| License body | Apache-2.0 | Full MIT permission text |

The two copyright lines appear nowhere in the upstream LICENSE.

Upstream v1.3.0/LICENSE is a dual-license state: an Apache-2.0 body and a distinct MIT License section under the same copyright holder, because contributions not yet relicensed remain MIT. That code is compiled into the assemblies we redistribute, so the entry now reproduces both notices under the single upstream copyright line, mirroring upstream's own LICENSE layout. Thanks to @RobertGlobant20 for catching that the first revision of this PR described the MIT residual in prose instead of reproducing the notice, which would have traded an Apache-2.0 gap for an MIT one.

The cited LICENSE URL is pinned to /blob/v1.3.0/LICENSE instead of /blob/main/LICENSE. main is a moving target on a repository that is actively relicensing, which is the most likely reason the MIT text was accurate when transcribed and wrong by the time it merged.

**2. Ten Microsoft.Extensions packages ship in the DynamoMCP package with no attribution at all.**

MCPExtension.csproj copies mcp_server/Microsoft.Extensions*.dll by wildcard. The resolved set is Microsoft.Extensions.AI.Abstractions v10.5.2 plus nine packages at v10.0.8: Caching, Configuration, DependencyInjection, Diagnostics, FileProviders, Hosting and Logging Abstractions, plus Options and Primitives. All MIT.

ABOUT.txt already attributes Microsoft.Extensions.Configuration.Json v6.0.0 individually, so the established convention in this file is to list these rather than treat them under a blanket .NET runtime attribution. The new block is placed immediately beside that entry and reuses its exact format and license text. Its license URLs are pinned rather than citing main: dotnet/runtime at tag v10.0.8, and dotnet/extensions at the commit recorded in the AI.Abstractions nuspec, since that package has no matching tag. The pre-existing Configuration.Json v6.0.0 entry is left untouched as out of scope.

Note on scope: the same csproj also has a mcp_server/System.Net*.dll wildcard, but it matches nothing. No System.Net package appears in the resolved dependency graph and no such DLL is produced, so there is nothing to attribute there.

ABOUT.txt remains CRLF throughout: 939 CRLF, 0 bare LF.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Corrected the About box attribution for the Model Context Protocol C# SDK, which is dual-licensed under Apache-2.0 and MIT rather than MIT alone, and added the previously missing attributions for the Microsoft.Extensions packages bundled with DynamoMCP.

### Reviewers

@RobertGlobant20, who raised both findings in #17228 and reviewed the first revision here.

Two notes for reviewers:

- Roberto has asked for an OSS-compliance sign-off on the dual-license wording. That is outstanding.
- This needs to be cherry-picked to RC4.2.0_master, which carries the same incorrect text via #17233.

### FYIs

None
