### PR TITLE
DYN-10744: Bump DynamoMCP to 0.5.6

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2218,7 +2218,7 @@
     different DynamoVisualProgramming.* API. Bump in lockstep with the DynamoMCP release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.5.5]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.5.6]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
     The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_DynamoMCP)\bin IS


### PR DESCRIPTION
## Summary
- Bumps the pinned `DynamoVisualProgramming.DynamoMCP` NuGet reference in `src/DynamoCoreWpf/DynamoCoreWpf.csproj` from `[0.5.5]` to `[0.5.6]`.
- DynamoMCP 0.5.6 ships DYN-10744 (sign all built-in package DLLs), DYN-10743 (MCPExtension.dll version metadata), DYN-10746 (remove fragile Revit add-in assembly probe), and DYN-10747 (guard MCP server start across assembly load contexts). See [DynamoMCP CHANGELOG](https://git.autodesk.com/Dynamo/DynamoMCP/blob/master/CHANGELOG.md#056).
- Release: [DynamoMCP v0.5.6](https://git.autodesk.com/Dynamo/DynamoMCP/releases/tag/v0.5.6), package already published to nuget.org.

## Test plan
- [ ] CI restores and builds against `DynamoVisualProgramming.DynamoMCP` 0.5.6