### PR TITLE
DYN-4783: Align invalid input handling for Number, Sliders, and DateTime

### DIFF
--- a/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
+++ b/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
@@ -223,6 +223,7 @@ namespace Dynamo.Nodes
 
                     if (expr.HasValidationError && nvm != null)
                     {
+                        nvm.NodeModel.ClearErrorsAndWarnings();
                         nvm.NodeModel.Error(expr.ValidationError.ErrorContent as string);
                     }
                 }

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -337,6 +337,8 @@ namespace CoreNodeModels.Input
         {
             base.DeserializeCore(element, context); //Base implementation must be called
 
+            ClearErrorsAndWarnings();
+
             foreach (
                 XmlNode subNode in
                     element.ChildNodes.Cast<XmlNode>()
@@ -344,6 +346,9 @@ namespace CoreNodeModels.Input
             {
                 Value = subNode.Attributes[0].Value;
             }
+
+            // Value's equality guard can skip notify, force UI to drop uncommitted invalid text
+            RaisePropertyChanged(nameof(Value));
         }
 
         #endregion

--- a/src/Libraries/CoreNodeModels/Input/DateTime.cs
+++ b/src/Libraries/CoreNodeModels/Input/DateTime.cs
@@ -27,16 +27,13 @@ namespace CoreNodeModels.Input
 
         /// <summary>
         /// Display text for the DateTime input. Bound TwoWay so WPF validation can run;
-        /// the setter is intentionally empty — commits go through UpdateModelValueCommand.
+        /// the setter intentionally discard the value — commits go through UpdateModelValueCommand.
         /// </summary>
         [JsonIgnore]
         public string ValueText
         {
-            get
-            { return Value.ToString(PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture); }
-            // Required for TwoWay binding / ValidateWithoutUpdate. Do not write the model here —
-            // DynamoTextBox commits via UpdateModelValueCommand; a real setter would double-commit.
-            set { }
+            get => Value.ToString(PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture);
+            set => _ = value;
         }
 
         public override System.DateTime Value

--- a/src/Libraries/CoreNodeModels/Input/DateTime.cs
+++ b/src/Libraries/CoreNodeModels/Input/DateTime.cs
@@ -25,6 +25,23 @@ namespace CoreNodeModels.Input
             ShouldDisplayPreviewCore = false;
         }
 
+        public string ValueText
+        {
+            get
+            { return Value.ToString(PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture); }
+            set { }
+        }
+
+        public override System.DateTime Value
+        {
+            get { return base.Value; }
+            set
+            {
+                base.Value = value;
+                RaisePropertyChanged(nameof(ValueText));
+            }
+        }
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -96,7 +113,8 @@ namespace CoreNodeModels.Input
 
         protected override bool UpdateValueCore(UpdateValueParams updateValueParams)
         {
-            if (updateValueParams.PropertyName == nameof(Value))
+            if (updateValueParams.PropertyName == nameof(Value)
+                || updateValueParams.PropertyName == nameof(ValueText))
             {
                 if (TryParseDateTime(updateValueParams.PropertyValue, out var parsed))
                 {

--- a/src/Libraries/CoreNodeModels/Input/DateTime.cs
+++ b/src/Libraries/CoreNodeModels/Input/DateTime.cs
@@ -1,10 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Globalization;
 using Dynamo.Configuration;
+using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
 using Newtonsoft.Json;
 using ProtoCore.AST.AssociativeAST;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Xml;
 
 namespace CoreNodeModels.Input
 {
@@ -92,12 +94,42 @@ namespace CoreNodeModels.Input
             };
         }
 
+        protected override bool UpdateValueCore(UpdateValueParams updateValueParams)
+        {
+            if (updateValueParams.PropertyName == nameof(Value))
+            {
+                if (TryParseDateTime(updateValueParams.PropertyValue, out var parsed))
+                {
+                    ClearErrorsAndWarnings();
+                    Value = System.DateTime.SpecifyKind(parsed, DateTimeKind.Utc);
+                }
+                return true;
+            }
+            return base.UpdateValueCore(updateValueParams);
+        }
+
+        internal static bool TryParseDateTime(string text, out System.DateTime parsed)
+        {
+            return System.DateTime.TryParseExact(
+                text,
+                PreferenceSettings.DefaultDateFormat,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out parsed);
+        }
+
         protected override System.DateTime DeserializeValue(string val)
         {
             System.DateTime result;
             result = System.DateTime.TryParseExact(val, PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out result) ?
                 result : PreferenceSettings.DynamoDefaultTime;
             return System.DateTime.SpecifyKind(result, DateTimeKind.Utc);
+        }
+
+        protected override void DeserializeCore(XmlElement nodeElement, SaveContext context)
+        {
+            base.DeserializeCore(nodeElement, context); 
+            ClearErrorsAndWarnings();
         }
 
         protected override string SerializeValue()

--- a/src/Libraries/CoreNodeModels/Input/DateTime.cs
+++ b/src/Libraries/CoreNodeModels/Input/DateTime.cs
@@ -25,10 +25,17 @@ namespace CoreNodeModels.Input
             ShouldDisplayPreviewCore = false;
         }
 
+        /// <summary>
+        /// Display text for the DateTime input. Bound TwoWay so WPF validation can run;
+        /// the setter is intentionally empty — commits go through UpdateModelValueCommand.
+        /// </summary>
+        [JsonIgnore]
         public string ValueText
         {
             get
             { return Value.ToString(PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture); }
+            // Required for TwoWay binding / ValidateWithoutUpdate. Do not write the model here —
+            // DynamoTextBox commits via UpdateModelValueCommand; a real setter would double-commit.
             set { }
         }
 
@@ -116,17 +123,27 @@ namespace CoreNodeModels.Input
             if (updateValueParams.PropertyName == nameof(Value)
                 || updateValueParams.PropertyName == nameof(ValueText))
             {
-                if (TryParseDateTime(updateValueParams.PropertyValue, out var parsed))
+                if (!TryParseDateTime(updateValueParams.PropertyValue, out var parsed))
                 {
-                    ClearErrorsAndWarnings();
-                    Value = System.DateTime.SpecifyKind(parsed, DateTimeKind.Utc);
+                    Error(Properties.Resources.DateTimeNodeInputInvalidFormat);
+                    return false;
                 }
+
+                ClearErrorsAndWarnings();
+                Value = System.DateTime.SpecifyKind(parsed, DateTimeKind.Utc);
                 return true;
             }
             return base.UpdateValueCore(updateValueParams);
         }
 
