### PR TITLE
DYN-10693: Keep the FunctionNotFound warning across Code Block Node edits

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -684,6 +684,9 @@ namespace Dynamo.Graph.Nodes
         /// </summary>
         internal void UndefineFunctionDefinitions()
         {
+            if (ParseParam?.ParsedNodes == null)
+                return;
+
             var funcDefs = ParseParam.ParsedNodes.OfType<FunctionDefinitionNode>();
             foreach (var funcDef in funcDefs)
             {
@@ -790,6 +793,17 @@ namespace Dynamo.Graph.Nodes
             {
                 previewVariable = null;
             }
+
+            // Deactivate the function definitions registered by this node's previous compile before
+            // recompiling. They are still active on the shared precompilation core, so re-appending
+            // them is rejected as a redefinition, and code generation then flags the definition
+            // skipMe and never traverses its body. That silently drops every diagnostic inside the
+            // body - notably the "function not found" warning of DYN-10693, which appeared when the
+            // graph was opened and then vanished after any edit to the code block. Deactivating
+            // first lets ProcedureTable.Append replace the stale entry, so the body is compiled and
+            // its warnings are reported again. See DYN-10693.
+            UndefineFunctionDefinitions();
+
             // During loading of CBN from file, the elementResolver from the workspace is unavailable
             // in which case, a local copy of the ER obtained from the CBN is used
             var resolver = workspaceElementResolver ?? ElementResolver;

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -437,6 +437,42 @@ b = c[w][x][y][z];";
             Assert.AreEqual(0, cbn.Infos.Count);
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void FunctionCall_KeepsWarning_WhenCodeBlockIsEditedAfterUnresolvedCallInBody()
+        {
+            // Regression test for DYN-10693: editing a code block node that redefines the same
+            // function must not lose the "function not found" warning raised for an unresolved
+            // call inside the function body. The previously compiled definition stayed active on
+            // the precompilation core, so the redefinition was skipped and its body was never
+            // traversed, silently dropping the warning on every recompile after the first.
+            var cbn = OpenSingleFunctionCbn("testfunction_nodefn_in_body.dyn", expectedNodeCount: 1);
+            Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
+
+            cbn.SetCodeContent("def tostr(x)\n{\nreturn = MissingFunc(x);\n};\ntostr(2.718);",
+                CurrentDynamoModel.CurrentWorkspace.ElementResolver);
+
+            Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
+            Assert.True(cbn.Infos.Any(x => x.State == ElementState.PersistentWarning
+                && x.Message.Contains("MissingFunc")));
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void FunctionCall_NoWarning_WhenForwardReferenceInSameCodeBlockIsEdited()
+        {
+            // Regression guard for DYN-10693: recompiling a code block node that redefines its own
+            // functions must not report a valid forward reference between them as unresolved.
+            var cbn = OpenSingleFunctionCbn("testfunction_forwardref_samecbn.dyn", expectedNodeCount: 1);
+            Assert.AreEqual(ElementState.Active, cbn.State);
+
+            cbn.SetCodeContent("def a()\n{\nreturn = b();\n};\ndef b()\n{\nreturn = 43;\n};\na();",
+                CurrentDynamoModel.CurrentWorkspace.ElementResolver);
+
+            Assert.AreEqual(ElementState.Active, cbn.State);
+            Assert.AreEqual(0, cbn.Infos.Count);
+        }
+
         // Opens a graph under core\dsevaluation and returns the code block node with the well-known
         // guid used by the function-warning test fixtures. Shared by the DYN-10693 regression tests.
         private CodeBlockNodeModel OpenSingleFunctionCbn(string dynFileName, int expectedNodeCount)


### PR DESCRIPTION
### Purpose

Follow-up fix for [DYN-10693](https://jira.autodesk.atlassian.net/browse/DYN-10693), reported by Neal Burnham during testing of #17224 on 4.3.0.5770:

> In preliminary testing with 4.3.0.5770 the fix is validated for a "first time in" case, however if the cbn is edited and re-executed the warning state vanishes: INCORRECT. The nature of the edit is un-important: any edit will cause the flaw.

#17224 only covered the **graph-open** path. Opening a graph runs the two-pass compile (`ReCompileCodeBlockNodesForFunctionDefinitions`), and the deferred re-check in `RecompileCodeBlockAST` emits the warning correctly. Editing a Code Block Node recompiles it in a single pass, where the warning was lost for a different — and older — reason that #17224 made visible.

**Root cause**

A Code Block Node's previously compiled `def` is still *active* in the shared precompilation core when the node is recompiled after an edit:

1. `ProcedureTable.Append` finds an active duplicate and returns `kInvalidIndex`.
2. Code generation logs `FunctionAlreadyDefined` and sets `funcDef.skipMe = true` (`ProtoAssociative/CodeGen.cs:3785`).
3. `FunctionAlreadyDefined` is deliberately filtered out of Code Block Node warnings (`CodeBlockNode.cs:870`), so nothing is surfaced.
4. `DfsTraverse` returns early on `skipMe` (`ProtoAssociative/CodeGen.cs:6050`), so **the function body is never traversed** — the unresolved call inside it is never visited and no `FunctionNotFound` is raised.
5. `ProcessCodeDirect` has already called `ClearErrorsAndWarnings()`, so the warning shown at graph open simply disappears.

This is not specific to `FunctionNotFound`: *any* diagnostic inside a redefined function body was being dropped on recompile.

**Fix**

Deactivate the node's own definitions in `ProcessCode` before recompiling, so `ProcedureTable.Append` takes its `!existingProcNode.IsActive` branch and replaces the stale entry in place. The body is compiled again and its warnings are reported. This mirrors what `LiveRunner.UndefineFunctions` already does for redefined subtrees.

Also guards `UndefineFunctionDefinitions` against a null `ParseParam`, which is the state on a node's first compile.

**Behavior change worth a look during review:** a Code Block Node that renames or deletes a `def` now leaves the old name genuinely undefined, instead of leaving a permanently-registered definition behind. That is more correct, but it does change what other Code Block Nodes resolve when they next recompile.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

No public API surface changes — `UndefineFunctionDefinitions` is `internal` and already existed.

### Release Notes

Fixed an issue where the "Method not found" warning on a Code Block Node disappeared after the node was edited and the graph re-executed, leaving broken code silently returning null.

### Reviewers

@jasonstratton (reviewed and merged #17224)

@edwin-vasquez-ucaldas

Notes for testers — the repro is the same as DYN-10693, with an extra step:

1. Open a graph containing a Code Block Node with an unresolved call inside a `def` body, e.g. `def tostr(x) { return = ToString(x); }; tostr(3.1415);`
2. Confirm the "Method 'ToString()' not found" warning appears.
3. Make any edit to the Code Block Node (changing the argument value is enough) and re-run.
4. The warning must still be shown. Before this fix it disappeared.

Also worth confirming that valid forward references still do not warn after an edit, both within one Code Block Node and across two.

**Testing performed**

- New regression tests in `CodeBlockNodeTests`: `FunctionCall_KeepsWarning_WhenCodeBlockIsEditedAfterUnresolvedCallInBody` and `FunctionCall_NoWarning_WhenForwardReferenceInSameCodeBlockIsEdited`.
- All 11 `FunctionCall_*` / `ImperativeFunctionCall_*` tests pass, plus the full `CodeBlockNodeTests` fixture (79 tests) and `CodeBlockNodeTests2` / `DynamoDefects` / `CallsiteTests` / `CoreTests` (109 tests).
- A wider `Name~Function|Cbn|CodeBlock` sweep surfaced 4 failures (`UsingFunctionObject01`, `UsingFunctionObject02`, `TestMigration_Core_Functions`, `ImperativeArrayIndexingInCodeBlockToCode`). These were verified to fail identically on clean `master` with this change stashed, so they are pre-existing and unrelated.

### FYIs

Neal Burnham (reported the regression in testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)