### PR TITLE
[Cherry-pick] DYN-10735: Align Autodesk.IDSDK wrapper with Revit's AdskIdentitySDK.dll version

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Label="Common dependencies">
-    <PackageReference Include="Autodesk.IDSDK" Version="1.2.5" />
+    <PackageReference Include="Autodesk.IDSDK" Version="1.2.6" />
     <PackageReference Include="Greg" Version="3.0.2.8780" />
     <PackageReference Include="DynamoVisualProgramming.LibG_231_0_0" Version="4.0.0.5336" GeneratePathProperty="true" ExcludeAssets="all"/>
     <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334" Condition=" '$(Configuration)' == 'Release' " GeneratePathProperty="true" ExcludeAssets="runtime"/>


### PR DESCRIPTION
Manual cherry-pick of #17270 (`6b9bb9b3ec`) onto `RC4.2.0_master` for the Dynamo 4.2 release.

The `auto_cherrypick.yml` bot did not pick this up automatically due to the ongoing GitHub Actions outage (webhook delivery severely throttled, queued jobs failing to get runners) — see https://www.githubstatus.com/. Cherry-picked manually per DYN-10735.

Original PR: #17270