-        internal static bool TryParseDateTime(string text, out System.DateTime parsed)
+        /// <summary>
+        /// Parses <paramref name="text"/> using <see cref="PreferenceSettings.DefaultDateFormat"/>
+        /// and the invariant culture.
+        /// </summary>
+        /// <param name="text">The date/time string to parse.</param>
+        /// <param name="parsed">When this method returns, the parsed value if successful; otherwise default.</param>
+        /// <returns>Return <c>true</c> if <paramref name="text"/> matches the expected format; otherwise <c>false</c>.</returns>
+        public static bool TryParseDateTime(string text, out System.DateTime parsed)
         {
             return System.DateTime.TryParseExact(
                 text,
@@ -138,9 +155,7 @@ namespace CoreNodeModels.Input
 
         protected override System.DateTime DeserializeValue(string val)
         {
-            System.DateTime result;
-            result = System.DateTime.TryParseExact(val, PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out result) ?
-                result : PreferenceSettings.DynamoDefaultTime;
+            var result = TryParseDateTime(val, out var parsed) ? parsed : PreferenceSettings.DynamoDefaultTime;
             return System.DateTime.SpecifyKind(result, DateTimeKind.Utc);
         }
 

--- a/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
@@ -122,6 +122,7 @@ namespace CoreNodeModels.Input
                     return true; // UpdateValueCore handled.
                 case "Max":
                 case "MaxText":
+                    ClearErrorsAndWarnings();
                     Max = ConvertStringToDouble(value);
                     return true; // UpdateValueCore handled.
                 case "Value":
@@ -184,6 +185,9 @@ namespace CoreNodeModels.Input
                             break;
                     }
                 }
+
+                // Value's equality guard can skip notify, force UI to drop uncommitted invalid text
+                RaisePropertyChanged(nameof(Value));
 
                 break;
             }

--- a/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
@@ -117,6 +117,7 @@ namespace CoreNodeModels.Input
             {
                 case "Min":
                 case "MinText":
+                    ClearErrorsAndWarnings();
                     Min = ConvertStringToDouble(value);
                     return true; // UpdateValueCore handled.
                 case "Max":
@@ -125,10 +126,12 @@ namespace CoreNodeModels.Input
                     return true; // UpdateValueCore handled.
                 case "Value":
                 case "ValueText":
+                    ClearErrorsAndWarnings();
                     Value = ConvertStringToDouble(value);
                     return true; // UpdateValueCore handled.
                 case "Step":
                 case "StepText":
+                    ClearErrorsAndWarnings();
                     Step = ConvertStringToDouble(value);
                     return true;
             }
@@ -153,6 +156,8 @@ namespace CoreNodeModels.Input
         protected override void DeserializeCore(XmlElement element, SaveContext context)
         {
             base.DeserializeCore(element, context); //Base implementation must be called.
+
+            ClearErrorsAndWarnings();
 
             foreach (XmlNode subNode in element.ChildNodes)
             {

--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -291,7 +291,7 @@ namespace CoreNodeModels.Input
         }
 
         // If the value field in the slider has a number greater than
-        // long.Maxvalue (or MinValue), the value will be changed to long.MaxValue (or MinValue)
+        // long.MaxValue (or MinValue), the value will be changed to long.MaxValue (or MinValue)
         // The property setter is overridden here to update the UI, in case the value is changed. 
         public override long Value
         {
@@ -336,18 +336,6 @@ namespace CoreNodeModels.Input
             }
 
             return base.UpdateValueCore(updateValueParams);
-        }
-
-        private void UpdateNodeInfo(string value)
-        {
-            if (IsValueInt64(value))
-            {
-                ClearInfoMessages();
-            }
-            else
-            {
-                Info(Resources.IntegerSliderInfoMessage, true);
-            }
         }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)

--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -315,19 +315,22 @@ namespace CoreNodeModels.Input
             {
                 case nameof(Min):
                 case "MinText":
+                    ClearErrorsAndWarnings();
                     Min = ConvertStringToInt64(value);
                     return true; // UpdateValueCore handled.
                 case nameof(Max):
                 case "MaxText":
+                    ClearErrorsAndWarnings();
                     Max = ConvertStringToInt64(value);
                     return true; // UpdateValueCore handled.
                 case nameof(Value):
                 case "ValueText":
-                    UpdateNodeInfo(value);
+                    ClearErrorsAndWarnings();
                     Value = ConvertStringToInt64(value);
                     return true; // UpdateValueCore handled.
                 case nameof(Step):
                 case "StepText":
+                    ClearErrorsAndWarnings();
                     Step = ConvertStringToInt64(value);
                     return true;
             }
@@ -389,6 +392,8 @@ namespace CoreNodeModels.Input
         protected override void DeserializeCore(XmlElement element, SaveContext context)
         {
             base.DeserializeCore(element, context); //Base implementation must be called.
+
+            ClearErrorsAndWarnings();
 
             foreach (XmlNode subNode in element.ChildNodes)
             {

--- a/src/Libraries/CoreNodeModels/Input/SliderBase.cs
+++ b/src/Libraries/CoreNodeModels/Input/SliderBase.cs
@@ -160,23 +160,5 @@ namespace CoreNodeModels.Input
             }
             return result;
         }
