### PR TITLE
DYN-10736 Dynamo Player sample file incorrectly appears under Revit sample files

### DIFF
--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -319,7 +319,14 @@ namespace Dynamo.UI.Controls
                             SampleFileEntry sampleFileEntry =
                                 new SampleFileEntry(directory.Name, directory.FullName);
                             WalkDirectoryTree(directory, sampleFileEntry);
-                            rootProperty.AddChildSampleFile(sampleFileEntry);
+
+                            // Only surface folders that actually contain sample graphs (directly or
+                            // in a nested subfolder); otherwise the entry renders as a clickable file
+                            // on the home page even though there is nothing to open (DYN-10736).
+                            if (sampleFileEntry.Children != null && sampleFileEntry.Children.Any())
+                            {
+                                rootProperty.AddChildSampleFile(sampleFileEntry);
+                            }
                         }
                     }
                 }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -2529,7 +2529,13 @@ namespace Dynamo.Controls
                                 sampleFiles.Add(path);
                             }
                         }
-                        SamplesMenu.Items.Add(dirItem);
+
+                        // Skip folders with no sample graphs directly under them so the Samples
+                        // menu does not show empty, unopenable submenus (DYN-10736).
+                        if (dirItem.Items.Count > 0)
+                        {
+                            SamplesMenu.Items.Add(dirItem);
+                        }
                     }
                 }
 

--- a/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
+++ b/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
@@ -557,6 +557,24 @@ namespace Dynamo.UI.Views
             _ = OpenFileAsync(path);
         }
 
