### PR TITLE
DYN-10745: Block non-built-in Autodesk Assistant / DynamoMCP instances

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -720,6 +720,11 @@ namespace Dynamo.Models
             NoNetworkMode = config.NoNetworkMode;
             HostAnalyticsInfo = config.HostAnalyticsInfo;
 
+            // DYN-10745: disabled in test mode since the suite routinely loads packages and
+            // extensions from directories outside Built-In Packages. Remove with DYN-10739.
+            LegacyAssistantExtensionGuard.Reset();
+            LegacyAssistantExtensionGuard.IsEnabled = !IsTestMode;
+
             DebugSettings = new DebugSettings();
             if (Logger == null)
             {

--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -559,7 +559,16 @@ namespace Dynamo.Properties {
                 return ResourceManager.GetString("DuplicatedNewerPackage", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to An outdated copy of {0} was found at {1}. Dynamo now includes {0} as a built-in package, so the older copy was not loaded. Delete the folder to complete your upgrade..
+        /// </summary>
+        public static string LegacyAssistantPackageBlocked {
+            get {
+                return ResourceManager.GetString("LegacyAssistantPackageBlocked", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to An older version of the package called {0} version {2} was found at {1} with version {3}. The older version has been ignored..
         /// </summary>

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -755,6 +755,9 @@ Parameter name: {0}</value>
   <data name="DuplicatedNewerPackage" xml:space="preserve">
     <value>A newer version of the package called {0} version {2} was found at {1} with version {3}. The newer version has been ignored.</value>
   </data>
+  <data name="LegacyAssistantPackageBlocked" xml:space="preserve">
+    <value>An outdated copy of {0} was found at {1}. Dynamo now includes {0} as a built-in package, so the older copy was not loaded. Delete the folder to complete your upgrade.</value>
+  </data>
   <data name="NoneLinterDescriptorName" xml:space="preserve">
     <value>None</value>
   </data>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -757,6 +757,9 @@ Parameter name: {0}</value>
   <data name="DuplicatedNewerPackage" xml:space="preserve">
     <value>A newer version of the package called {0} version {2} was found at {1} with version {3}. The newer version has been ignored.</value>
   </data>
+  <data name="LegacyAssistantPackageBlocked" xml:space="preserve">
+    <value>An outdated copy of {0} was found at {1}. Dynamo now includes {0} as a built-in package, so the older copy was not loaded. Delete the folder to complete your upgrade.</value>
+  </data>
   <data name="Autocomplete" xml:space="preserve">
     <value>Autocomplete</value>
   </data>

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -6,3 +6,4 @@ Dynamo.Models.DynamoModel.DefaultStartConfiguration.EnableUnTrustedLocationsNoti
 Dynamo.Models.DynamoModel.IStartConfiguration.EnableUnTrustedLocationsNotifications.get -> bool
 Dynamo.Models.DynamoModel.OpenFileCommand.OpenFileCommand(System.String filePath, System.Boolean forceManualExecutionMode, System.Boolean isTemplate, System.Boolean forceBlockRun) -> void
 Dynamo.Models.DynamoModel.InsertFileCommand.InsertFileCommand(System.String filePath, System.Boolean forceManualExecutionMode, System.Boolean forceBlockRun) -> void
+static Dynamo.Properties.Resources.LegacyAssistantPackageBlocked.get -> string

--- a/src/DynamoCore/Utilities/LegacyAssistantExtensionGuard.cs
+++ b/src/DynamoCore/Utilities/LegacyAssistantExtensionGuard.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Dynamo.Core;
 
@@ -104,8 +105,26 @@ namespace Dynamo.Utilities
             if (string.IsNullOrEmpty(path)) return true;
 
             var builtInDirectory = PathManager.BuiltinPackagesDirectory;
-            return string.IsNullOrEmpty(builtInDirectory) ||
-                !path.StartsWith(builtInDirectory, StringComparison.OrdinalIgnoreCase);
+            if (string.IsNullOrEmpty(builtInDirectory)) return true;
+
+            string fullPath;
+            string fullBuiltInDirectory;
+            try
+            {
+                fullPath = Path.GetFullPath(path);
+                fullBuiltInDirectory = Path.GetFullPath(builtInDirectory)
+                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+            catch (Exception ex) when (ex is ArgumentException || ex is NotSupportedException || ex is PathTooLongException)
+            {
+                return true;
+            }
+
+            // A plain StartsWith would let a sibling like "Built-In PackagesOld" pass as if it
+            // were under "Built-In Packages" -- require an exact match or a directory-separator
+            // boundary right after the prefix.
+            return !fullPath.Equals(fullBuiltInDirectory, StringComparison.OrdinalIgnoreCase) &&
+                !fullPath.StartsWith(fullBuiltInDirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
         }
 
         internal static void RecordBlockedPackage(string directory)

--- a/src/DynamoCore/Utilities/LegacyAssistantExtensionGuard.cs
+++ b/src/DynamoCore/Utilities/LegacyAssistantExtensionGuard.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Dynamo.Core;
+
+namespace Dynamo.Utilities
+{
+    /// <summary>
+    /// A view extension blocked by <see cref="LegacyAssistantExtensionGuard"/>, recorded so a
+    /// single startup notification/dialog can be raised for it once the main window exists.
+    /// </summary>
+    internal readonly struct BlockedLegacyViewExtension
+    {
+        internal string DisplayName { get; }
+        internal string ManifestPath { get; }
+        internal string AssemblyPath { get; }
+
+        internal BlockedLegacyViewExtension(string displayName, string manifestPath, string assemblyPath)
+        {
+            DisplayName = displayName;
+            ManifestPath = manifestPath;
+            AssemblyPath = assemblyPath;
+        }
+    }
+
+    /// <summary>
+    /// DYN-10745 band-aid. Dynamo 4.2 ships Autodesk Assistant and DynamoMCP as built-in
+    /// packages for the first time. Older, pre-built-in copies of either extension are still
+    /// present on some machines (manual alpha installs, or files orphaned by a Revit
+    /// uninstall) and can silently displace the built-in copy or corrupt assembly resolution
+    /// order. This guard refuses to load either extension from any location outside Dynamo's
+    /// Built-In Packages directory.
+    /// Remove this entire type, and its call sites in PackageLoader.ScanPackageDirectory and
+    /// ViewExtensionLoader.Load(string), once DYN-10739 lands the permanent architectural fix.
+    /// </summary>
+    internal static class LegacyAssistantExtensionGuard
+    {
+        internal const string AutodeskAssistantTypeName = "Dynamo.AutodeskAssistant.AutodeskAssistantViewExtension";
+        internal const string McpViewExtensionTypeName = "Dynamo.MCP.McpViewExtension";
+
+        // Autodesk Assistant's package identity churned across DYN-10450
+        // (AutodeskAssistant -> DynamoAssistant -> back to AutodeskAssistant). Both names are
+        // treated as the same restricted package so a pre-rename install is still caught.
+        private static readonly Dictionary<string, string> restrictedPackageDisplayNames =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "AutodeskAssistant", "Autodesk Assistant" },
+                { "DynamoAssistant", "Autodesk Assistant" },
+                { "DynamoMCP", "DynamoMCP" }
+            };
+
+        private static readonly Dictionary<string, string> restrictedTypeDisplayNames =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { AutodeskAssistantTypeName, "Autodesk Assistant" },
+                { McpViewExtensionTypeName, "DynamoMCP" }
+            };
+
+        // Package blocks record the package's ROOT DIRECTORY: a Dynamo package is a
+        // self-contained folder, so "delete this folder" is safe and correct advice.
+        private static readonly HashSet<string> blockedPackageDirectories =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // View-extension blocks record the individual manifest/assembly FILE paths, not a
+        // folder. A legacy install found this way (e.g. files orphaned directly under a
+        // Revit add-in folder by an uninstall) is not necessarily isolated in its own folder,
+        // so inferring "delete this folder" from the file's location could tell a user to
+        // delete something far broader than intended.
+        private static readonly List<BlockedLegacyViewExtension> blockedViewExtensions =
+            new List<BlockedLegacyViewExtension>();
+
+        /// <summary>
+        /// Whether the guard is active. Set from DynamoModel startup based on
+        /// !IsTestMode, so the existing test suite (which routinely loads packages and
+        /// extensions from directories outside Built-In Packages) is unaffected.
+        /// </summary>
+        internal static bool IsEnabled { get; set; }
+
+        /// <summary>
+        /// Looks up the friendly display name for a restricted package name. Returns false
+        /// for any package name that is not restricted.
+        /// </summary>
+        internal static bool TryGetRestrictedPackageDisplayName(string packageName, out string displayName)
+        {
+            displayName = null;
+            return packageName != null && restrictedPackageDisplayNames.TryGetValue(packageName, out displayName);
+        }
+
+        /// <summary>
+        /// Looks up the friendly display name for a restricted view extension TypeName.
+        /// Returns false for any TypeName that is not restricted.
+        /// </summary>
+        internal static bool TryGetRestrictedViewExtensionDisplayName(string typeName, out string displayName)
+        {
+            displayName = null;
+            return typeName != null && restrictedTypeDisplayNames.TryGetValue(typeName, out displayName);
+        }
+
+        /// <summary>
+        /// True if the given path is not located under Dynamo's Built-In Packages directory.
+        /// </summary>
+        internal static bool IsOutsideBuiltInPackages(string path)
+        {
+            if (string.IsNullOrEmpty(path)) return true;
+
+            var builtInDirectory = PathManager.BuiltinPackagesDirectory;
+            return string.IsNullOrEmpty(builtInDirectory) ||
+                !path.StartsWith(builtInDirectory, StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static void RecordBlockedPackage(string directory)
+        {
+            if (!string.IsNullOrEmpty(directory)) blockedPackageDirectories.Add(directory);
+        }
+
+        internal static void RecordBlockedViewExtension(string displayName, string manifestPath, string assemblyPath)
+        {
+            blockedViewExtensions.Add(new BlockedLegacyViewExtension(displayName, manifestPath, assemblyPath));
+        }
+
+        /// <summary>
+        /// View extensions blocked at that layer only. A block at the package layer already
+        /// raises its own startup notification via LibraryLoadFailedException, so those
+        /// packages are intentionally excluded here to avoid a duplicate notification.
+        /// </summary>
+        internal static IReadOnlyList<BlockedLegacyViewExtension> BlockedViewExtensions => blockedViewExtensions;
+
+        /// <summary>
+        /// The union of every path blocked by either gate (package folders and view-extension
+        /// files alike), for the consolidated startup dialog.
+        /// </summary>
+        internal static IReadOnlyCollection<string> AllBlockedPaths =>
+            blockedPackageDirectories
+                .Concat(blockedViewExtensions.SelectMany(b => new[] { b.ManifestPath, b.AssemblyPath }))
+                .Where(p => !string.IsNullOrEmpty(p))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+        internal static bool HasBlockedPaths =>
+            blockedPackageDirectories.Count > 0 || blockedViewExtensions.Count > 0;
+
+        /// <summary>
+        /// Clears all recorded state. Called once per DynamoModel construction so repeated
+        /// model instances in the same process (tests, multi-instance hosts) don't leak state
+        /// from a previous instance.
+        /// </summary>
+        internal static void Reset()
+        {
+            blockedPackageDirectories.Clear();
+            blockedViewExtensions.Clear();
+        }
+    }
+}

--- a/src/DynamoCoreWpf/Extensions/ViewExtensionLoader.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewExtensionLoader.cs
@@ -45,6 +45,8 @@ namespace Dynamo.Wpf.Extensions
 
         public IViewExtension Load(string extensionPath)
         {
+            extensionPath = Path.GetFullPath(extensionPath);
+
             var document = new XmlDocument();
             document.Load(extensionPath);
 
@@ -62,7 +64,7 @@ namespace Dynamo.Wpf.Extensions
             {
                 if (item.Name == "AssemblyPath")
                 {
-                    path = Path.Combine(path, item.InnerText);
+                    path = Path.GetFullPath(Path.Combine(path, item.InnerText));
                     definition.AssemblyPath = path;
                 }
                 else if (item.Name == "TypeName")
@@ -92,7 +94,8 @@ namespace Dynamo.Wpf.Extensions
             // the permanent fix.
             if (LegacyAssistantExtensionGuard.IsEnabled &&
                 LegacyAssistantExtensionGuard.TryGetRestrictedViewExtensionDisplayName(definition.TypeName, out var restrictedDisplayName) &&
-                LegacyAssistantExtensionGuard.IsOutsideBuiltInPackages(extensionPath))
+                (LegacyAssistantExtensionGuard.IsOutsideBuiltInPackages(extensionPath) ||
+                 LegacyAssistantExtensionGuard.IsOutsideBuiltInPackages(definition.AssemblyPath)))
             {
                 LegacyAssistantExtensionGuard.RecordBlockedViewExtension(restrictedDisplayName, extensionPath, definition.AssemblyPath);
                 Log($"Not loading outdated copy of {restrictedDisplayName}. Found at {extensionPath} and {definition.AssemblyPath}");

--- a/src/DynamoCoreWpf/Extensions/ViewExtensionLoader.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewExtensionLoader.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Reflection;
 using System.Xml;
 using Dynamo.Logging;
+using Dynamo.Utilities;
 using DynamoUtilities;
 
 namespace Dynamo.Wpf.Extensions
@@ -83,6 +84,19 @@ namespace Dynamo.Wpf.Extensions
                 {
                     definition.RequiresSignedEntryPoint = true;
                 }
+            }
+
+            // DYN-10745: Dynamo 4.2 ships Autodesk Assistant and DynamoMCP as built-in
+            // extensions. Refuse to load either from any location outside Built-In Packages,
+            // before the assembly ever gets loaded. Remove this block once DYN-10739 lands
+            // the permanent fix.
+            if (LegacyAssistantExtensionGuard.IsEnabled &&
+                LegacyAssistantExtensionGuard.TryGetRestrictedViewExtensionDisplayName(definition.TypeName, out var restrictedDisplayName) &&
+                LegacyAssistantExtensionGuard.IsOutsideBuiltInPackages(extensionPath))
+            {
+                LegacyAssistantExtensionGuard.RecordBlockedViewExtension(restrictedDisplayName, extensionPath, definition.AssemblyPath);
+                Log($"Not loading outdated copy of {restrictedDisplayName}. Found at {extensionPath} and {definition.AssemblyPath}");
+                return null;
             }
 
             var extension = Load(definition);

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -6836,7 +6836,55 @@ namespace Dynamo.Wpf.Properties {
                 return ResourceManager.GetString("PackagePathAutoAddNotificationDetailedDescription", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Extension Not Loaded.
+        /// </summary>
+        public static string LegacyAssistantExtensionBlockedTitle {
+            get {
+                return ResourceManager.GetString("LegacyAssistantExtensionBlockedTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to An outdated copy of {0} was found and was not loaded..
+        /// </summary>
+        public static string LegacyAssistantExtensionBlockedShortDescription {
+            get {
+                return ResourceManager.GetString("LegacyAssistantExtensionBlockedShortDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Dynamo now includes {0} as a built-in extension. Delete the following to complete your upgrade, then restart Dynamo:
+        ///{1}.
+        /// </summary>
+        public static string LegacyAssistantExtensionBlockedDetailedDescription {
+            get {
+                return ResourceManager.GetString("LegacyAssistantExtensionBlockedDetailedDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Outdated Autodesk Assistant / DynamoMCP Files Found.
+        /// </summary>
+        public static string LegacyAssistantExtensionsModalTitle {
+            get {
+                return ResourceManager.GetString("LegacyAssistantExtensionsModalTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Dynamo now includes Autodesk Assistant and DynamoMCP as built-in features. Older copies were found outside the built-in location and were not loaded. Delete the following, then restart Dynamo:
+        ///
+        ///{0}.
+        /// </summary>
+        public static string LegacyAssistantExtensionsModalMessage {
+            get {
+                return ResourceManager.GetString("LegacyAssistantExtensionsModalMessage", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to A library (*.dll, *.ds) was recently imported into Dynamo. Its path was automatically added to &quot;Preferences &gt; Node and Package Paths...&quot;.
         /// </summary>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1675,6 +1675,24 @@ Next assemblies were loaded several times:
   <data name="PackagePathAutoAddNotificationDetailedDescription" xml:space="preserve">
     <value>The import path "{0}" was added to "Node and Package Paths". If you want to update or remove this path, please open "Dynamo &gt; Preferences &gt;Package Manager &gt; Node and Package Paths..."</value>
   </data>
+  <data name="LegacyAssistantExtensionBlockedTitle" xml:space="preserve">
+    <value>Extension Not Loaded</value>
+  </data>
+  <data name="LegacyAssistantExtensionBlockedShortDescription" xml:space="preserve">
+    <value>An outdated copy of {0} was found and was not loaded.</value>
+  </data>
+  <data name="LegacyAssistantExtensionBlockedDetailedDescription" xml:space="preserve">
+    <value>Dynamo now includes {0} as a built-in extension. Delete the following to complete your upgrade, then restart Dynamo:
+{1}</value>
+  </data>
+  <data name="LegacyAssistantExtensionsModalTitle" xml:space="preserve">
+    <value>Outdated Autodesk Assistant / DynamoMCP Files Found</value>
+  </data>
+  <data name="LegacyAssistantExtensionsModalMessage" xml:space="preserve">
+    <value>Dynamo now includes Autodesk Assistant and DynamoMCP as built-in features. Older copies were found outside the built-in location and were not loaded. Delete the following, then restart Dynamo:
+
+{0}</value>
+  </data>
   <data name="PackageSearchStateNoResult" xml:space="preserve">
     <value>Search returned no results!</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2357,6 +2357,24 @@ Do you want to install the latest Dynamo update?</value>
   <data name="PackagePathAutoAddNotificationDetailedDescription" xml:space="preserve">
     <value>The import path "{0}" was added to "Node and Package Paths". If you want to update or remove this path, please open "Dynamo &gt; Preferences &gt;Package Manager &gt; Node and Package Paths..."</value>
   </data>
+  <data name="LegacyAssistantExtensionBlockedTitle" xml:space="preserve">
+    <value>Extension Not Loaded</value>
+  </data>
+  <data name="LegacyAssistantExtensionBlockedShortDescription" xml:space="preserve">
+    <value>An outdated copy of {0} was found and was not loaded.</value>
+  </data>
+  <data name="LegacyAssistantExtensionBlockedDetailedDescription" xml:space="preserve">
+    <value>Dynamo now includes {0} as a built-in extension. Delete the following to complete your upgrade, then restart Dynamo:
+{1}</value>
+  </data>
+  <data name="LegacyAssistantExtensionsModalTitle" xml:space="preserve">
+    <value>Outdated Autodesk Assistant / DynamoMCP Files Found</value>
+  </data>
+  <data name="LegacyAssistantExtensionsModalMessage" xml:space="preserve">
+    <value>Dynamo now includes Autodesk Assistant and DynamoMCP as built-in features. Older copies were found outside the built-in location and were not loaded. Delete the following, then restart Dynamo:
+
+{0}</value>
+  </data>
   <data name="NodeContextMenuIsInput" xml:space="preserve">
     <value>Is Input</value>
   </data>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -83,4 +83,9 @@ static Dynamo.Wpf.Properties.Resources.SplashScreenResetSettingsTooltip.get -> s
 static Dynamo.Wpf.Properties.Resources.SplashScreenSettingsImportedRestartMessage.get -> string
 static Dynamo.Wpf.Properties.Resources.SplashScreenSettingsResetSuccess.get -> string
 static Dynamo.Wpf.Properties.Resources.ToastHyperlinkPathText.get -> string
+static Dynamo.Wpf.Properties.Resources.LegacyAssistantExtensionBlockedTitle.get -> string
+static Dynamo.Wpf.Properties.Resources.LegacyAssistantExtensionBlockedShortDescription.get -> string
+static Dynamo.Wpf.Properties.Resources.LegacyAssistantExtensionBlockedDetailedDescription.get -> string
+static Dynamo.Wpf.Properties.Resources.LegacyAssistantExtensionsModalTitle.get -> string
+static Dynamo.Wpf.Properties.Resources.LegacyAssistantExtensionsModalMessage.get -> string
 static readonly Dynamo.PackageManager.UI.PackageManagerTabControl.SuppressHomeEndWhenSelectedProperty -> System.Windows.DependencyProperty

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1560,6 +1560,8 @@ namespace Dynamo.Controls
             sharedViewExtensionLoadedParams = new ViewLoadedParams(this, dynamoViewModel);
             this.DynamoLoadedViewExtensionHandler(sharedViewExtensionLoadedParams, viewExtensionManager.ViewExtensions);
 
+            NotifyLegacyAssistantExtensionsBlocked();
+
             BackgroundPreview = new Watch3DView { Name = BackgroundPreviewName };
             background_grid.Children.Add(BackgroundPreview);
             BackgroundPreview.DataContext = dynamoViewModel.BackgroundPreviewViewModel;
@@ -3457,6 +3459,39 @@ namespace Dynamo.Controls
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// DYN-10745: raises a notification for each Autodesk Assistant / DynamoMCP view
+        /// extension that LegacyAssistantExtensionGuard blocked at startup, then shows one
+        /// consolidated dialog listing every file or folder blocked by either gate (package or
+        /// view extension) so the user can complete their upgrade to Dynamo 4.2. Package-layer
+        /// blocks already raise their own notification via LibraryLoadFailedException, so only
+        /// the modal (not a second notification) covers them here.
+        /// Remove this method, and its call site above, once DYN-10739 lands the permanent fix.
+        /// </summary>
+        private void NotifyLegacyAssistantExtensionsBlocked()
+        {
+            foreach (var blocked in LegacyAssistantExtensionGuard.BlockedViewExtensions)
+            {
+                var paths = string.Join(Environment.NewLine,
+                    new[] { blocked.ManifestPath, blocked.AssemblyPath }.Where(p => !string.IsNullOrEmpty(p)));
+
+                dynamoViewModel.Model.Logger.LogNotification(
+                    "Dynamo",
+                    Wpf.Properties.Resources.LegacyAssistantExtensionBlockedTitle,
+                    string.Format(Wpf.Properties.Resources.LegacyAssistantExtensionBlockedShortDescription, blocked.DisplayName),
+                    string.Format(Wpf.Properties.Resources.LegacyAssistantExtensionBlockedDetailedDescription, blocked.DisplayName, paths));
+            }
+
+            if (!LegacyAssistantExtensionGuard.HasBlockedPaths) return;
+
+            var allPaths = string.Join(Environment.NewLine, LegacyAssistantExtensionGuard.AllBlockedPaths);
+            MessageBoxService.Show(
+                string.Format(Wpf.Properties.Resources.LegacyAssistantExtensionsModalMessage, allPaths),
+                Wpf.Properties.Resources.LegacyAssistantExtensionsModalTitle,
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
         }
     }
 }

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -571,7 +571,7 @@ namespace Dynamo.PackageManager
                 // Remove this block once DYN-10739 lands the permanent fix.
                 if (LegacyAssistantExtensionGuard.IsEnabled &&
                     LegacyAssistantExtensionGuard.TryGetRestrictedPackageDisplayName(discoveredPackage.Name, out var restrictedDisplayName) &&
-                    !discoveredPackage.BuiltInPackage)
+                    LegacyAssistantExtensionGuard.IsOutsideBuiltInPackages(discoveredPackage.RootDirectory))
                 {
                     LegacyAssistantExtensionGuard.RecordBlockedPackage(discoveredPackage.RootDirectory);
                     throw new LibraryLoadFailedException(directory,

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -565,6 +565,20 @@ namespace Dynamo.PackageManager
                     throw new LibraryLoadFailedException(directory, String.Format(Properties.Resources.NoHeaderPackage, headerPath));
                 }
 
+                // DYN-10745: Dynamo 4.2 ships Autodesk Assistant and DynamoMCP as built-in
+                // packages. Refuse any copy of either found outside Built-In Packages, so it
+                // can't displace the built-in one or pollute assembly resolution order.
+                // Remove this block once DYN-10739 lands the permanent fix.
+                if (LegacyAssistantExtensionGuard.IsEnabled &&
+                    LegacyAssistantExtensionGuard.TryGetRestrictedPackageDisplayName(discoveredPackage.Name, out var restrictedDisplayName) &&
+                    !discoveredPackage.BuiltInPackage)
+                {
+                    LegacyAssistantExtensionGuard.RecordBlockedPackage(discoveredPackage.RootDirectory);
+                    throw new LibraryLoadFailedException(directory,
+                        String.Format(Properties.Resources.LegacyAssistantPackageBlocked,
+                            restrictedDisplayName, discoveredPackage.RootDirectory));
+                }
+
                 // prevent loading unsigned packages if the certificates are required on package dlls
                 if (checkCertificates)
                 {

--- a/test/DynamoCoreTests/LegacyAssistantExtensionGuardTests.cs
+++ b/test/DynamoCoreTests/LegacyAssistantExtensionGuardTests.cs
@@ -1,0 +1,159 @@
+using System.IO;
+
+using Dynamo.Core;
+using Dynamo.Utilities;
+
+using NUnit.Framework;
+
+namespace Dynamo.Tests
+{
+    /// <summary>
+    /// DYN-10745 band-aid tests. Remove this file along with LegacyAssistantExtensionGuard
+    /// once DYN-10739 lands the permanent fix.
+    /// </summary>
+    [TestFixture]
+    class LegacyAssistantExtensionGuardTests
+    {
+        private string originalBuiltinPackagesDirectory;
+
+        [SetUp]
+        public void Setup()
+        {
+            originalBuiltinPackagesDirectory = PathManager.BuiltinPackagesDirectory;
+            LegacyAssistantExtensionGuard.Reset();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            PathManager.BuiltinPackagesDirectory = originalBuiltinPackagesDirectory;
+            LegacyAssistantExtensionGuard.Reset();
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        [TestCase("AutodeskAssistant", "Autodesk Assistant")]
+        [TestCase("DynamoAssistant", "Autodesk Assistant")]
+        [TestCase("DynamoMCP", "DynamoMCP")]
+        public void WhenPackageNameIsRestrictedThenDisplayNameIsReturned(string packageName, string expectedDisplayName)
+        {
+            Assert.IsTrue(LegacyAssistantExtensionGuard.TryGetRestrictedPackageDisplayName(packageName, out var displayName));
+            Assert.AreEqual(expectedDisplayName, displayName);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("SomeOtherPackage")]
+        [TestCase("TuneUp")]
+        public void WhenPackageNameIsNotRestrictedThenNoDisplayNameIsReturned(string packageName)
+        {
+            Assert.IsFalse(LegacyAssistantExtensionGuard.TryGetRestrictedPackageDisplayName(packageName, out var displayName));
+            Assert.IsNull(displayName);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        [TestCase(LegacyAssistantExtensionGuard.AutodeskAssistantTypeName, "Autodesk Assistant")]
+        [TestCase(LegacyAssistantExtensionGuard.McpViewExtensionTypeName, "DynamoMCP")]
+        public void WhenViewExtensionTypeIsRestrictedThenDisplayNameIsReturned(string typeName, string expectedDisplayName)
+        {
+            Assert.IsTrue(LegacyAssistantExtensionGuard.TryGetRestrictedViewExtensionDisplayName(typeName, out var displayName));
+            Assert.AreEqual(expectedDisplayName, displayName);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("Some.Other.ViewExtension")]
+        public void WhenViewExtensionTypeIsNotRestrictedThenNoDisplayNameIsReturned(string typeName)
+        {
+            Assert.IsFalse(LegacyAssistantExtensionGuard.TryGetRestrictedViewExtensionDisplayName(typeName, out var displayName));
+            Assert.IsNull(displayName);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenPathIsUnderBuiltinPackagesDirectoryThenIsNotOutside()
+        {
+            PathManager.BuiltinPackagesDirectory = @"C:\Dynamo\Built-In Packages\Packages";
+            var path = Path.Combine(PathManager.BuiltinPackagesDirectory, "AutodeskAssistant");
+
+            Assert.IsFalse(LegacyAssistantExtensionGuard.IsOutsideBuiltInPackages(path));
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenPathIsOutsideBuiltinPackagesDirectoryThenIsOutside()
+        {
+            PathManager.BuiltinPackagesDirectory = @"C:\Dynamo\Built-In Packages\Packages";
+
+            Assert.IsTrue(LegacyAssistantExtensionGuard.IsOutsideBuiltInPackages(@"C:\Users\someone\AppData\Roaming\Dynamo\Dynamo Core\4.2\packages\DynamoMCP"));
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        [TestCase(null)]
+        [TestCase("")]
+        public void WhenPathIsNullOrEmptyThenIsOutside(string path)
+        {
+            Assert.IsTrue(LegacyAssistantExtensionGuard.IsOutsideBuiltInPackages(path));
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenPackageBlockedThenItAppearsInAllBlockedPathsOnly()
+        {
+            LegacyAssistantExtensionGuard.RecordBlockedPackage(@"C:\packages\DynamoMCP");
+
+            CollectionAssert.AreEquivalent(new[] { @"C:\packages\DynamoMCP" }, LegacyAssistantExtensionGuard.AllBlockedPaths);
+            // Package blocks already raise their own notification via LibraryLoadFailedException,
+            // so they must not also appear in the view-extension-only collection.
+            Assert.AreEqual(0, LegacyAssistantExtensionGuard.BlockedViewExtensions.Count);
+            Assert.IsTrue(LegacyAssistantExtensionGuard.HasBlockedPaths);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenViewExtensionBlockedThenBothFilesAppearInAllBlockedPaths()
+        {
+            LegacyAssistantExtensionGuard.RecordBlockedViewExtension(
+                "Autodesk Assistant",
+                @"C:\Revit\AddIns\DynamoForRevit\viewExtensions\AutodeskAssistant_ViewExtensionDefinition.xml",
+                @"C:\Revit\AddIns\DynamoForRevit\AutodeskAssistantViewExtension.dll");
+
+            Assert.AreEqual(1, LegacyAssistantExtensionGuard.BlockedViewExtensions.Count);
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
+                    @"C:\Revit\AddIns\DynamoForRevit\viewExtensions\AutodeskAssistant_ViewExtensionDefinition.xml",
+                    @"C:\Revit\AddIns\DynamoForRevit\AutodeskAssistantViewExtension.dll"
+                },
+                LegacyAssistantExtensionGuard.AllBlockedPaths);
+            Assert.IsTrue(LegacyAssistantExtensionGuard.HasBlockedPaths);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenNothingBlockedThenHasBlockedPathsIsFalse()
+        {
+            Assert.IsFalse(LegacyAssistantExtensionGuard.HasBlockedPaths);
+            Assert.AreEqual(0, LegacyAssistantExtensionGuard.AllBlockedPaths.Count);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenResetThenAllRecordedStateIsCleared()
+        {
+            LegacyAssistantExtensionGuard.RecordBlockedPackage(@"C:\packages\DynamoMCP");
+            LegacyAssistantExtensionGuard.RecordBlockedViewExtension("Autodesk Assistant", @"C:\a.xml", @"C:\a.dll");
+
+            LegacyAssistantExtensionGuard.Reset();
+
+            Assert.IsFalse(LegacyAssistantExtensionGuard.HasBlockedPaths);
+            Assert.AreEqual(0, LegacyAssistantExtensionGuard.BlockedViewExtensions.Count);
+        }
+    }
+}

--- a/test/DynamoCoreTests/LegacyAssistantExtensionGuardTests.cs
+++ b/test/DynamoCoreTests/LegacyAssistantExtensionGuardTests.cs
@@ -95,6 +95,36 @@ namespace Dynamo.Tests
 
         [Test]
         [Category("UnitTests")]
+        public void WhenPathIsUnderSimilarlyNamedSiblingDirectoryThenIsOutside()
+        {
+            // A plain StartsWith would let "Built-In PackagesOld" pass as if it were under
+            // "Built-In Packages" -- the check must require a directory-separator boundary.
+            PathManager.BuiltinPackagesDirectory = @"C:\Dynamo\Built-In Packages";
+
+            Assert.IsTrue(LegacyAssistantExtensionGuard.IsOutsideBuiltInPackages(@"C:\Dynamo\Built-In PackagesOld\AutodeskAssistant"));
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenPathEqualsBuiltinPackagesDirectoryExactlyThenIsNotOutside()
+        {
+            PathManager.BuiltinPackagesDirectory = @"C:\Dynamo\Built-In Packages";
+
+            Assert.IsFalse(LegacyAssistantExtensionGuard.IsOutsideBuiltInPackages(@"C:\Dynamo\Built-In Packages"));
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenPathContainsDotDotSegmentsEscapingBuiltinDirectoryThenIsOutside()
+        {
+            PathManager.BuiltinPackagesDirectory = @"C:\Dynamo\Built-In Packages";
+
+            Assert.IsTrue(LegacyAssistantExtensionGuard.IsOutsideBuiltInPackages(
+                @"C:\Dynamo\Built-In Packages\Packages\AutodeskAssistant\..\..\..\Escaped"));
+        }
+
+        [Test]
+        [Category("UnitTests")]
         [TestCase(null)]
         [TestCase("")]
         public void WhenPathIsNullOrEmptyThenIsOutside(string path)

--- a/test/DynamoCoreWpf2Tests/ViewExtensions/Sample Manifests/LegacyAutodeskAssistant_EscapingAssemblyPath_ViewExtensionDefinition.xml
+++ b/test/DynamoCoreWpf2Tests/ViewExtensions/Sample Manifests/LegacyAutodeskAssistant_EscapingAssemblyPath_ViewExtensionDefinition.xml
@@ -1,0 +1,4 @@
+<ViewExtensionDefinition>
+  <AssemblyPath>..\..\..\Escaped\AutodeskAssistantViewExtension.dll</AssemblyPath>
+  <TypeName>Dynamo.AutodeskAssistant.AutodeskAssistantViewExtension</TypeName>
+</ViewExtensionDefinition>

--- a/test/DynamoCoreWpf2Tests/ViewExtensions/Sample Manifests/LegacyAutodeskAssistant_ViewExtensionDefinition.xml
+++ b/test/DynamoCoreWpf2Tests/ViewExtensions/Sample Manifests/LegacyAutodeskAssistant_ViewExtensionDefinition.xml
@@ -1,0 +1,4 @@
+<ViewExtensionDefinition>
+  <AssemblyPath>..\bin\AutodeskAssistantViewExtension.dll</AssemblyPath>
+  <TypeName>Dynamo.AutodeskAssistant.AutodeskAssistantViewExtension</TypeName>
+</ViewExtensionDefinition>

--- a/test/DynamoCoreWpf2Tests/ViewExtensions/ViewExtensionTests.cs
+++ b/test/DynamoCoreWpf2Tests/ViewExtensions/ViewExtensionTests.cs
@@ -192,9 +192,11 @@ namespace DynamoCoreWpfTests
 
                 var manifestDirectory = Path.Combine(GetTestDirectory(ExecutingDirectory),
                     @"DynamoCoreWpf2Tests\ViewExtensions\Sample Manifests");
-                // Treat the fixture's own folder as the trusted built-in location, so the
-                // guard should NOT record a block for it.
-                PathManager.BuiltinPackagesDirectory = manifestDirectory;
+                // The fixture's AssemblyPath is "..\bin\...", mirroring a real built-in package
+                // layout where the manifest and its assembly are sibling subfolders of a shared
+                // package root. Treat that shared root -- not the manifest's own folder -- as the
+                // trusted built-in location, so the guard should NOT record a block for it.
+                PathManager.BuiltinPackagesDirectory = Path.GetDirectoryName(manifestDirectory);
 
                 var extensionManager = View.viewExtensionManager;
                 var loader = extensionManager.ExtensionLoader;
@@ -203,6 +205,41 @@ namespace DynamoCoreWpfTests
                 loader.Load(manifestPath);
 
                 Assert.AreEqual(0, LegacyAssistantExtensionGuard.BlockedViewExtensions.Count);
+            }
+            finally
+            {
+                LegacyAssistantExtensionGuard.IsEnabled = originalEnabled;
+                PathManager.BuiltinPackagesDirectory = originalBuiltinPackagesDirectory;
+                LegacyAssistantExtensionGuard.Reset();
+            }
+        }
+
+        [Test]
+        public void LegacyAutodeskAssistantWithAssemblyPathEscapingBuiltInPackagesIsBlocked()
+        {
+            RaiseLoadedEvent(this.View);
+
+            var originalEnabled = LegacyAssistantExtensionGuard.IsEnabled;
+            var originalBuiltinPackagesDirectory = PathManager.BuiltinPackagesDirectory;
+            try
+            {
+                LegacyAssistantExtensionGuard.IsEnabled = true;
+                LegacyAssistantExtensionGuard.Reset();
+
+                var manifestDirectory = Path.Combine(GetTestDirectory(ExecutingDirectory),
+                    @"DynamoCoreWpf2Tests\ViewExtensions\Sample Manifests");
+                // The manifest itself lives under the trusted built-in location, but its
+                // AssemblyPath climbs out via ".." -- the resolved assembly path must be
+                // checked independently of the manifest path.
+                PathManager.BuiltinPackagesDirectory = manifestDirectory;
+
+                var extensionManager = View.viewExtensionManager;
+                var loader = extensionManager.ExtensionLoader;
+                var manifestPath = Path.Combine(manifestDirectory,
+                    "LegacyAutodeskAssistant_EscapingAssemblyPath_ViewExtensionDefinition.xml");
+
+                Assert.IsNull(loader.Load(manifestPath));
+                Assert.AreEqual(1, LegacyAssistantExtensionGuard.BlockedViewExtensions.Count);
             }
             finally
             {

--- a/test/DynamoCoreWpf2Tests/ViewExtensions/ViewExtensionTests.cs
+++ b/test/DynamoCoreWpf2Tests/ViewExtensions/ViewExtensionTests.cs
@@ -5,9 +5,11 @@ using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using Dynamo.Controls;
+using Dynamo.Core;
 using Dynamo.Engine;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
+using Dynamo.Utilities;
 using Dynamo.Wpf.Extensions;
 using Dynamo.Wpf.UI.GuidedTour;
 using DynamoCoreWpfTests.Utility;
@@ -145,6 +147,69 @@ namespace DynamoCoreWpfTests
             var loader = extensionManager.ExtensionLoader;
             // Once IsEnabled set to false, loader will skip the loading and expect to return null.
             Assert.IsNull(loader.Load(Path.Combine(GetTestDirectory(ExecutingDirectory), @"DynamoCoreWpf2Tests\ViewExtensions\Sample Manifests\Sample_ViewExtensionDefinition.xml")));
+        }
+
+        // DYN-10745 band-aid tests. Remove along with LegacyAssistantExtensionGuard once
+        // DYN-10739 lands the permanent fix.
+        [Test]
+        public void LegacyAutodeskAssistantOutsideBuiltInPackagesIsNotLoaded()
+        {
+            RaiseLoadedEvent(this.View);
+
+            var originalEnabled = LegacyAssistantExtensionGuard.IsEnabled;
+            try
+            {
+                LegacyAssistantExtensionGuard.IsEnabled = true;
+                LegacyAssistantExtensionGuard.Reset();
+
+                var extensionManager = View.viewExtensionManager;
+                var loader = extensionManager.ExtensionLoader;
+                var manifestPath = Path.Combine(GetTestDirectory(ExecutingDirectory),
+                    @"DynamoCoreWpf2Tests\ViewExtensions\Sample Manifests\LegacyAutodeskAssistant_ViewExtensionDefinition.xml");
+
+                Assert.IsNull(loader.Load(manifestPath));
+                Assert.AreEqual(1, LegacyAssistantExtensionGuard.BlockedViewExtensions.Count);
+                Assert.AreEqual("Autodesk Assistant", LegacyAssistantExtensionGuard.BlockedViewExtensions[0].DisplayName);
+            }
+            finally
+            {
+                LegacyAssistantExtensionGuard.IsEnabled = originalEnabled;
+                LegacyAssistantExtensionGuard.Reset();
+            }
+        }
+
+        [Test]
+        public void LegacyAutodeskAssistantUnderBuiltInPackagesIsNotBlocked()
+        {
+            RaiseLoadedEvent(this.View);
+
+            var originalEnabled = LegacyAssistantExtensionGuard.IsEnabled;
+            var originalBuiltinPackagesDirectory = PathManager.BuiltinPackagesDirectory;
+            try
+            {
+                LegacyAssistantExtensionGuard.IsEnabled = true;
+                LegacyAssistantExtensionGuard.Reset();
+
+                var manifestDirectory = Path.Combine(GetTestDirectory(ExecutingDirectory),
+                    @"DynamoCoreWpf2Tests\ViewExtensions\Sample Manifests");
+                // Treat the fixture's own folder as the trusted built-in location, so the
+                // guard should NOT record a block for it.
+                PathManager.BuiltinPackagesDirectory = manifestDirectory;
+
+                var extensionManager = View.viewExtensionManager;
+                var loader = extensionManager.ExtensionLoader;
+                var manifestPath = Path.Combine(manifestDirectory, "LegacyAutodeskAssistant_ViewExtensionDefinition.xml");
+
+                loader.Load(manifestPath);
+
+                Assert.AreEqual(0, LegacyAssistantExtensionGuard.BlockedViewExtensions.Count);
+            }
+            finally
+            {
+                LegacyAssistantExtensionGuard.IsEnabled = originalEnabled;
+                PathManager.BuiltinPackagesDirectory = originalBuiltinPackagesDirectory;
+                LegacyAssistantExtensionGuard.Reset();
+            }
         }
 
         [Test]

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -1704,6 +1704,41 @@ namespace Dynamo.PackageManager.Tests
         }
 
         [Test]
+        public void LegacyDynamoMcpPackageInSiblingDirectoryWithSimilarNameIsNotLoaded()
+        {
+            // Regression test for a review finding: relying on Package.BuiltInPackage's plain
+            // StartsWith check would misclassify "...\Packages Old\DynamoMCP" as being under
+            // "...\Packages" merely because it shares a string prefix. The guard must instead
+            // require a real directory-separator boundary (LegacyAssistantExtensionGuard.IsOutsideBuiltInPackages).
+            var originalBuiltinPackagesDirectory = PathManager.BuiltinPackagesDirectory;
+            var originalEnabled = LegacyAssistantExtensionGuard.IsEnabled;
+            try
+            {
+                LegacyAssistantExtensionGuard.IsEnabled = true;
+                LegacyAssistantExtensionGuard.Reset();
+
+                var scratchRoot = Path.Combine(TempFolder, "legacy_boundary_" + Guid.NewGuid().ToString("N"));
+                var trustedPackagesRoot = Path.Combine(scratchRoot, "Packages");
+                PathManager.BuiltinPackagesDirectory = trustedPackagesRoot;
+
+                var siblingPackagesRoot = trustedPackagesRoot + "Old";
+                var packageDir = WriteLegacyDynamoMcpPackage(siblingPackagesRoot);
+
+                var loader = GetPackageLoader();
+                var pkg = loader.ScanPackageDirectory(packageDir);
+
+                Assert.IsNull(pkg);
+                CollectionAssert.Contains(LegacyAssistantExtensionGuard.AllBlockedPaths, packageDir);
+            }
+            finally
+            {
+                LegacyAssistantExtensionGuard.IsEnabled = originalEnabled;
+                PathManager.BuiltinPackagesDirectory = originalBuiltinPackagesDirectory;
+                LegacyAssistantExtensionGuard.Reset();
+            }
+        }
+
+        [Test]
         public void UnrestrictedPackageOutsideBuiltInIsStillLoadedWithGuardEnabled()
         {
             // The guard must only restrict Autodesk Assistant / DynamoMCP; every other

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -13,6 +13,7 @@ using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Interfaces;
 using Dynamo.Search.SearchElements;
+using Dynamo.Utilities;
 using Moq;
 using NUnit.Framework;
 
@@ -1598,5 +1599,134 @@ namespace Dynamo.PackageManager.Tests
 
         }
 
+        // DYN-10745 band-aid tests. Remove along with LegacyAssistantExtensionGuard once
+        // DYN-10739 lands the permanent fix.
+        private string WriteLegacyDynamoMcpPackage(string packagesRoot)
+        {
+            var packageDir = Path.Combine(packagesRoot, "DynamoMCP");
+            Directory.CreateDirectory(Path.Combine(packageDir, "bin"));
+            File.WriteAllText(Path.Combine(packageDir, "pkg.json"),
+                "{\"file_hash\":null,\"name\":\"DynamoMCP\",\"version\":\"0.5.4\",\"description\":\"\",\"group\":\"\"," +
+                "\"keywords\":[],\"dependencies\":[],\"license\":\"Apache-2.0\",\"contents\":\"\"," +
+                "\"engine_version\":\"4.2.0\",\"engine_metadata\":\"\",\"engine\":\"dynamo\",\"node_libraries\":[]}");
+            return packageDir;
+        }
+
+        [Test]
+        public void LegacyDynamoMcpPackageOutsideBuiltInIsNotLoaded()
+        {
+            var originalEnabled = LegacyAssistantExtensionGuard.IsEnabled;
+            try
+            {
+                LegacyAssistantExtensionGuard.IsEnabled = true;
+                LegacyAssistantExtensionGuard.Reset();
+
+                var packagesRoot = Path.Combine(TempFolder, "legacy_mcp_" + Guid.NewGuid().ToString("N"));
+                var packageDir = WriteLegacyDynamoMcpPackage(packagesRoot);
+
+                var loader = GetPackageLoader();
+                var pkg = loader.ScanPackageDirectory(packageDir);
+
+                Assert.IsNull(pkg);
+                // The real built-in DynamoMCP package may also be loaded in this environment;
+                // what matters is that the legacy copy specifically was never added.
+                Assert.IsFalse(loader.LocalPackages.Any(p => p.RootDirectory == packageDir));
+                CollectionAssert.Contains(LegacyAssistantExtensionGuard.AllBlockedPaths, packageDir);
+            }
+            finally
+            {
+                LegacyAssistantExtensionGuard.IsEnabled = originalEnabled;
+                LegacyAssistantExtensionGuard.Reset();
+            }
+        }
+
+        [Test]
+        public void LegacyDynamoMcpPackageDoesNotPolluteAssemblyResolutionPaths()
+        {
+            var originalEnabled = LegacyAssistantExtensionGuard.IsEnabled;
+            try
+            {
+                LegacyAssistantExtensionGuard.IsEnabled = true;
+                LegacyAssistantExtensionGuard.Reset();
+
+                var packagesRoot = Path.Combine(TempFolder, "legacy_mcp_" + Guid.NewGuid().ToString("N"));
+                WriteLegacyDynamoMcpPackage(packagesRoot);
+
+                var pathManager = new Mock<IPathManager>();
+                pathManager.SetupGet(x => x.PackagesDirectories).Returns(new List<string> { packagesRoot });
+
+                var loader = new PackageLoader(pathManager.Object);
+                loader.LoadAll(new LoadPackageParams { Preferences = new PreferenceSettings() });
+
+                Assert.IsFalse(loader.LocalPackages.Any(p => p.Name == "DynamoMCP"));
+                // The rejected package's bin directory must never be added as an assembly
+                // resolution path -- that is the DLL-load-order conflict this guard prevents.
+                pathManager.Verify(x => x.AddResolutionPath(It.Is<string>(p => p.Contains("DynamoMCP"))), Times.Never);
+            }
+            finally
+            {
+                LegacyAssistantExtensionGuard.IsEnabled = originalEnabled;
+                LegacyAssistantExtensionGuard.Reset();
+            }
+        }
+
+        [Test]
+        public void LegacyDynamoAssistantPackageNameIsAlsoBlocked()
+        {
+            // Autodesk Assistant's package identity churned across DYN-10450 (AutodeskAssistant
+            // -> DynamoAssistant -> back to AutodeskAssistant); a pre-rename install must still
+            // be caught.
+            var originalEnabled = LegacyAssistantExtensionGuard.IsEnabled;
+            try
+            {
+                LegacyAssistantExtensionGuard.IsEnabled = true;
+                LegacyAssistantExtensionGuard.Reset();
+
+                var packagesRoot = Path.Combine(TempFolder, "legacy_dynamoassistant_" + Guid.NewGuid().ToString("N"));
+                var packageDir = Path.Combine(packagesRoot, "DynamoAssistant");
+                Directory.CreateDirectory(Path.Combine(packageDir, "bin"));
+                File.WriteAllText(Path.Combine(packageDir, "pkg.json"),
+                    "{\"file_hash\":null,\"name\":\"DynamoAssistant\",\"version\":\"0.3.3\",\"description\":\"\",\"group\":\"\"," +
+                    "\"keywords\":[],\"dependencies\":[],\"license\":\"Apache-2.0\",\"contents\":\"\"," +
+                    "\"engine_version\":\"4.1.0\",\"engine_metadata\":\"\",\"engine\":\"dynamo\",\"node_libraries\":[]}");
+
+                var loader = GetPackageLoader();
+                var pkg = loader.ScanPackageDirectory(packageDir);
+
+                Assert.IsNull(pkg);
+                CollectionAssert.Contains(LegacyAssistantExtensionGuard.AllBlockedPaths, packageDir);
+            }
+            finally
+            {
+                LegacyAssistantExtensionGuard.IsEnabled = originalEnabled;
+                LegacyAssistantExtensionGuard.Reset();
+            }
+        }
+
+        [Test]
+        public void UnrestrictedPackageOutsideBuiltInIsStillLoadedWithGuardEnabled()
+        {
+            // The guard must only restrict Autodesk Assistant / DynamoMCP; every other
+            // package's normal load path is unaffected.
+            var originalEnabled = LegacyAssistantExtensionGuard.IsEnabled;
+            try
+            {
+                LegacyAssistantExtensionGuard.IsEnabled = true;
+                LegacyAssistantExtensionGuard.Reset();
+
+                var pkgDir = Path.Combine(PackagesDirectory, "Custom Rounding");
+                var loader = GetPackageLoader();
+                var pkg = loader.ScanPackageDirectory(pkgDir);
+
+                Assert.IsNotNull(pkg);
+                Assert.AreEqual("Custom Rounding", pkg.Name);
+                Assert.IsFalse(LegacyAssistantExtensionGuard.HasBlockedPaths);
+            }
+            finally
+            {
+                LegacyAssistantExtensionGuard.IsEnabled = originalEnabled;
+                LegacyAssistantExtensionGuard.Reset();
+            }
+        }
     }
 }


### PR DESCRIPTION
### Purpose

Dynamo 4.2 ships Autodesk Assistant and DynamoMCP as built-in packages for the first time. Alpha-era copies of either can still be present on disk — a manually-installed `DynamoMCP` package under the default packages folder, or an orphaned Autodesk Assistant view extension left behind by a Dynamo-for-Revit uninstall — and can silently displace the shipped built-in copy (see [DYN-10739](https://jira.autodesk.com/browse/DYN-10739)).

This is an explicit 4.2 band-aid, not the permanent fix. Path is the only reliable signal (package names have churned and alpha builds are signed the same as release builds), so `LegacyAssistantExtensionGuard` refuses any AA/DynamoMCP package or view extension found outside `Built-In Packages`, and reports exactly which files to delete via a notification plus a consolidated modal. It is disabled in test mode and every new symbol is marked for removal once DYN-10739 lands the architectural fix in 4.3.

**Target:** `master`, then cherry-pick to `RC4.2.0_master`.

Supersedes #17277, which was opened from a branch whose merge-base predated the DYN-10716 squash-merge and so pulled in that PR's already-merged commits/diff again. This PR is cut from current `master` and contains only the DYN-10745 changes.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Dynamo now detects and refuses to load outdated, non-built-in copies of Autodesk Assistant or DynamoMCP left over from earlier alpha testing, and tells you which files to delete.

### Reviewers

(Assign reviewer)

Note for reviewers: this changes the local-dev workflow for AA/DynamoMCP maintainers — local builds must now be deployed directly into `Built-In Packages\packages\<Name>\` rather than a `CustomPackageFolders` override, since any copy outside Built-In Packages is now refused when the guard is enabled (non-test builds).

### FYIs