### PR TITLE
DYN-9321: Prevent adding CBN into collapsed annotation on double-click

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1319,14 +1319,18 @@ namespace Dynamo.ViewModels
 
             var model = DynamoViewModel.Model;
 
-            // Create and add code node block
+            // Create the code block node
             var newNode = new CodeBlockNodeModel(model.LibraryServices);
             var cmd = new DynamoModel.CreateNodeCommand(newNode, position.X, position.Y, false, true);
             DynamoViewModel.ExecuteCommand(cmd);
 
-            var updated = annotation.Nodes.ToList();
-            updated.Add(newNode);
-            annotation.Nodes = updated;
+            // Only add the node to the annotation when the annotation is expanded
+            if (annotation.IsExpanded)
+            {
+                var updated = annotation.Nodes.ToList();
+                updated.Add(newNode);
+                annotation.Nodes = updated;
+            }
         }
 
         private static bool IsInRegion(Rect2D region, ILocatable locatable, bool fullyEnclosed)

--- a/test/DynamoCoreWpfTests/AnnotationViewTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewTests.cs
@@ -186,5 +186,41 @@ namespace DynamoCoreWpfTests
             // Assert
             Assert.AreEqual(3, group1.Nodes.Count(), "Expected group to have 3 nodes after double click.");
         }
+
+        [Test]
+        public void DoubleClickOnCollapsedGroupAddsNodeToWorkspaceButNotToGroup()
+        {
+            // Arrange
+            Open(@"core\annotationViewModelTests\groupsTestFile.dyn");
+
+            var groupGuid = new Guid("8324afb7-2d77-4a75-aa5e-f10e59964c2b");
+            var ws = this.Model.CurrentWorkspace;
+            var groupModel = ws.Annotations.FirstOrDefault(a => a.GUID == groupGuid);
+            Assert.IsNotNull(groupModel, "Expected annotation group present in workspace.");
+
+            var annotationView = NodeViewWithGuid(groupGuid.ToString());
+            Assert.IsNotNull(annotationView, "Expected annotation view to exist.");
+
+            // Ensure the annotation is collapsed
+            annotationView.ViewModel.IsExpanded = false;
+            Assert.IsFalse(annotationView.ViewModel.IsExpanded, "Test precondition: annotation should be collapsed.");
+
+            var initialWorkspaceNodeCount = ws.Nodes.Count();
+            var initialGroupNodeCount = groupModel.Nodes.Count();
+
+            var workspaceView = View.WorkspaceTabs.ChildrenOfType<WorkspaceView>().First();
+            var workspaceViewModel = workspaceView.ViewModel;
+
+            // Click position inside the group's model area (below the text)
+            var clickPosition = new Point(groupModel.X + 1, groupModel.Y + groupModel.TextBlockHeight + 1);
+
+            // Act
+            workspaceViewModel.HandleAnnotationDoubleClick(clickPosition, groupModel);
+            DispatcherUtil.DoEvents();
+
+            // Assert
+            Assert.AreEqual(initialWorkspaceNodeCount + 1, ws.Nodes.Count(), "A new node should be created in the workspace.");
+            Assert.AreEqual(initialGroupNodeCount, groupModel.Nodes.Count(), "Collapsed group should NOT receive the new node.");
+        }
     }
 }


### PR DESCRIPTION
### Purpose

This is a small PR to address [DYN-9321](https://autodesk.atlassian.net/browse/DYN-9321) 

Fixes a bug where double-clicking a collapsed annotation would create a visible `CodeBlock` node that nevertheless became part of the collapsed group's model (causing layout/visibility/boundary glitches).

Now double-clicking an annotation still creates a `CodeBlock` node, but the node is only added to the annotation when the annotation is expanded (aligned with drag-to-group behavior).

Changes
- `WorkspaceViewModel.HandleAnnotationDoubleClick` ensure newly created node is added to the annotation only when annotation.IsExpanded
 - regression test
 
Before:
 
<img width="960" height="540" alt="DYN-9321-Before__" src="https://github.com/user-attachments/assets/9f1c25e4-027c-477c-ba9f-a6cd72f5cb57" />

After:

<img width="960" height="540" alt="DYN-9321-After__" src="https://github.com/user-attachments/assets/09a42b7d-3173-47c6-8361-037c6a6c52d4" />


### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Prevent newly created Code Block nodes from being added into collapsed groups when double-clicking the group. 

### Reviewers

@DynamoDS/eidos
@jasonstratton
@johnpierson

### FYIs

@dnenov 