+        /// <summary>
+        /// Determines whether the given path points at an openable graph file rather than a
+        /// folder or unrelated file. Directories can reach here as childless sample folder
+        /// cards on the home page (DYN-10736); they are not graphs and must not be treated as
+        /// a missing/openable file.
+        /// </summary>
+        internal static bool IsSampleGraphPath(string path)
+        {
+            if (string.IsNullOrEmpty(path) || Directory.Exists(path))
+            {
+                return false;
+            }
+
+            var extension = Path.GetExtension(path);
+            return extension.Equals(".dyn", StringComparison.OrdinalIgnoreCase) ||
+                extension.Equals(".dyf", StringComparison.OrdinalIgnoreCase);
+        }
+
         private async Task OpenFileAsync(string path)
         {
             if (String.IsNullOrEmpty(path)) return;
@@ -568,6 +586,13 @@ namespace Dynamo.UI.Views
 
             try
             {
+                // A childless sample folder can still reach here as a card; it is not a graph
+                // to open, so bail out instead of reporting it as a missing file (DYN-10736).
+                if (!IsSampleGraphPath(path))
+                {
+                    return;
+                }
+
                 if (startPage.HandleMissingFilePath(path))
                 {
                     var recentFiles = startPage.RecentFiles?.DistinctBy(x => x.ContextData).ToList() ?? new List<StartPageListItem>();

--- a/test/DynamoCoreWpfTests/HomePageTests.cs
+++ b/test/DynamoCoreWpfTests/HomePageTests.cs
@@ -174,9 +174,10 @@ namespace DynamoCoreWpfTests
         public void IsSampleGraphPathExcludesDirectoriesAndUnsupportedFiles()
         {
             // Arrange
-            var directoryPath = GetTestDirectory(ExecutingDirectory);
-            var dynPath = Path.Combine(GetTestDirectory(ExecutingDirectory), @"core\nodeLocationTest.dyn");
-            var unrelatedPath = Path.Combine(GetTestDirectory(ExecutingDirectory), "readme.txt");
+var testDirectory = GetTestDirectory(ExecutingDirectory);
+var directoryPath = testDirectory;
+var dynPath = Path.Combine(testDirectory, "core", "nodeLocationTest.dyn");
+var unrelatedPath = Path.Combine(testDirectory, "readme.txt");
 
             // Assert
             Assert.IsTrue(Directory.Exists(directoryPath));

--- a/test/DynamoCoreWpfTests/HomePageTests.cs
+++ b/test/DynamoCoreWpfTests/HomePageTests.cs
@@ -110,6 +110,82 @@ namespace DynamoCoreWpfTests
             Assert.IsFalse(vm.Model.PreferenceSettings.RecentFiles.Contains(missingPath));
         }
 
+        [Test]
+        public void WalkDirectoryTreeExcludesFolderWithNoDynFiles()
+        {
+            // Arrange
+            var rootPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}");
+            var emptyFolderPath = Path.Combine(rootPath, "DynamoPlayer");
+            Directory.CreateDirectory(emptyFolderPath);
+            File.WriteAllText(Path.Combine(emptyFolderPath, "readme.txt"), string.Empty);
+
+            try
+            {
+                var vm = View.DataContext as DynamoViewModel;
+                var startPage = new StartPageViewModel(vm, true);
+                var rootEntity = new SampleFileEntry("root", rootPath);
+
+                // Act
+                startPage.WalkDirectoryTree(new DirectoryInfo(rootPath), rootEntity);
+
+                // Assert - a folder with no .dyn files anywhere below it must not be
+                // surfaced as a sample entry, otherwise it renders as an openable card (DYN-10736).
+                Assert.IsTrue(rootEntity.Children == null || !rootEntity.Children.Any());
+            }
+            finally
+            {
+                Directory.Delete(rootPath, true);
+            }
+        }
+
+        [Test]
+        public void WalkDirectoryTreeIncludesFolderWithNestedDynFile()
+        {
+            // Arrange
+            var rootPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}");
+            var parentFolderPath = Path.Combine(rootPath, "Revit");
+            var nestedFolderPath = Path.Combine(parentFolderPath, "DynamoPlayer");
+            Directory.CreateDirectory(nestedFolderPath);
+            File.WriteAllText(Path.Combine(nestedFolderPath, "sample.dyn"), string.Empty);
+
+            try
+            {
+                var vm = View.DataContext as DynamoViewModel;
+                var startPage = new StartPageViewModel(vm, true);
+                var rootEntity = new SampleFileEntry("root", rootPath);
+
+                // Act
+                startPage.WalkDirectoryTree(new DirectoryInfo(rootPath), rootEntity);
+
+                // Assert - the folder holding the nested .dyn is still surfaced, even though
+                // the .dyn file itself lives one level deeper.
+                var parentEntity = rootEntity.Children?.FirstOrDefault(c => c.FileName == "Revit");
+                Assert.IsNotNull(parentEntity);
+                Assert.IsNotNull(parentEntity.Children);
+                Assert.IsTrue(parentEntity.Children.Any(c => c.FileName == "DynamoPlayer"));
+            }
+            finally
+            {
+                Directory.Delete(rootPath, true);
+            }
+        }
+
+        [Test]
+        public void IsSampleGraphPathExcludesDirectoriesAndUnsupportedFiles()
+        {
+            // Arrange
+            var directoryPath = GetTestDirectory(ExecutingDirectory);
+            var dynPath = Path.Combine(GetTestDirectory(ExecutingDirectory), @"core\nodeLocationTest.dyn");
+            var unrelatedPath = Path.Combine(GetTestDirectory(ExecutingDirectory), "readme.txt");
+
+            // Assert
+            Assert.IsTrue(Directory.Exists(directoryPath));
+            Assert.IsFalse(HomePage.IsSampleGraphPath(directoryPath),
+                "A directory path must not be treated as an openable graph (DYN-10736).");
+            Assert.IsTrue(HomePage.IsSampleGraphPath(dynPath));
+            Assert.IsFalse(HomePage.IsSampleGraphPath(unrelatedPath));
+        }
+
         #endregion
 
         #region integration tests


### PR DESCRIPTION
### Purpose

`StartPage.WalkDirectoryTree` added a `SampleFileEntry` for every subdirectory under the samples folder, regardless of whether it (or any nested subfolder) actually contained `.dyn` files. **samples\en-US\Revit\DynamoPlayer** has none, so it got an entry with `Children == null`, which the React home page renders as a clickable file card. Clicking it hit `HomePage.OpenFileAsync`, which had no directory/extension guard, so `File.Exists(path)` returned **_false_** for the folder and it fell into `HandleMissingFilePath`, producing the misleading "no longer available" dialog. The legacy WPF start page never had this bug because it filtered on `.dyn` before opening — that guard wasn't carried over to the WebView2 home page.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes
N/A

### Fixes applied
**StartPage.xaml.cs:** WalkDirectoryTree now only adds a subdirectory entry after recursion if it actually produced children (works for nested .dyn files too).
**HomePage.xaml.cs:** Extracted a testable IsSampleGraphPath guard (rejects directories and non-.dyn/.dyf paths) and applied it in OpenFileAsync, restoring parity with the legacy start page and ProcessUri.
**DynamoView.xaml.cs:** Classic "Samples" menu no longer adds a top-level submenu for folders with no .dyn files directly inside them.

### Tests added
**WalkDirectoryTreeExcludesFolderWithNoDynFiles** — a folder with no .dyn anywhere below it is excluded from the sample tree.
**WalkDirectoryTreeIncludesFolderWithNestedDynFile** — a folder whose .dyn lives in a nested subfolder is still included.
**IsSampleGraphPathExcludesDirectoriesAndUnsupportedFiles** — directs at the extracted guard, confirming directories/unsupported extensions are rejected while .dyn passes.

**Before Fix**
<img width="1440" height="826" alt="image" src="https://github.com/user-attachments/assets/e0596fb1-d5dc-4d76-ac54-87fc8598d0ca" />

**After Fix when the Folder has sample Files**
<img width="1847" height="1076" alt="image" src="https://github.com/user-attachments/assets/34617d7e-1c8c-4ad7-b376-4b485531aa7c" />

**After Fix when the sample Folder is empty**
<img width="1816" height="1062" alt="image" src="https://github.com/user-attachments/assets/f76946f1-6636-4b1e-973f-b8ee27f1cd0c" />

### Reviewers

@jasonstratton @RobertGlobant20 @johnpierson 

### FYIs

@jnealb @eamiri 
