### PR TITLE
DYN-10716: Consume DynamoVisualProgramming.AutodeskAssistant 0.3.5 built-in package

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2243,7 +2243,7 @@
     different DynamoVisualProgramming.* API. Bump in lockstep with the AA release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.AutodeskAssistant" Version="[0.3.4]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.AutodeskAssistant" Version="[0.3.5]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
     The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_AutodeskAssistant)\bin IS


### PR DESCRIPTION
### Purpose

Bumps the hard-pinned `DynamoVisualProgramming.AutodeskAssistant` built-in package from `[0.3.4]` to `[0.3.5]`, consuming the [Dynamo-AutodeskAssistant 0.3.5 release](https://git.autodesk.com/Dynamo/Dynamo-AutodeskAssistant/releases/tag/v0.3.5).

This is the consuming half of **DYN-10716**. #17251 added `ViewLoadedParams.IsIDSDKInitialized` on the Dynamo side, and AA 0.3.5 is the first Autodesk Assistant release built against it — until this bump lands, the package shipped in `Built-In Packages\packages\AutodeskAssistant` is still 0.3.4 and does not consult that API, so the feature added in #17251 has no consumer.

What AA 0.3.5 contains:

- **DYN-10716** — a new "Show Autodesk Assistant" item in the Extensions menu mirroring the toolbar button (there was no menu entry point before), and both entry points now disable/grey together whenever Autodesk Identity is not initialized, instead of the toolbar button silently failing to open the panel.
- **DYN-10737** — the new approved 'Pingrid' AA brand mark on the toolbar (ships at 16/24/32/64 px, picked by display scale so it stays crisp at 125–200%), and a permanently greyed-out Assistant button with the tooltip "Please open Autodesk Assistant in Revit to interact with Dynamo" in Dynamo for Revit, instead of no button at all.

Only the version token changes. The package id, the `$(PkgDynamoVisualProgramming_AutodeskAssistant)` path property, and the `BuildAutodeskAssistantDynamoPackage` copy target are all unchanged.

⚠️ **One thing reviewers should be aware of:** AA 0.3.5 raises its `pkg.json` `engine_version` floor from 4.1 to `4.2.0.5817`, so the package will refuse to load on a Dynamo older than that 4.2 beta build. `master` satisfies this, but this pin should not be back-ported to a 4.1 release branch as-is.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

Notes on the declarations: this is a dependency version bump with no Dynamo API surface change, so the API Changes document needs no entry. Testing is covered by the Dynamo-AutodeskAssistant repo's own suite (43 tests green on the 0.3.5 release build); on this side the meaningful check is that the exact-version pin resolves and the package copies into `Built-In Packages`.

Verified locally before opening:

- `dotnet restore src/DynamoCoreWpf/DynamoCoreWpf.csproj` succeeds and `project.assets.json` resolves `DynamoVisualProgramming.AutodeskAssistant/0.3.5`.
- The published package layout is intact (`pkg.json` + `bin\` + `extra\`), `pkg.json` reads `version 0.3.5` / `engine_version 4.2.0.5817`.
- `AutodeskAssistantViewExtension.dll` is stamped FileVersion/ProductVersion `0.3.5` and its Authenticode signature validates.

### Release Notes

The Autodesk Assistant built-in package is updated to 0.3.5. The Assistant can now be opened from a new "Show Autodesk Assistant" item in the Extensions menu, and both that item and the toolbar button are greyed out when Autodesk Identity is unavailable rather than silently doing nothing. The toolbar icon is updated to the new Autodesk Assistant brand mark, and Dynamo for Revit now shows a disabled Assistant button explaining that the Assistant should be opened from Revit, instead of showing no button.

### Reviewers

@jasonstratton

### FYIs

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