-
-        /// <summary>
-        /// check if the value is within int64 range
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        protected static bool IsValueInt64(string value)
-        {
-            try
-            {
-                var result = Convert.ToInt64(value);
-                return true;
-            }
-            catch (OverflowException)
-            {
-                return false;
-            }
-        }
     }
 }

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -480,6 +480,15 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The input must match the Date Time format..
+        /// </summary>
+        public static string DateTimeNodeInputInvalidFormat {
+            get {
+                return ResourceManager.GetString("DateTimeNodeInputInvalidFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Validates the data type of an input and returns it.
         /// </summary>
         public static string DefineDataDescription {

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -480,7 +480,7 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The input must match the Date Time format..
+        ///   Looks up a localized string similar to The input must match the Date Time format and be a valid date/time..
         /// </summary>
         public static string DateTimeNodeInputInvalidFormat {
             get {
@@ -984,6 +984,15 @@ namespace CoreNodeModels.Properties {
         public static string IntegerSliderInfoMessage {
             get {
                 return ResourceManager.GetString("IntegerSliderInfoMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The input must be an integer..
+        /// </summary>
+        public static string IntegerSliderInputMustBeInteger {
+            get {
+                return ResourceManager.GetString("IntegerSliderInputMustBeInteger", resourceCulture);
             }
         }
         

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -584,6 +584,9 @@
   <data name="NumberNodeInputMustBeNumeric" xml:space="preserve">
     <value>The input must be numeric.</value>
   </data>
+  <data name="DateTimeNodeInputInvalidFormat" xml:space="preserve">
+    <value>The input must match the Date Time format.</value>
+  </data>    
   <data name="ColorPaletteDescription" xml:space="preserve">
     <value>Select a Color from the palette</value>
   </data>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -585,8 +585,11 @@
     <value>The input must be numeric.</value>
   </data>
   <data name="DateTimeNodeInputInvalidFormat" xml:space="preserve">
-    <value>The input must match the Date Time format.</value>
-  </data>    
+    <value>The input must match the Date Time format and be a valid date/time.</value>
+  </data>
+  <data name="IntegerSliderInputMustBeInteger" xml:space="preserve">
+    <value>The input must be an integer.</value>
+  </data>
   <data name="ColorPaletteDescription" xml:space="preserve">
     <value>Select a Color from the palette</value>
   </data>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -585,7 +585,10 @@
     <value>The input must be numeric.</value>
   </data>
   <data name="DateTimeNodeInputInvalidFormat" xml:space="preserve">
-    <value>The input must match the Date Time format.</value>
+    <value>The input must match the Date Time format and be a valid date/time.</value>
+  </data>
+  <data name="IntegerSliderInputMustBeInteger" xml:space="preserve">
+    <value>The input must be an integer.</value>
   </data>
   <data name="ColorPaletteDescription" xml:space="preserve">
     <value>Select a Color from the palette</value>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -584,6 +584,9 @@
   <data name="NumberNodeInputMustBeNumeric" xml:space="preserve">
     <value>The input must be numeric.</value>
   </data>
+  <data name="DateTimeNodeInputInvalidFormat" xml:space="preserve">
+    <value>The input must match the Date Time format.</value>
+  </data>
   <data name="ColorPaletteDescription" xml:space="preserve">
     <value>Select a Color from the palette</value>
   </data>

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DateTimeInputControl.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DateTimeInputControl.xaml
@@ -1,7 +1,6 @@
 ﻿<UserControl x:Class="CoreNodeModelsWpf.Controls.DateTimeInputControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:converters="clr-namespace:CoreNodeModelsWpf.Converters"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:nodes="clr-namespace:Dynamo.Nodes;assembly=DynamoCoreWpf"

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DateTimeInputControl.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DateTimeInputControl.xaml
@@ -4,13 +4,13 @@
              xmlns:converters="clr-namespace:CoreNodeModelsWpf.Converters"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:nodes="clr-namespace:Dynamo.Nodes;assembly=DynamoCoreWpf"
              xmlns:p="clr-namespace:Dynamo.Wpf.Properties"
              xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
              Width="Auto"
              mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
-            <converters:StringToDateTimeConverter x:Key="StringToDateTimeConverter" />
             <ResourceDictionary.MergedDictionaries>
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
@@ -18,7 +18,8 @@
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
-        <TextBox Height="29"
+        <nodes:DynamoTextBox x:Name="DateTimeTb"
+                 Height="29"
                  Margin="0,-5,0,0"
                  Padding="5,3"
                  HorizontalAlignment="Stretch"
@@ -30,11 +31,10 @@
                  CaretBrush="#6AC0E7"
                  FontSize="16px"
                  Foreground="#EEEEEE"
-                 Style="{StaticResource SZoomFadeTextBox}"
-                 Text="{Binding Value, Mode=TwoWay, Converter={StaticResource StringToDateTimeConverter}}">
-            <TextBox.ToolTip>
+                 Style="{StaticResource SZoomFadeTextBox}" >
+            <nodes:DynamoTextBox.ToolTip>
                 <ToolTip Content="{x:Static p:CoreNodeModelWpfResources.DateTimeInputToolTip}" Style="{StaticResource GenericToolTipLight}"/>
-            </TextBox.ToolTip>
-        </TextBox>
+            </nodes:DynamoTextBox.ToolTip>
+        </nodes:DynamoTextBox>
     </Grid>
 </UserControl>

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DateTimeInputControl.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DateTimeInputControl.xaml.cs
@@ -18,6 +18,8 @@ namespace CoreNodeModelsWpf.Controls
 
         private void DateTimeInputControl_Loaded(object sender, RoutedEventArgs e)
         {
+            Loaded -= DateTimeInputControl_Loaded;
+
             var binding = new System.Windows.Data.Binding(nameof(CoreNodeModels.Input.DateTime.ValueText))
             {
                 Mode = BindingMode.TwoWay,

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DateTimeInputControl.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DateTimeInputControl.xaml.cs
@@ -1,5 +1,7 @@
-﻿using System.Windows;
-using System.Windows.Forms;
+using CoreNodeModelsWpf.Converters;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
 using UserControl = System.Windows.Controls.UserControl;
 
 namespace CoreNodeModelsWpf.Controls
@@ -12,15 +14,25 @@ namespace CoreNodeModelsWpf.Controls
         public DateTimeInputControl()
         {
             InitializeComponent();
+            Loaded += DateTimeInputControl_Loaded;
         }
 
-        private void ButtonBase_OnClick(object sender, RoutedEventArgs e)
+        private void DateTimeInputControl_Loaded(object sender, RoutedEventArgs e)
         {
-            var picker = new DateTimePicker
+            var binding = new System.Windows.Data.Binding(nameof(CoreNodeModels.Input.DateTime.Value))
             {
-                Format = DateTimePickerFormat.Time,
-                ShowUpDown = true,
+                Mode = BindingMode.TwoWay,
+                Converter = new StringToDateTimeConverter(),
+                UpdateSourceTrigger = UpdateSourceTrigger.Explicit,
+                NotifyOnValidationError = false
             };
+            var rule = new DateTimeValidationRule
+            {
+                ValidationStep = ValidationStep.RawProposedValue
+            };
+            binding.ValidationRules.Add(rule);
+            DateTimeTb.BindToProperty(binding);
+            Validation.SetErrorTemplate(DateTimeTb, null);
         }
     }
 }

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DateTimeInputControl.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DateTimeInputControl.xaml.cs
@@ -1,4 +1,3 @@
-using CoreNodeModelsWpf.Converters;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -19,10 +18,9 @@ namespace CoreNodeModelsWpf.Controls
 
         private void DateTimeInputControl_Loaded(object sender, RoutedEventArgs e)
         {
-            var binding = new System.Windows.Data.Binding(nameof(CoreNodeModels.Input.DateTime.Value))
+            var binding = new System.Windows.Data.Binding(nameof(CoreNodeModels.Input.DateTime.ValueText))
             {
                 Mode = BindingMode.TwoWay,
-                Converter = new StringToDateTimeConverter(),
                 UpdateSourceTrigger = UpdateSourceTrigger.Explicit,
                 NotifyOnValidationError = false
             };

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
@@ -150,8 +150,7 @@
                     Background="{StaticResource MidGreyBrush}"
                     BorderBrush="#4A4A4A"
                     BorderThickness="1"
-                    Foreground="#bcbcbc"
-                    Text="{Binding MinText, Mode=OneWay, UpdateSourceTrigger=Explicit}" />
+                    Foreground="#bcbcbc" />
                 <nodes1:DynamoTextBox
                     x:Name="MaxTb"
                     Grid.Row="1"
@@ -162,8 +161,7 @@
                     Background="{StaticResource MidGreyBrush}"
                     BorderBrush="#4A4A4A"
                     BorderThickness="1"
-                    Foreground="#bcbcbc"
-                    Text="{Binding MaxText, Mode=OneWay, UpdateSourceTrigger=Explicit}" />
+                    Foreground="#bcbcbc" />
                 <nodes1:DynamoTextBox
                     x:Name="StepTb"
                     Grid.Row="2"
@@ -174,8 +172,7 @@
                     Background="{StaticResource MidGreyBrush}"
                     BorderBrush="#4A4A4A"
                     BorderThickness="1"
-                    Foreground="#bcbcbc"
-                    Text="{Binding StepText, Mode=OneWay, UpdateSourceTrigger=Explicit}" />
+                    Foreground="#bcbcbc" />
             </Grid>
 
         </Expander>
@@ -201,8 +198,7 @@
                 BorderThickness="1"
                 TextWrapping="NoWrap"
                 Foreground="{StaticResource PrimaryCharcoal100Brush}"
-                Opacity="1"
-                Text="{Binding ValueText, Mode=OneWay}">
+                Opacity="1">
                 <nodes1:DynamoTextBox.ToolTip>
                     <ToolTip Style="{StaticResource GenericToolTipLight}" Content="{Binding ValueText, UpdateSourceTrigger=PropertyChanged}"/>
                 </nodes1:DynamoTextBox.ToolTip>

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml.cs
@@ -34,18 +34,20 @@ namespace CoreNodeModelsWpf.Controls
 
         }
 
-        public void BindValidatedTextBoxes(Func<ValidationRule> ruleFactory)
+        /// <summary>
+        /// Installs the Text bindings for the value, min, max and step text boxes.
+        /// </summary>
+        /// <param name="ruleFactory">
+        /// Optional factory, invoked once per text box. It must return a <b>new</b> rule instance on
+        /// every call - a shared instance would let one field's validation state leak into another.
+        /// Pass <c>null</c> to bind without validation.
+        /// </param>
+        public void BindValidatedTextBoxes(Func<ValidationRule> ruleFactory = null)
         {
-            BindField(ValTb, "ValueText", ruleFactory());
-            BindField(MinTb, "MinText", ruleFactory());
-            BindField(MaxTb, "MaxText", ruleFactory());
-            BindField(StepTb, "StepText", ruleFactory());
-        }
-
-        private static ValidationRule CloneStep(ValidationRule template)
-        {
-            template.ValidationStep = ValidationStep.RawProposedValue;
-            return template;
+            BindField(ValTb, "ValueText", ruleFactory?.Invoke());
+            BindField(MinTb, "MinText", ruleFactory?.Invoke());
+            BindField(MaxTb, "MaxText", ruleFactory?.Invoke());
+            BindField(StepTb, "StepText", ruleFactory?.Invoke());
         }
 
         private static void BindField(DynamoTextBox textBox, string propertyName, ValidationRule validationRule)
@@ -57,8 +59,11 @@ namespace CoreNodeModelsWpf.Controls
                 NotifyOnValidationError = false
             };
 
-            validationRule.ValidationStep = ValidationStep.RawProposedValue;
-            binding.ValidationRules.Add(validationRule);
+            if (validationRule != null)
+            {
+                validationRule.ValidationStep = ValidationStep.RawProposedValue;
+                binding.ValidationRules.Add(validationRule);
+            }
 
             textBox.BindToProperty(binding);
             Validation.SetErrorTemplate(textBox, null);

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml.cs
@@ -1,11 +1,14 @@
-﻿using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
-using System.Windows.Input;
-using System.Windows.Shapes;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
+using Dynamo.Nodes;
 using Dynamo.UI;
 using Dynamo.ViewModels;
+using System;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
+using System.Windows.Input;
+using System.Windows.Shapes;
 
 namespace CoreNodeModelsWpf.Controls
 {
@@ -29,6 +32,36 @@ namespace CoreNodeModelsWpf.Controls
                 nodeUI.ViewModel.DynamoViewModel.OnRequestReturnFocusToView();
             };
 
+        }
+
+        public void BindValidatedTextBoxes(Func<ValidationRule> ruleFactory)
+        {
+            BindField(ValTb, "ValueText", ruleFactory());
+            BindField(MinTb, "MinText", ruleFactory());
+            BindField(MaxTb, "MaxText", ruleFactory());
+            BindField(StepTb, "StepText", ruleFactory());
+        }
+
+        private static ValidationRule CloneStep(ValidationRule template)
+        {
+            template.ValidationStep = ValidationStep.RawProposedValue;
+            return template;
+        }
+
+        private static void BindField(DynamoTextBox textBox, string propertyName, ValidationRule validationRule)
+        {
+            var binding = new Binding(propertyName)
+            {
+                Mode = BindingMode.TwoWay,
+                UpdateSourceTrigger = UpdateSourceTrigger.Explicit,
+                NotifyOnValidationError = false
+            };
+
+            validationRule.ValidationStep = ValidationStep.RawProposedValue;
+            binding.ValidationRules.Add(validationRule);
+
+            textBox.BindToProperty(binding);
+            Validation.SetErrorTemplate(textBox, null);
         }
 
         #region Event Handlers

--- a/src/Libraries/CoreNodeModelsWpf/InputValidationRules.cs
+++ b/src/Libraries/CoreNodeModelsWpf/InputValidationRules.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Windows.Controls;
+using CoreNodeModels.Properties;
+using Dynamo.Configuration;
+
+namespace CoreNodeModelsWpf
+{
+    /// <summary>
+    /// Accepts invariant numeric doubles/longs.
+    /// </summary>
+    public class NumericValidationRule : ValidationRule
+    {
+        public override ValidationResult Validate(object value, CultureInfo cultureInfo)
+        {
+            var text = value as string;
+            if (IsNumeric(text)) return ValidationResult.ValidResult;
+
+            return new ValidationResult(false, Resources.NumberNodeInputMustBeNumeric);
+        }
+
+        internal static bool IsNumeric(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return false;
+
+            return double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out _) || long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _);
+        }
+    }
+
+    /// <summary>
+    /// Accepts Int64 integers only. Non-numeric and overflow both fail (Error bubble via DynamoTextBox).
+    /// </summary>
+    public class Integer64ValidationRule : ValidationRule
+    {
+        public override ValidationResult Validate(object value, CultureInfo cultureInfo)
+        {
+            var text = value as string;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return new ValidationResult(false, Resources.NumberNodeInputMustBeNumeric);
+            }
+
+            try
+            {
+                Convert.ToInt64(text, CultureInfo.InvariantCulture);
+                return ValidationResult.ValidResult;
+            }
+            catch (FormatException)
+            {
+                return new ValidationResult(false, Resources.NumberNodeInputMustBeNumeric);
+            }
+            catch (OverflowException)
+            {
+                return new ValidationResult(false, Resources.IntegerSliderInfoMessage);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Accepts PreferenceSettings.DefaultDateFormat only.
+    /// </summary>
+    public class DateTimeValidationRule : ValidationRule
+    {
+        public override ValidationResult Validate(object value, CultureInfo cultureInfo)
+        {
+            var text = value as string;
+            if (DateTime.TryParseExact(text, PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out _))
+            {
+                return ValidationResult.ValidResult;
+            }
+
+            return new ValidationResult(false, Resources.DateTimeNodeInputInvalidFormat);
+        }
+    }
+}

--- a/src/Libraries/CoreNodeModelsWpf/InputValidationRules.cs
+++ b/src/Libraries/CoreNodeModelsWpf/InputValidationRules.cs
@@ -48,7 +48,7 @@ namespace CoreNodeModelsWpf
             }
             catch (FormatException)
             {
-                return new ValidationResult(false, Resources.NumberNodeInputMustBeNumeric);
+                return new ValidationResult(false, Resources.IntegerSliderInputMustBeInteger);
             }
             catch (OverflowException)
             {

--- a/src/Libraries/CoreNodeModelsWpf/InputValidationRules.cs
+++ b/src/Libraries/CoreNodeModelsWpf/InputValidationRules.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Diagnostics;
 using System.Globalization;
 using System.Windows.Controls;
 using CoreNodeModels.Properties;
-using Dynamo.Configuration;
 
 namespace CoreNodeModelsWpf
 {
@@ -33,6 +31,8 @@ namespace CoreNodeModelsWpf
     /// </summary>
     public class Integer64ValidationRule : ValidationRule
     {
+        private const NumberStyles IntegerStyles = NumberStyles.Integer | NumberStyles.AllowThousands;
+
         public override ValidationResult Validate(object value, CultureInfo cultureInfo)
         {
             var text = value as string;
@@ -43,7 +43,7 @@ namespace CoreNodeModelsWpf
 
             try
             {
-                Convert.ToInt64(text, CultureInfo.InvariantCulture);
+                long.Parse(text, IntegerStyles, CultureInfo.InvariantCulture);
                 return ValidationResult.ValidResult;
             }
             catch (FormatException)
@@ -65,7 +65,7 @@ namespace CoreNodeModelsWpf
         public override ValidationResult Validate(object value, CultureInfo cultureInfo)
         {
             var text = value as string;
-            if (DateTime.TryParseExact(text, PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out _))
+            if (CoreNodeModels.Input.DateTime.TryParseDateTime(text, out _))
             {
                 return ValidationResult.ValidResult;
             }

--- a/src/Libraries/CoreNodeModelsWpf/InputValidationRules.cs
+++ b/src/Libraries/CoreNodeModelsWpf/InputValidationRules.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Globalization;
+using System.Numerics;
 using System.Windows.Controls;
 using CoreNodeModels.Properties;
 
@@ -41,19 +41,14 @@ namespace CoreNodeModelsWpf
                 return new ValidationResult(false, Resources.NumberNodeInputMustBeNumeric);
             }
 
-            try
+            if (long.TryParse(text, IntegerStyles, CultureInfo.InvariantCulture, out _))
             {
-                long.Parse(text, IntegerStyles, CultureInfo.InvariantCulture);
                 return ValidationResult.ValidResult;
             }
-            catch (FormatException)
-            {
-                return new ValidationResult(false, Resources.IntegerSliderInputMustBeInteger);
-            }
-            catch (OverflowException)
-            {
-                return new ValidationResult(false, Resources.IntegerSliderInfoMessage);
-            }
+
+            return BigInteger.TryParse(text, IntegerStyles, CultureInfo.InvariantCulture, out _)
+                ? new ValidationResult(false, Resources.IntegerSliderInfoMessage)
+                : new ValidationResult(false, Resources.IntegerSliderInputMustBeInteger);
         }
     }
 

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
@@ -2,45 +2,13 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
-using System.Windows.Media;
 using CoreNodeModels.Input;
-using CoreNodeModels.Properties;
 using Dynamo.Controls;
 using Dynamo.Nodes;
 using Dynamo.Wpf;
 
 namespace CoreNodeModelsWpf.Nodes
-{
-    internal class NumericValidationRule : ValidationRule
-    {
-        //if the string can be parsed to a common numeric type return true
-        internal bool validateInput(string value)
-        {
-            double doubleVal;
-            long longVal;
-
-            if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out doubleVal)
-                || long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out longVal))
-            {
-                return true;
-            }
-            return false;
-        }
-
-        public override ValidationResult Validate(object value, CultureInfo cultureInfo)
-        {
-
-            if (!validateInput(value as string))
-            {
-                return new ValidationResult(false, Resources.NumberNodeInputMustBeNumeric);
-            }
-            else
-            {
-                return new ValidationResult(true, null);
-            }
-        }
-    }
-   
+{   
     public class DoubleInputNodeViewCustomization : INodeViewCustomization<DoubleInput>
     {
         public void CustomizeView(DoubleInput nodeModel, NodeView nodeView)
@@ -67,8 +35,9 @@ namespace CoreNodeModelsWpf.Nodes
                 Source = nodeModel,
                 UpdateSourceTrigger = UpdateSourceTrigger.Explicit
             };
+
             var numericalValidation = new NumericValidationRule();
-            numericalValidation.ValidationStep = ValidationStep.ConvertedProposedValue;
+            numericalValidation.ValidationStep = ValidationStep.RawProposedValue;
             textToValueBinding.ValidationRules.Add(numericalValidation);
             tb.BindToProperty(textToValueBinding);
             Validation.SetErrorTemplate(tb, null);

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleSlider.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleSlider.cs
@@ -14,6 +14,8 @@ namespace CoreNodeModelsWpf.NodeViewCustomizations
                 DataContext = new SliderViewModel<double>(model)
             };
 
+            slider.BindValidatedTextBoxes(() => new NumericValidationRule());
+
             nodeView.inputGrid.Children.Add(slider);
         }
 

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/IntegerSlider.cs
@@ -29,6 +29,8 @@ namespace CoreNodeModelsWpf.NodeViewCustomizations
                 DataContext = new SliderViewModel<long>(model)
             };
 
+            slider.BindValidatedTextBoxes(() => new Integer64ValidationRule());
+
             nodeView.inputGrid.Children.Add(slider);
         }
 

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/IntegerSlider.cs
@@ -14,6 +14,8 @@ namespace CoreNodeModelsWpf.NodeViewCustomizations
                 DataContext = new SliderViewModel<int>(model)
             };
 
+            slider.BindValidatedTextBoxes();
+
             nodeView.inputGrid.Children.Add(slider);
         }
 

--- a/src/Libraries/CoreNodeModelsWpf/SliderViewModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/SliderViewModel.cs
@@ -20,21 +20,25 @@ namespace CoreNodeModelsWpf
         public string MaxText
         {
             get { return SliderBase<T>.ConvertNumberToString(model.Max); }
+            set { }
         }
 
         public string MinText
         {
             get { return SliderBase<T>.ConvertNumberToString(model.Min); }
+            set { }
         }
 
         public string StepText
         {
             get { return SliderBase<T>.ConvertNumberToString(model.Step); }
+            set { }
         }
 
         public string ValueText
         {
             get { return SliderBase<T>.ConvertNumberToString(model.Value); }
+            set { }
         }
 
         public T Max

--- a/src/Libraries/CoreNodeModelsWpf/SliderViewModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/SliderViewModel.cs
@@ -17,6 +17,9 @@ namespace CoreNodeModelsWpf
     {
         private SliderBase<T> model;
 
+        // These text setters are intentionally empty. Bindings are TwoWay so
+        // ValidateWithoutUpdate() can run; DynamoTextBox writes the model via
+        // UpdateModelValueCommand. Implementing these would double-commit on every edit.
         public string MaxText
         {
             get { return SliderBase<T>.ConvertNumberToString(model.Max); }

--- a/src/Libraries/CoreNodeModelsWpf/SliderViewModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/SliderViewModel.cs
@@ -17,31 +17,31 @@ namespace CoreNodeModelsWpf
     {
         private SliderBase<T> model;
 
-        // These text setters are intentionally empty. Bindings are TwoWay so
+        // These text setters intentionally discard the value. Bindings are TwoWay so
         // ValidateWithoutUpdate() can run; DynamoTextBox writes the model via
         // UpdateModelValueCommand. Implementing these would double-commit on every edit.
         public string MaxText
         {
-            get { return SliderBase<T>.ConvertNumberToString(model.Max); }
-            set { }
+            get => SliderBase<T>.ConvertNumberToString(model.Max);
+            set => _ = value;
         }
 
         public string MinText
         {
-            get { return SliderBase<T>.ConvertNumberToString(model.Min); }
-            set { }
+            get => SliderBase<T>.ConvertNumberToString(model.Min);
+            set => _ = value;
         }
 
         public string StepText
         {
-            get { return SliderBase<T>.ConvertNumberToString(model.Step); }
-            set { }
+            get => SliderBase<T>.ConvertNumberToString(model.Step);
+            set => _ = value;
         }
 
         public string ValueText
         {
-            get { return SliderBase<T>.ConvertNumberToString(model.Value); }
-            set { }
+            get => SliderBase<T>.ConvertNumberToString(model.Value);
+            set => _ = value;
         }
 
         public T Max

--- a/test/DynamoCoreWpf3Tests/InputValidationErrorBubbleTests.cs
+++ b/test/DynamoCoreWpf3Tests/InputValidationErrorBubbleTests.cs
@@ -1,0 +1,296 @@
+using CoreNodeModels.Input;
+using CoreNodeModels.Properties;
+using CoreNodeModelsWpf.Controls;
+using Dynamo.Configuration;
+using Dynamo.Controls;
+using Dynamo.Graph.Nodes;
+using Dynamo.Models;
+using Dynamo.Nodes;
+using Dynamo.Utilities;
+using DynamoCoreWpfTests.Utility;
+using NUnit.Framework;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Controls;
+using System.Windows.Data;
+using DateTimeNode = CoreNodeModels.Input.DateTime;
+
+namespace DynamoCoreWpfTests
+{
+    public class InputValidationErrorBubbleTests : DynamoTestUIBase
+    {
+        protected override void GetLibrariesToPreload(System.Collections.Generic.List<string> libraries)
+        {
+            libraries.Add("VMDataBridge.dll");
+            libraries.Add("DSCoreNodes.dll");
+            base.GetLibrariesToPreload(libraries);
+        }
+
+        private static DynamoTextBox ValueBox(NodeView nodeView)
+        {
+            // Number / DateTime: single box. Sliders: ValTb.
+            var named = nodeView.ChildrenOfType<DynamoTextBox>()
+                .FirstOrDefault(tb => tb.Name == "ValTb" || tb.Name == "DateTimeTb");
+            return named ?? nodeView.inputGrid.ChildrenOfType<DynamoTextBox>().First();
+        }
+
+        private static int ErrorCount(NodeModel node) => node.NodeInfos.Count(i => i.State == ElementState.Error);
+
+        private NodeView AddAndGetView(NodeModel node)
+        {
+            Model.AddNodeToCurrentWorkspace(node, true);
+            DispatcherUtil.DoEventsLoop(() => View.NodeViewsInFirstWorkspace().Any(nv => nv.ViewModel.NodeLogic.GUID == node.GUID), timeoutSeconds: 5);
+            return NodeViewWithGuid(node.GUID.ToString());
+        }
+
+        private void CommitText(DynamoTextBox box, string text)
+        {
+            box.Text = text; // triggers DynamoTextBox.UpdateDataSource(recordForUndo: true)
+            DispatcherUtil.DoEvents();
+        }
+
+        #region Number (DoubleInput)
+
+        [Test]
+        public void WhenNumberGetsInvalidInputThenKeepsValueShowsErrorKeepsTextAndSkipsUndo()
+        {
+            var node = new DoubleInput();
+            var view = AddAndGetView(node);
+            var box = ValueBox(view);
+
+            CommitText(box, "1");
+            CommitText(box, "2");
+            CommitText(box, "K");
+
+            Assert.AreEqual("2", node.Value);
+            Assert.AreEqual("K", box.Text);
+            Assert.IsTrue(node.IsInErrorState);
+            Assert.AreEqual(1, ErrorCount(node));
+            Assert.AreEqual(Resources.NumberNodeInputMustBeNumeric,
+                node.NodeInfos.Single(i => i.State == ElementState.Error).Message);
+
+            Model.CurrentWorkspace.Undo();
+            DispatcherUtil.DoEvents();
+
+            // Invalid "K" was not recorded — undo reverses 1→2, not 2→K.
+            Assert.AreEqual("1", node.Value);
+            Assert.IsFalse(node.IsInErrorState);
+            Assert.AreEqual(0, ErrorCount(node));
+            Assert.AreEqual("1.000", box.Text);
+        }
+
+        [Test]
+        public void WhenNumberGetsValidInputAfterErrorThenClearsBubbleAndUpdatesValue()
+        {
+            var node = new DoubleInput();
+            var view = AddAndGetView(node);
+            var box = ValueBox(view);
+
+            CommitText(box, "5");
+            CommitText(box, "K");
+            Assert.IsTrue(node.IsInErrorState);
+
+            CommitText(box, "7");
+
+            Assert.AreEqual("7", node.Value);
+            Assert.AreEqual("7.000", box.Text);
+            Assert.IsFalse(node.IsInErrorState);
+            Assert.AreEqual(0, ErrorCount(node));
+        }
+
+        [Test]
+        public void WhenNumberSwapsInvalidInputsThenShowsOnlyLatestError()
+         {
+            var node = new DoubleInput();
+            var view = AddAndGetView(node);
+            var box = ValueBox(view);
+
+            CommitText(box, "1");
+            CommitText(box, "K");
+            CommitText(box, "m");
+
+            Assert.AreEqual("1", node.Value);
+            Assert.AreEqual("m", box.Text);
+            Assert.AreEqual(1, ErrorCount(node));
+            Assert.AreEqual(Resources.NumberNodeInputMustBeNumeric,
+                node.NodeInfos.Single(i => i.State == ElementState.Error).Message);
+        }
+
+        [Test]
+        public void WhenNumberUndoesAfterErrorOnSameValueThenClearsBubble()
+        {
+            // Repro: Value setter early-returns when restored string equals current;
+            // DeserializeCore must clear Infos unconditionally.
+            var node = new DoubleInput();
+            AddAndGetView(node);
+
+            Model.ExecuteCommand(new DynamoModel.UpdateModelValueCommand(
+                Model.CurrentWorkspace.Guid, node.GUID, nameof(DoubleInput.Value), "5"));
+            Model.ExecuteCommand(new DynamoModel.UpdateModelValueCommand(
+                Model.CurrentWorkspace.Guid, node.GUID, nameof(DoubleInput.Value), "5"));
+
+            var view = NodeViewWithGuid(node.GUID.ToString());
+            CommitText(ValueBox(view), "K");
+            Assert.IsTrue(node.IsInErrorState);
+
+            Model.CurrentWorkspace.Undo();
+            DispatcherUtil.DoEvents();
+
+            Assert.AreEqual("5", node.Value);
+            Assert.IsFalse(node.IsInErrorState);
+            Assert.AreEqual(0, ErrorCount(node));
+        }
+
+        #endregion
+
+        #region Integer Slider 64-bit
+
+        [Test]
+        public void WhenIntegerSlider64GetsInvalidInputThenKeepsValueShowsErrorAndSkipsUndo()
+        {
+            var node = new IntegerSlider64Bit();
+            var view = AddAndGetView(node);
+            var box = ValueBox(view);
+
+            CommitText(box, "1");
+            CommitText(box, "2");
+            CommitText(box, "K");
+
+            Assert.AreEqual(2L, node.Value);
+            Assert.AreEqual("K", box.Text);
+            Assert.IsTrue(node.IsInErrorState);
+            Assert.AreEqual(1, ErrorCount(node));
+
+            Model.CurrentWorkspace.Undo();
+            DispatcherUtil.DoEvents();
+
+            Assert.AreEqual(1L, node.Value);
+            Assert.IsFalse(node.IsInErrorState);
+            Assert.AreEqual("1", box.Text);
+        }
+
+        [Test]
+        public void WhenIntegerSlider64GetsThousandsGroupedInputThenAcceptsValue()
+        {
+            var node = new IntegerSlider64Bit { Max = 10000 };
+            var view = AddAndGetView(node);
+            var box = ValueBox(view);
+
+            CommitText(box, "2,500");
+
+            Assert.AreEqual(2500L, node.Value);
+            Assert.IsFalse(node.IsInErrorState);
+            Assert.AreEqual(0, ErrorCount(node));
+        }
+
+        [Test]
+        public void WhenIntegerSlider64OverflowsThenShowsRangeErrorNotStacked()
+        {
+            var node = new IntegerSlider64Bit();
+            var view = AddAndGetView(node);
+            var box = ValueBox(view);
+
+            CommitText(box, "1");
+            CommitText(box, "m");
+            Assert.AreEqual(Resources.IntegerSliderInputMustBeInteger,
+                node.NodeInfos.Single(i => i.State == ElementState.Error).Message);
+
+            CommitText(box, "9223372036854775808"); // long.MaxValue + 1
+
+            Assert.AreEqual(1L, node.Value);
+            Assert.AreEqual(1, ErrorCount(node));
+            Assert.AreEqual(Resources.IntegerSliderInfoMessage,
+                node.NodeInfos.Single(i => i.State == ElementState.Error).Message);
+        }
+
+        #endregion
+
+        #region Double Slider
+
+        [Test]
+        public void WhenDoubleSliderGetsInvalidInputThenKeepsValueShowsErrorAndClearsOnValid()
+        {
+            var node = new CoreNodeModels.Input.DoubleSlider();
+            var view = AddAndGetView(node);
+            var box = ValueBox(view);
+
+            CommitText(box, "3.5");
+            CommitText(box, "abc");
+
+            Assert.AreEqual(3.5, node.Value, 1e-9);
+            Assert.AreEqual("abc", box.Text);
+            Assert.IsTrue(node.IsInErrorState);
+
+            CommitText(box, "4.25");
+
+            Assert.AreEqual(4.25, node.Value, 1e-9);
+            Assert.IsFalse(node.IsInErrorState);
+            Assert.AreEqual(0, ErrorCount(node));
+        }
+
+        #endregion
+
+        #region DateTime
+
+        [Test]
+        public void WhenDateTimeGetsInvalidInputThenKeepsValueShowsErrorAndClearsOnUndo()
+        {
+            var node = new DateTimeNode
+            {
+                // DefaultDateFormat carries only minutes, so we need a value that round-trips
+                // exactly through serialize/undo. UtcNow would lose seconds and ticks.
+                Value = new System.DateTime(2015, 5, 30, 5, 30, 0, System.DateTimeKind.Utc)
+            };
+            var original = node.Value;
+            var view = AddAndGetView(node);
+            var box = ValueBox(view);
+
+            var valid = new System.DateTime(2020, 12, 8, 12, 0, 0, System.DateTimeKind.Utc);
+            CommitText(box, valid.ToString(PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture));
+            Assert.AreEqual(valid, node.Value);
+
+            CommitText(box, "not-a-date");
+
+            Assert.AreEqual(valid, node.Value);
+            Assert.AreEqual("not-a-date", box.Text);
+            Assert.IsTrue(node.IsInErrorState);
+            Assert.AreEqual(Resources.DateTimeNodeInputInvalidFormat,
+                node.NodeInfos.Single(i => i.State == ElementState.Error).Message);
+
+            Model.CurrentWorkspace.Undo();
+            DispatcherUtil.DoEvents();
+
+            Assert.AreEqual(original, node.Value);
+            Assert.IsFalse(node.IsInErrorState);
+            Assert.AreEqual(0, ErrorCount(node));
+        }
+
+        #endregion
+
+        #region Legacy IntegerSlider (32-bit) binding regression
+
+        [Test]
+        public void WhenIntegerSliderCustomizedThenTextBoxesAreBoundAndPopulated()
+        {
+            var node = new CoreNodeModels.Input.IntegerSlider64Bit { Value = 41, Min = 0, Max = 100, Step = 1 };
+            var view = AddAndGetView(node);
+            var slider = view.ChildrenOfType<DynamoSlider>().First();
+
+            foreach (var name in new[] { "ValTb", "MinTb", "MaxTb", "StepTb" })
+            {
+                var tb = (DynamoTextBox)slider.FindName(name);
+                Assert.IsNotNull(tb, $"{name} missing");
+                Assert.IsNotNull(
+                    BindingOperations.GetBindingExpression(tb, TextBox.TextProperty),
+                    $"{name} has no Text binding");
+            }
+
+            Assert.AreEqual("41", ((DynamoTextBox)slider.FindName("ValTb")).Text);
+            Assert.AreEqual("0", ((DynamoTextBox)slider.FindName("MinTb")).Text);
+            Assert.AreEqual("100", ((DynamoTextBox)slider.FindName("MaxTb")).Text);
+            Assert.AreEqual("1", ((DynamoTextBox)slider.FindName("StepTb")).Text);
+        }
+
+        #endregion
+    }
+}

--- a/test/DynamoCoreWpf3Tests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpf3Tests/NodeViewCustomizationTests.cs
@@ -1,13 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Windows;
-using System.Windows.Controls;
 using CoreNodeModels.Input;
-using CoreNodeModelsWpf.Controls;
 using CoreNodeModelsWpf;
+using CoreNodeModelsWpf.Controls;
+using Dynamo.Configuration;
 using Dynamo.Controls;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.CustomNodes;
@@ -17,6 +11,13 @@ using Dynamo.Nodes;
 using Dynamo.Utilities;
 using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
 
 namespace DynamoCoreWpfTests
 {
@@ -502,6 +503,66 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(NodeModelAssemblyLoader.ContainsNodeViewCustomizationType(dyncorewpfAssem));
             //this assembly contains some builtin nodeviewcustomizations and this methd should return true.
             Assert.IsFalse(NodeModelAssemblyLoader.ContainsNodeViewCustomizationType(dyncoreAssem));
+        }
+
+
+
+
+
+        [Test]
+        [Category("UnitTests")]
+        public static void WhenInteger64InputIsNonIntegerThenValidationFails()
+        {
+            var rule = new Integer64ValidationRule();
+            Assert.IsFalse(rule.Validate("m", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(rule.Validate("1.5", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(rule.Validate("", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(rule.Validate(" ", CultureInfo.InvariantCulture).IsValid);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public static void WhenInteger64InputIsValidOrGroupedThenValidationPasses()
+        {
+            var rule = new Integer64ValidationRule();
+            Assert.IsTrue(rule.Validate("0", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsTrue(rule.Validate("2500", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsTrue(rule.Validate("2,500", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsTrue(rule.Validate("-2,500", CultureInfo.InvariantCulture).IsValid);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public static void WhenInteger64InputOverflowsThenValidationFailsWithRangeMessage()
+        {
+            var rule = new Integer64ValidationRule();
+            var result = rule.Validate("9223372036854775808", CultureInfo.InvariantCulture); // long.MaxValue + 1
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(CoreNodeModels.Properties.Resources.IntegerSliderInfoMessage, result.ErrorContent);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public static void WhenDateTimeInputMatchesDefaultFormatThenValidationPasses()
+        {
+            var rule = new DateTimeValidationRule();
+            var text = new System.DateTime(2000, 1, 1, 12, 0, 0)
+                .ToString(PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture);
+            Assert.IsTrue(rule.Validate(text, CultureInfo.InvariantCulture).IsValid);
+            Assert.IsTrue(CoreNodeModels.Input.DateTime.TryParseDateTime(text, out _));
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public static void WhenDateTimeInputIsInvalidThenValidationFails()
+        {
+            var rule = new DateTimeValidationRule();
+            var result = rule.Validate("not-a-date", CultureInfo.InvariantCulture);
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(
+                CoreNodeModels.Properties.Resources.DateTimeNodeInputInvalidFormat,
+                result.ErrorContent);
+            Assert.IsFalse(CoreNodeModels.Input.DateTime.TryParseDateTime("not-a-date", out _));
         }
     }
 

--- a/test/DynamoCoreWpf3Tests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpf3Tests/NodeViewCustomizationTests.cs
@@ -7,7 +7,7 @@ using System.Windows;
 using System.Windows.Controls;
 using CoreNodeModels.Input;
 using CoreNodeModelsWpf.Controls;
-using CoreNodeModelsWpf.Nodes;
+using CoreNodeModelsWpf;
 using Dynamo.Controls;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.CustomNodes;


### PR DESCRIPTION

### Purpose

This PR aims to address [DYN-4783](https://jira.autodesk.com/browse/DYN-4783) (Do not allow non integer input in Integer Slider node).

The original ticket asked to reject non-integer input on the Integer Slider. After discussion with the team, we aligned invalid-input handling across the related input nodes (Number, Number Slider, Integer Slider, and DateTime) so they share the same behavior as the Number node.

When the user types an invalid value:

- an error bubble is shown
- the last valid model value is kept
- the invalid text remains visible in the text box
- no undo step is recorded for the failed commit

A subsequent valid commit clears the Error bubble and updates the value. Undo after a valid -> invalid sequence restores the previous valid value and clears the Error bubble. Replacing one invalid input with another shows only the latest error message.

Key changes:

- shared WPF validation rules for numeric, Int64, and DateTime input
- sliders and `DateTime` bind through `DynamoTextBox` with explicit `TwoWay` bindings and validation
- error state is cleared on successful `UpdateValueCore` and on deserialize/undo
- regression tests covering the shared invalid-input and undo behavior

This is 4.3 work and is not a priority for review.

<img width="960" height="540" alt="DYN-4783-Fix" src="https://github.com/user-attachments/assets/9040c4c4-d697-41c7-a51d-e7c6d6e57b70" />


<img width="242" height="782" alt="error bubles" src="https://github.com/user-attachments/assets/6ed106b0-aa3a-4a75-bbd9-39cc2d4068ba" />


### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Number, Number Slider, Integer Slider, and DateTime now show an error and keep the last valid value when invalid input is typed.

### Reviewers

@DynamoDS/eidos
@jasonstratton
@johnpierson

### FYIs

@dnenov 
@jnealb
