### PR TITLE
DYN-10735: Align Autodesk.IDSDK wrapper with Revit's AdskIdentitySDK.dll version

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Label="Common dependencies">
-    <PackageReference Include="Autodesk.IDSDK" Version="1.2.5" />
+    <PackageReference Include="Autodesk.IDSDK" Version="1.2.6" />
     <PackageReference Include="Greg" Version="3.0.2.8780" />
     <PackageReference Include="DynamoVisualProgramming.LibG_231_0_0" Version="4.0.0.5336" GeneratePathProperty="true" ExcludeAssets="all"/>
     <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334" Condition=" '$(Configuration)' == 'Release' " GeneratePathProperty="true" ExcludeAssets="runtime"/>


### PR DESCRIPTION
### Purpose

[DYN-10735](https://autodesk.atlassian.net/browse/DYN-10735): Dynamo bundles Autodesk.IDSDK 1.2.5 (native AdskIdentitySDK.dll 1.15.3.5). Revit 2027.3 ships AdskIdentitySDK.dll 1.16.4.7 at its root, so Dynamo's bundled copy under AddIns/DynamoForRevit/ is meaningfully behind the host. No Autodesk.IDSDK.Client wrapper release bundles Revit's exact 1.16.4.7, so this PR moves to the closest available artifact: wrapper **1.2.6**, which bundles native DLL **1.16.5.1**.

This has been confirmed acceptable by both the Identity team and Revit:
- Identity team (Wilfred Ng): backward/forward compatibility across this range is supported.
- Revit (Sorin Brinzaru): explicitly approved 1.16.5.1 as 'one of the FY27 ML-Final version we should align on.'

Note: the originally-reported Debug Warning dialog on Dynamo sign-out turned out to be an unrelated, pre-existing Revit-side bug ([REVIT-255685](https://autodesk.atlassian.net/browse/REVIT-255685)) that reproduces even with DLL versions fully aligned — this PR does not (and cannot) fix that dialog. It closes the separate, real version gap that predates this ticket.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

No public API surface changes — this is a single PackageReference version bump in src/DynamoCore/DynamoCore.csproj.

Testing: built locally, confirmed the harvested AdskIdentitySDK.dll is 1.16.5.1, deployed into a local Revit 2027.3 install via Dynamo.config redirect, and exercised sign-in/sign-out from the splash screen with no issues observed.

### Release Notes

Updated the bundled Autodesk Identity SDK to a version closer to what Revit ships, reducing the native SDK version gap between Dynamo and its host application.

### Reviewers

(TBD — Jason to assign)

### FYIs

@casandra.armeanu, @sorin.brinzaru
