### PR TITLE
DYN-10727: Consume DynamoMCP 0.5.5, downgrade json-everything to plain MIT

### DIFF
--- a/ABOUT.txt
+++ b/ABOUT.txt
@@ -889,7 +889,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 For more information, please refer to <http://unlicense.org>
 
-Humanizer v.3.0.10:
+Humanizer v.3.0.1:
 https://github.com/Humanizr/Humanizer
 https://github.com/Humanizr/Humanizer/blob/main/license.txt
 The MIT License (MIT)
@@ -924,9 +924,9 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-JsonSchema.Net v.9.2.0:
-JsonPointer.Net v.7.0.1:
-Json.More.Net v.3.0.1:
+JsonSchema.Net v.8.0.5:
+JsonPointer.Net v.6.0.1:
+Json.More.Net v.2.2.0:
 https://github.com/gregsdennis/json-everything
 https://github.com/gregsdennis/json-everything/blob/master/LICENSE
 The MIT License (MIT)

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2218,7 +2218,7 @@
     different DynamoVisualProgramming.* API. Bump in lockstep with the DynamoMCP release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.5.4]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.5.5]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
     The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_DynamoMCP)\bin IS


### PR DESCRIPTION
### Purpose

DYN-10727: https://jira.autodesk.com/browse/DYN-10727 -- The DynamoMCP built-in package redistributes prebuilt json-everything assemblies. From JsonSchema.Net 9.0.0 onward, those packages stopped being plain MIT -- their nuspecs declare a license type of file (OSMFEULA.txt) with requireLicenseAcceptance=true, an Open Source Maintenance Fee Agreement that imposes a monthly fee on revenue-generating users above $10,000 annual gross revenue. Autodesk qualifies, and ABOUT.txt disclosed these as plain MIT with no mention of the fee agreement.

This PR consumes the newly released DynamoVisualProgramming.DynamoMCP 0.5.5, which repins the json-everything dependency chain back to the last plain-MIT release line, and updates ABOUT.txt to match what actually ships.

Key changes:
- src/DynamoCoreWpf/DynamoCoreWpf.csproj: bump DynamoVisualProgramming.DynamoMCP pin from 0.5.4 to 0.5.5
- ABOUT.txt: JsonSchema.Net 9.2.0 to 8.0.5, JsonPointer.Net 7.0.1 to 6.0.1, Json.More.Net 3.0.1 to 2.2.0, Humanizer 3.0.10 to 3.0.1 (moves as a side effect of the JsonPointer.Net downgrade)

This is the last step of the DYN-10727 chain: DynamoPlayer 7.0.7 and DynamoMCP 0.5.5 have already been repinned and released; this PR updates Dynamo to consume the new DynamoMCP version.

### Declarations

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

N/A

### Reviewers

(FILL ME IN) Reviewer 1

### FYIs

(FILL ME IN, Optional)