### PR TITLE
DYN-10768: Bump DynamoVisualProgramming.AutodeskAssistant to [0.3.7]

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2243,7 +2243,7 @@
     different DynamoVisualProgramming.* API. Bump in lockstep with the AA release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.AutodeskAssistant" Version="[0.3.6]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.AutodeskAssistant" Version="[0.3.7]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
     The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_AutodeskAssistant)\bin IS

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2243,7 +2243,7 @@
     different DynamoVisualProgramming.* API. Bump in lockstep with the AA release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.AutodeskAssistant" Version="[0.3.5]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.AutodeskAssistant" Version="[0.3.6]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
     The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_AutodeskAssistant)\bin IS


### PR DESCRIPTION
### Purpose

Primary ticket for this PR: **DYN-10768** (Autodesk Assistant panel now hides/shows on toggle instead of being destroyed and recreated, preserving the conversation and removing the destroy/recreate churn that stressed the native ADP SDK).

Consumes the **0.3.7** release of the Autodesk Assistant built-in package (`DynamoVisualProgramming.AutodeskAssistant`), now published to nuget.org. Bumps the exact-version bracket pin in `DynamoCoreWpf.csproj` from `[0.3.6]` -> `[0.3.7]`.

`0.3.7` folds in fixes for the following, in addition to the `0.3.6` dependency trim already covered by this branch:

| Ticket | Summary |
| --- | --- |
| DYN-10768 | Autodesk Assistant panel now hides/shows on toggle instead of being destroyed and recreated, preserving the conversation and removing the destroy/recreate churn that stressed the native ADP SDK. |
| DYN-10716 | Autodesk Assistant toolbar/menu entry point is disabled when the IDSDK is not present, instead of surfacing four sequential native error dialogs. |
| DYN-10767 | Fixes a `DynamoSandbox` crash (access violation in `coreclr.dll`) caused by rapid Autodesk Assistant toolbar button clicks racing panel create/destroy. |
| DYN-10769 | Serializes the `PushMcpServersAsync` / `GetAssistantURL` native SDK calls on panel open instead of racing them, removing a suspected source of an intermittent access violation in `AdpSDKCSharpWrapper.dll`. |
| DYN-10730 | Stops shipping four host-provided dependency DLLs (`AdpSDKCSharpWrapper.dll`, `Analytics.NET.ADP.dll`, `Analytics.NET.Core.dll`, `Newtonsoft.Json.dll`), trimming the built-in package's `bin/` to just `AutodeskAssistantViewExtension.dll` and its `en-US` satellite. (Already covered by this branch's prior [0.3.6] bump.) |

No API or behavioral change to Dynamo itself beyond what these AA-side fixes deliver.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Updated the built-in Autodesk Assistant package to 0.3.7, fixing the missing-IDSDK dialog spam, a rapid-toggle crash, panel state loss on close/reopen, and an intermittent native SDK crash on panel open.

### Reviewers

(FILL ME IN) Reviewer 1

### FYIs

N/A
