### PR TITLE
DYN-10740: Fix empty-message engine failure when force-execute collides with the DYN-5128 recompile

### DIFF
--- a/src/DynamoCore/Models/DynamoModelEvents.cs
+++ b/src/DynamoCore/Models/DynamoModelEvents.cs
@@ -360,12 +360,52 @@ namespace Dynamo.Models
         {
             if (!e.EvaluationSucceeded)
             {
+                // Record the failure before handing the dialog off to the dispatcher. When a UI
+                // dispatcher is attached the queued action runs later - and may never run at all if
+                // the application is already tearing down - so logging from inside
+                // DisplayEngineFailureMessage is not guaranteed to reach the log file. See DYN-10740,
+                // where the only evidence of the failure was a crash dialog with a blank message and
+                // the log file contained nothing at all.
+                LogEngineFailure(e.Error);
+
                 Action showFailureMessage = () => DisplayEngineFailureMessage(e.Error);
                 OnRequestDispatcherBeginInvoke(showFailureMessage);
             }
 
             if (EvaluationCompleted != null)
                 EvaluationCompleted(sender, e);
+        }
+
+        /// <summary>
+        /// Prefix written ahead of an unhandled engine evaluation failure in the Dynamo log.
+        /// </summary>
+        internal const string EngineFailureLogPrefix = "Dynamo engine failure: ";
+
+        /// <summary>
+        /// Writes an unhandled engine evaluation failure to the Dynamo log so the failure remains
+        /// diagnosable from a user's log file even when the crash dialog is dismissed or never shown.
+        /// </summary>
+        /// <remarks>
+        /// The exception type is logged explicitly and the full <see cref="Exception.ToString"/> text
+        /// is included, because <see cref="Exception.Message"/> alone can be empty; the type and the
+        /// stack trace are what identify the failing invariant in that case. Nothing beyond what the
+        /// exception itself carries is written, so no workspace content or user file path is added.
+        /// </remarks>
+        /// <param name="exception">The exception that ended the evaluation. May be null.</param>
+        private void LogEngineFailure(Exception exception)
+        {
+            if (Logger == null)
+                return;
+
+            if (exception == null)
+            {
+                Logger.Log(EngineFailureLogPrefix + "evaluation reported failure without an exception.",
+                    LogLevel.Console);
+                return;
+            }
+
+            Logger.Log(EngineFailureLogPrefix + exception.GetType().FullName + Environment.NewLine +
+                exception.ToString(), LogLevel.Console);
         }
 
         /// <summary>

--- a/src/Engine/ProtoCore/Utils/Validity.cs
+++ b/src/Engine/ProtoCore/Utils/Validity.cs
@@ -1,18 +1,53 @@
-﻿namespace ProtoCore.Utils
+﻿using System.Globalization;
+using System.IO;
+using System.Runtime.CompilerServices;
+
+namespace ProtoCore.Utils
 {
     public class Validity
     {
-        public static void Assert(bool cond)
+        private const string UnspecifiedAssertionFailure =
+            "Assertion failed (no diagnostic message was supplied).";
+
+        /// <summary>
+        /// Throws a compiler internal exception when <paramref name="cond"/> is false.
+        /// </summary>
+        /// <remarks>
+        /// The optional parameters are filled in by the compiler at the call site and must not be
+        /// passed explicitly. Because they are resolved at compile time they survive JIT inlining,
+        /// so the resulting message still identifies the failing assertion even when the throwing
+        /// frame is missing from the stack trace. Only the source file name is reported, never the
+        /// full path from the build machine, because this message can reach a user-facing dialog.
+        /// </remarks>
+        /// <param name="cond">Condition that is expected to hold.</param>
+        /// <param name="conditionExpression">
+        /// Supplied by the compiler: the literal source text of <paramref name="cond"/>.
+        /// </param>
+        /// <param name="memberName">Supplied by the compiler: the name of the calling member.</param>
+        /// <param name="filePath">Supplied by the compiler: the path of the calling source file.</param>
+        /// <param name="lineNumber">Supplied by the compiler: the line number of the call site.</param>
+        public static void Assert(bool cond,
+            [CallerArgumentExpression(nameof(cond))] string conditionExpression = null,
+            [CallerMemberName] string memberName = null,
+            [CallerFilePath] string filePath = null,
+            [CallerLineNumber] int lineNumber = 0)
         {
             if (!cond)
-                throw new Exceptions.CompilerInternalException("");
+                throw new Exceptions.CompilerInternalException(
+                    DescribeAssertionFailure(conditionExpression, memberName, filePath, lineNumber));
         }
 
+        /// <summary>
+        /// Throws a compiler internal exception carrying <paramref name="message"/> when
+        /// <paramref name="cond"/> is false.
+        /// </summary>
+        /// <param name="cond">Condition that is expected to hold.</param>
+        /// <param name="message">Message describing the invariant that was violated.</param>
         public static void Assert(bool cond, string message)
         {
             if (!cond)
             {
-                throw new Exceptions.CompilerInternalException(message);
+                throw new Exceptions.CompilerInternalException(EnsureDiagnosableMessage(message));
             }
         }
 
@@ -22,8 +57,35 @@
         {
             if (!cond)
             {
-                throw new Exceptions.CompilerInternalException(string.Format(format, items));
+                throw new Exceptions.CompilerInternalException(
+                    EnsureDiagnosableMessage(string.Format(format, items)));
             }
+        }
+
+        /// <summary>
+        /// Builds a self-describing assertion failure message from compiler-supplied caller info.
+        /// </summary>
+        private static string DescribeAssertionFailure(
+            string conditionExpression, string memberName, string filePath, int lineNumber)
+        {
+            var condition = string.IsNullOrEmpty(conditionExpression)
+                ? "<unknown condition>" : conditionExpression;
+            var member = string.IsNullOrEmpty(memberName) ? "<unknown member>" : memberName;
+            // Deliberately the file name only: filePath is an absolute path on the machine that
+            // compiled ProtoCore and must not be shown to users.
+            var fileName = string.IsNullOrEmpty(filePath) ? "<unknown file>" : Path.GetFileName(filePath);
+
+            return string.Format(CultureInfo.InvariantCulture,
+                "Assertion failed: '{0}' in {1} at {2}:{3}", condition, member, fileName, lineNumber);
+        }
+
+        /// <summary>
+        /// Guarantees a non-empty exception message. An empty message renders as a blank crash
+        /// dialog (DYN-10740), which makes the underlying failure impossible to diagnose.
+        /// </summary>
+        private static string EnsureDiagnosableMessage(string message)
+        {
+            return string.IsNullOrWhiteSpace(message) ? UnspecifiedAssertionFailure : message;
         }
     }
 }

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -263,7 +263,18 @@ namespace ProtoScript.Runners
                 // Mark all graphnodes dirty which are associated with the force exec ASTs
                 var firstDirtyNode = ProtoCore.AssociativeEngine.Utils.MarkGraphNodesDirtyAtGlobalScope(
                     runtimeCore, changeSet.ForceExecuteASTList);
-                Validity.Assert(firstDirtyNode != null);
+
+                // MarkGraphNodesDirtyAtGlobalScope only matches graph nodes that are still active,
+                // and ApplyChangeSetModified has already run by this point, so every force-executed
+                // AST whose graph nodes it deactivated has nothing left to mark dirty. This used to
+                // fail a bare assert and reach the user as an engine failure dialog with no message
+                // at all (DYN-10740). It is not a fatal condition: whatever replaced the deactivated
+                // graph nodes is compiled later in this same sync and will execute, so the request
+                // to re-execute is already satisfied. Leave the entrypoint to the code generator.
+                if (firstDirtyNode == null)
+                {
+                    return;
+                }
 
                 // If the only ASTs to execute are force exec, then set the entrypoint here.
                 // Otherwise the entrypoint is set by the code generator when the new ASTs are compiled
@@ -774,7 +785,14 @@ namespace ProtoScript.Runners
         /// </summary>
         /// <param name="st"></param>
         /// <param name="modifiedASTList"></param>
-        private void UpdateCachedASTList(Subtree st, List<AssociativeNode> modifiedASTList)
+        /// <param name="subtreeWasForceRecompiled">
+        /// True when the caller has already scheduled this subtree's cached graph nodes for
+        /// deactivation and replaced them with freshly compiled clones. Those clones re-execute the
+        /// subtree on their own, so its cached ASTs must not also be added to ForceExecuteASTList -
+        /// they refer to the graph nodes being deactivated, and marking them dirty is impossible.
+        /// </param>
+        private void UpdateCachedASTList(Subtree st, List<AssociativeNode> modifiedASTList,
+            bool subtreeWasForceRecompiled = false)
         {
             List<AssociativeNode> removedModifiedNodes = new List<AssociativeNode>();
 
@@ -838,7 +856,7 @@ namespace ProtoScript.Runners
                 else
                 {
                     var unmodifiedASTs = GetUnmodifiedASTList(oldSubTree.AstNodes, st.AstNodes);
-                    if (st.ForceExecution)
+                    if (st.ForceExecution && !subtreeWasForceRecompiled)
                     {
                         // Get the cached AST and append it to the changeSet
                         csData.ForceExecuteASTList.AddRange(unmodifiedASTs);
@@ -928,6 +946,10 @@ namespace ProtoScript.Runners
                     var modifiedASTList = GetModifiedNodes(modifiedSubTree, redefinitionAllowed, out modifiedInputAST);
                     csData.ModifiedNodesForRuntimeSetValue.AddRange(modifiedInputAST);
 
+                    // Set when the force-recompile path below replaces this subtree's cached graph
+                    // nodes, so UpdateCachedASTList knows not to also force-execute them.
+                    bool subtreeWasForceRecompiled = false;
+
                     // If another non-input subtree was structurally modified and this non-input
                     // subtree appears unchanged, force-recompile it so its new graph node lands
                     // at a PC higher than the recompiled upstream node. Also deactivate the old
@@ -945,6 +967,7 @@ namespace ProtoScript.Runners
                             // These originals stay untouched: DeactivateGraphnodes/ReActivateGraphNodesInCycle
                             // only read OriginalAstID, which clones preserve, so deactivation still matches.
                             csData.RemovedBinaryNodesFromModification.AddRange(cachedBinaryNodes);
+                            subtreeWasForceRecompiled = cachedBinaryNodes.Count > 0;
                             // Clone before stamping/injecting. cachedBinaryNodes are the live objects held in
                             // currentSubTreeList; mutating them or handing them to the compiler (which writes
                             // back UIDs and SSA-transforms in place) would corrupt the cached subtree and leak
@@ -989,7 +1012,8 @@ namespace ProtoScript.Runners
                         bnode.guid = modifiedSubTrees[n].GUID;
                         bnode.IsInputExpression = true;
                     }
-                    UpdateCachedASTList(modifiedSubTree, modifiedSubTree.ModifiedAstNodes);
+                    UpdateCachedASTList(modifiedSubTree, modifiedSubTree.ModifiedAstNodes,
+                        subtreeWasForceRecompiled);
                 }
                 else
                 {

--- a/test/DynamoCoreTests/Models/DynamoModelEventsTest.cs
+++ b/test/DynamoCoreTests/Models/DynamoModelEventsTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using CoreNodeModels;
@@ -437,6 +438,57 @@ namespace Dynamo.Tests.ModelsTest
         }
 
 
+
+        /// <summary>
+        /// DYN-10740: a failed evaluation showed an "Unhandled exception in Dynamo engine" dialog
+        /// with a completely blank message, and nothing was written to the Dynamo log, so the only
+        /// evidence available was a dialog that said nothing. OnEvaluationCompleted must record the
+        /// failing exception - specifically its type and stack trace, which stay useful when Message
+        /// is empty - to the log before the dialog is dispatched.
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void WhenEvaluationFailsThenExceptionTypeAndStackAreLogged()
+        {
+            //Arrange
+            //Throw and catch so the exception carries a real stack trace. The empty message is the
+            //DYN-10740 shape: Message alone conveys nothing.
+            Exception failure;
+            try
+            {
+                throw new Exception(string.Empty);
+            }
+            catch (Exception exception)
+            {
+                failure = exception;
+            }
+
+            Assert.IsEmpty(failure.Message, "The empty message is what makes this the DYN-10740 shape.");
+
+            //In test mode DynamoLogger writes to standard output, so capture it to observe the log.
+            var standardOutput = Console.Out;
+            string logOutput;
+            using (var logWriter = new StringWriter())
+            {
+                Console.SetOut(logWriter);
+                try
+                {
+                    //Act
+                    CurrentDynamoModel.OnEvaluationCompleted(this, new EvaluationCompletedEventArgs(true, failure));
+                }
+                finally
+                {
+                    Console.SetOut(standardOutput);
+                }
+
+                logOutput = logWriter.ToString();
+            }
+
+            //Assert
+            StringAssert.Contains(DynamoModel.EngineFailureLogPrefix, logOutput);
+            StringAssert.Contains(typeof(Exception).FullName, logOutput);
+            StringAssert.Contains(nameof(WhenEvaluationFailsThenExceptionTypeAndStackAreLogged), logOutput);
+        }
 
         #region SubscriberEvents
         private void CurrentDynamoModel_RefreshCompleted(Graph.Workspaces.HomeWorkspaceModel obj)

--- a/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -6163,6 +6163,269 @@ s = 1;
             Assert.Less(pcA, pcB, "Node A must have a lower PC than node B");
             Assert.Less(pcB, pcC, "Node B must have a lower PC than node C");
         }
+
+
+        #region DYN-10740
+
+        /// <summary>
+        /// DYN-10740 diagnostic helper.
+        ///
+        /// The reported crash surfaced as the "Unhandled exception in Dynamo engine" dialog with a
+        /// blank message, followed by only three stack frames: LiveRunner.SynchronizeInternal,
+        /// UpdateGraphAsyncTask.HandleTaskExecutionCore and AsyncTask.Execute.
+        ///
+        /// GenericTaskDialog renders Exception.Message, a blank line, then Exception.StackTrace, so the
+        /// blank first line in the reported screenshot meant Message was empty. At the time the only
+        /// exception ProtoCore constructed with an empty message was CompilerInternalException, thrown
+        /// by the single-argument Validity.Assert(bool) overload, which is how the failure was traced
+        /// to ProtoCore. Validity.Assert now composes a message naming the condition, member, file and
+        /// line, so that empty-message signature no longer applies - the message reported below
+        /// identifies the broken invariant directly.
+        /// </summary>
+        private void AssertGraphUpdateDoesNotFailInternally(Action updateGraph, string scenario)
+        {
+            try
+            {
+                updateGraph();
+            }
+            catch (Exception exception)
+            {
+                Assert.Fail(
+                    scenario + " threw " + exception.GetType().Name + " out of LiveRunner.UpdateGraph."
+                    + Environment.NewLine + "Message: \"" + exception.Message + "\""
+                    + Environment.NewLine
+                    + "A CompilerInternalException here is a Validity.Assert failure inside ProtoCore, "
+                    + "the DYN-10740 failure mode; its message names the invariant that broke."
+                    + Environment.NewLine + "StackTrace:" + Environment.NewLine + exception.StackTrace);
+            }
+        }
+
+        /// <summary>
+        /// DYN-10740 theory 1: SynchronizeInternal ends by calling
+        /// GetGraphNodesAtScope(kInvalidPC, kInvalidPC) and calling RemoveAll on the result, guarded
+        /// only by CodeBlockList.Any(). GetGraphNodesAtScope returns null when the global scope has no
+        /// entry in graphNodeMap, and every other call site in the codebase null-checks it. A subtree
+        /// containing only a function definition produces a code block without global-scope graph
+        /// nodes, so a following sync exercises that unguarded path.
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void WhenSubtreeDefinesOnlyAFunctionThenFollowingSyncDoesNotFailInternally()
+        {
+            var guidFunc = Guid.NewGuid();
+            var addedFunc = TestFrameWork.CreateSubTreeFromCode(guidFunc, "def dyn10740(){return = 1;}");
+
+            AssertGraphUpdateDoesNotFailInternally(
+                () => liveRunner.UpdateGraph(new GraphSyncData(null, new List<Subtree> { addedFunc }, null)),
+                "Adding a function-definition-only subtree");
+
+            // Re-send the same subtree unchanged. Nothing needs recompiling, so the delta AST list is
+            // empty and SynchronizeInternal skips compilation but still runs the tail bookkeeping.
+            var modifiedFunc = new Subtree(addedFunc.AstNodes, guidFunc);
+
+            AssertGraphUpdateDoesNotFailInternally(
+                () => liveRunner.UpdateGraph(new GraphSyncData(null, null, new List<Subtree> { modifiedFunc })),
+                "Re-sending an unchanged function-definition-only subtree");
+        }
+
+        /// <summary>
+        /// DYN-10740 theory 2: ChangeSetApplier.ApplyChangeSetForceExecute asserts that
+        /// MarkGraphNodesDirtyAtGlobalScope found a graph node for the force-executed ASTs, and that
+        /// helper only matches nodes whose isActive is true. ChangeSetApplier.Apply processes the
+        /// deleted set before the force-execute set, so deleting a subtree and force-executing it in
+        /// the same sync deactivates the graph nodes the assert then requires to be present.
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void WhenSubtreeIsDeletedAndForceExecutedInSameSyncThenEngineDoesNotFailInternally()
+        {
+            var guidA = Guid.NewGuid();
+            var addedA = TestFrameWork.CreateSubTreeFromCode(guidA, "dyn10740a = 1;");
+
+            liveRunner.UpdateGraph(new GraphSyncData(null, new List<Subtree> { addedA }, null));
+            AssertValue("dyn10740a", 1);
+
+            // The same subtree arrives as deleted and as a force-executed modification in one sync.
+            var deletedA = new Subtree(addedA.AstNodes, guidA);
+            var forceExecutedA = new Subtree(addedA.AstNodes, guidA) { ForceExecution = true };
+
+            AssertGraphUpdateDoesNotFailInternally(
+                () => liveRunner.UpdateGraph(new GraphSyncData(
+                    new List<Subtree> { deletedA },
+                    null,
+                    new List<Subtree> { forceExecutedA })),
+                "Deleting and force-executing the same subtree in one sync");
+        }
+
+        /// <summary>
+        /// DYN-10740 theory 3: the DYN-5128 fix (nodes executing twice after wire reconnect) added a
+        /// force-recompile path that deactivates a subtree's cached graph nodes and injects stamped
+        /// clones. SetValueForModifiedNodes then asserts the graph node it finds has a valid startpc.
+        /// Combining that recompile path with a deletion in the same sync exercises both at once.
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void WhenUpstreamIsModifiedAndAnotherSubtreeDeletedThenEngineDoesNotFailInternally()
+        {
+            var guidA = Guid.NewGuid();
+            var guidB = Guid.NewGuid();
+            var guidC = Guid.NewGuid();
+            var guidD = Guid.NewGuid();
+
+            var addedA = TestFrameWork.CreateSubTreeFromCode(guidA, "dyn10740a = 1;");
+            var addedB = TestFrameWork.CreateSubTreeFromCode(guidB, "dyn10740b = dyn10740a + 10;");
+            var addedC = TestFrameWork.CreateSubTreeFromCode(guidC, "dyn10740c = dyn10740b + 100;");
+            var addedD = TestFrameWork.CreateSubTreeFromCode(guidD, "dyn10740d = 5;");
+
+            liveRunner.UpdateGraph(new GraphSyncData(null,
+                new List<Subtree> { addedA, addedB, addedC, addedD }, null));
+            AssertValue("dyn10740c", 111);
+
+            // A changes structurally; B and C are re-sent unchanged, reusing the same AstNodes
+            // references so they compare equal and take the DYN-5128 force-recompile path. D is
+            // deleted in the same sync.
+            var modifiedA = TestFrameWork.CreateSubTreeFromCode(guidA, "dyn10740a = 2;");
+            var unchangedB = new Subtree(addedB.AstNodes, guidB);
+            var unchangedC = new Subtree(addedC.AstNodes, guidC);
+            var deletedD = new Subtree(addedD.AstNodes, guidD);
+
+            AssertGraphUpdateDoesNotFailInternally(
+                () => liveRunner.UpdateGraph(new GraphSyncData(
+                    new List<Subtree> { deletedD },
+                    null,
+                    new List<Subtree> { modifiedA, unchangedB, unchangedC })),
+                "Structurally modifying an upstream subtree while deleting another");
+
+            AssertValue("dyn10740b", 12);
+            AssertValue("dyn10740c", 112);
+        }
+
+        /// <summary>
+        /// DYN-10740 theory 4, the closest analogue to the reported repro. Asking the Assistant to
+        /// arrange the nodes so they do not overlap changes only node positions, so every node is
+        /// re-sent as a modified subtree while nothing has semantically changed. Code block nodes
+        /// arrive with DeltaComputation set to false (see EngineController.VerifyGraphSyncData), which
+        /// routes them past the delta-computation branch the other subtrees take. The graph shape
+        /// mirrors the attached Home.dyn: literal-list code blocks feeding a downstream chain.
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void WhenEverySubtreeIsResentUnchangedThenEngineDoesNotFailInternally()
+        {
+            var guidCoords = Guid.NewGuid();
+            var guidNames = Guid.NewGuid();
+            var guidOffset = Guid.NewGuid();
+            var guidResult = Guid.NewGuid();
+
+            // Code block subtrees, as produced by the Assistant when it writes literal lists.
+            var addedCoords = TestFrameWork.CreateSubTreeFromCode(guidCoords,
+                "dyn10740xs = [11.57, -7.69, 14.52, 6.63];");
+            addedCoords.DeltaComputation = false;
+            var addedNames = TestFrameWork.CreateSubTreeFromCode(guidNames,
+                "dyn10740names = [\"Bedroom 1\", \"Closet\", \"Bathroom 1\", \"Bedroom 2\"];");
+            addedNames.DeltaComputation = false;
+
+            // Downstream consumers, as produced by regular nodes.
+            var addedOffset = TestFrameWork.CreateSubTreeFromCode(guidOffset, "dyn10740pts = dyn10740xs + 1;");
+            var addedResult = TestFrameWork.CreateSubTreeFromCode(guidResult, "dyn10740out = dyn10740names;");
+
+            liveRunner.UpdateGraph(new GraphSyncData(null,
+                new List<Subtree> { addedCoords, addedNames, addedOffset, addedResult }, null));
+
+            // Re-send every subtree as modified with identical ASTs, which is a layout-only change.
+            var resentCoords = new Subtree(addedCoords.AstNodes, guidCoords) { DeltaComputation = false };
+            var resentNames = new Subtree(addedNames.AstNodes, guidNames) { DeltaComputation = false };
+            var resentOffset = new Subtree(addedOffset.AstNodes, guidOffset);
+            var resentResult = new Subtree(addedResult.AstNodes, guidResult);
+
+            AssertGraphUpdateDoesNotFailInternally(
+                () => liveRunner.UpdateGraph(new GraphSyncData(null, null,
+                    new List<Subtree> { resentCoords, resentNames, resentOffset, resentResult })),
+                "Re-sending every subtree unchanged, as a layout-only update does");
+        }
+
+        /// <summary>
+        /// DYN-10740 theory 5: as above, but the Assistant also prunes a node while relaying out the
+        /// graph, so one subtree is deleted in the same sync that re-sends the rest unchanged. This
+        /// combines the redefinition bookkeeping at the end of SynchronizeInternal with the deletion
+        /// path in ChangeSetApplier.
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void WhenGraphIsResentUnchangedWhileOneSubtreeIsDeletedThenEngineDoesNotFailInternally()
+        {
+            var guidCoords = Guid.NewGuid();
+            var guidOffset = Guid.NewGuid();
+            var guidSpare = Guid.NewGuid();
+
+            var addedCoords = TestFrameWork.CreateSubTreeFromCode(guidCoords, "dyn10740xs = [1, 2, 3];");
+            addedCoords.DeltaComputation = false;
+            var addedOffset = TestFrameWork.CreateSubTreeFromCode(guidOffset, "dyn10740pts = dyn10740xs + 1;");
+            var addedSpare = TestFrameWork.CreateSubTreeFromCode(guidSpare, "dyn10740spare = dyn10740xs;");
+
+            liveRunner.UpdateGraph(new GraphSyncData(null,
+                new List<Subtree> { addedCoords, addedOffset, addedSpare }, null));
+
+            var resentCoords = new Subtree(addedCoords.AstNodes, guidCoords) { DeltaComputation = false };
+            var resentOffset = new Subtree(addedOffset.AstNodes, guidOffset);
+            var deletedSpare = new Subtree(addedSpare.AstNodes, guidSpare);
+
+            AssertGraphUpdateDoesNotFailInternally(
+                () => liveRunner.UpdateGraph(new GraphSyncData(
+                    new List<Subtree> { deletedSpare },
+                    null,
+                    new List<Subtree> { resentCoords, resentOffset })),
+                "Re-sending the graph unchanged while deleting one subtree");
+        }
+
+
+        /// <summary>
+        /// DYN-10740 theory 6, the mechanism the first five tests all missed. ChangeSetApplier.Apply
+        /// runs its phases in a fixed order: Deleted, then Modified, then ForceExecute. The Modified
+        /// phase deactivates every graph node listed in RemovedBinaryNodesFromModification, and the
+        /// ForceExecute phase then asserts it can still find an *active* graph node for each AST in
+        /// ForceExecuteASTList. Any AST that lands in both lists therefore guarantees the assert fires.
+        ///
+        /// The DYN-5128 force-recompile block puts a subtree's cached binary nodes into the first list
+        /// when the subtree is non-input, structurally unchanged, and some *other* non-input subtree
+        /// did change. UpdateCachedASTList independently puts the same cached objects into the second
+        /// list whenever the subtree carries ForceExecution. Unlike the older path, which guards with
+        /// "else if (!st.ForceExecution)", the DYN-5128 block has no ForceExecution check - so both
+        /// lists end up holding the same object references.
+        ///
+        /// A slider cannot expose this because sliders are input nodes and are excluded by the
+        /// block's !IsInput test. It needs a *non-input* node that force-executes, which is why the
+        /// reported graph (no slider) could hit it and ordinary test graphs do not.
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void WhenUnchangedForceExecutedNonInputSubtreeAccompaniesStructuralChangeThenEngineDoesNotFailInternally()
+        {
+            var guidA = Guid.NewGuid();
+            var guidF = Guid.NewGuid();
+
+            var addedA = TestFrameWork.CreateSubTreeFromCode(guidA, "dyn10740a = 1;");
+            var addedF = TestFrameWork.CreateSubTreeFromCode(guidF, "dyn10740f = dyn10740a + 1;");
+
+            liveRunner.UpdateGraph(new GraphSyncData(null,
+                new List<Subtree> { addedA, addedF }, null));
+            AssertValue("dyn10740f", 2);
+
+            // A changes structurally, so anyNonInputActuallyModified is true. F is re-sent with the
+            // very same AstNodes reference, so it compares unchanged, and it force-executes. Subtree
+            // defaults IsInput to false, which is the non-input case the DYN-5128 block fails to guard.
+            var modifiedA = TestFrameWork.CreateSubTreeFromCode(guidA, "dyn10740a = 2;");
+            var forceExecutedF = new Subtree(addedF.AstNodes, guidF) { ForceExecution = true };
+
+            AssertGraphUpdateDoesNotFailInternally(
+                () => liveRunner.UpdateGraph(new GraphSyncData(null, null,
+                    new List<Subtree> { modifiedA, forceExecutedF })),
+                "Force-executing an unchanged non-input subtree alongside a structural change");
+
+            AssertValue("dyn10740f", 3);
+        }
+
+        #endregion
 
     }
 

--- a/test/Engine/ProtoTest/UtilsTests/ValidityTests.cs
+++ b/test/Engine/ProtoTest/UtilsTests/ValidityTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using NUnit.Framework;
+using ProtoCore.Exceptions;
+using ProtoCore.Utils;
+
+namespace ProtoTest.UtilsTests
+{
+    /// <summary>
+    /// Covers the diagnosability contract of <see cref="Validity"/>.
+    ///
+    /// DYN-10740 surfaced as the "Unhandled exception in Dynamo engine" dialog with a completely
+    /// blank message. The dialog renders Exception.Message followed by Exception.StackTrace, and the
+    /// only exception ProtoCore constructed with an empty message was the one thrown by the
+    /// single-argument Validity.Assert(bool) overload, so nothing at all identified the broken
+    /// invariant. These tests pin the assert helper to producing a message that names the failing
+    /// condition and its source location.
+    /// </summary>
+    [TestFixture]
+    public class ValidityTests
+    {
+        /// <summary>
+        /// Returns the line number of its own call site. Used so the expected line number is never
+        /// hard coded and stays correct when this file is edited.
+        /// </summary>
+        private static int CurrentLine([CallerLineNumber] int lineNumber = 0)
+        {
+            return lineNumber;
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenBareAssertFailsThenExceptionMessageIsNotEmpty()
+        {
+            var exception = Assert.Throws<CompilerInternalException>(() => Validity.Assert(false));
+
+            Assert.IsNotNull(exception.Message);
+            Assert.IsNotEmpty(exception.Message, "A blank message is the DYN-10740 defect.");
+            Assert.IsFalse(string.IsNullOrWhiteSpace(exception.Message));
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenBareAssertFailsThenMessageNamesConditionMemberAndLine()
+        {
+            var conditionThatDoesNotHold = false;
+
+            var expectedLine = CurrentLine() + 1;
+            var exception = Assert.Throws<CompilerInternalException>(() => Validity.Assert(conditionThatDoesNotHold));
+
+            var message = exception.Message;
+
+            // The literal source text of the condition, captured by [CallerArgumentExpression].
+            StringAssert.Contains(nameof(conditionThatDoesNotHold), message);
+
+            // The calling member, captured by [CallerMemberName]. Inside a lambda this resolves to
+            // the enclosing member, which is this test method.
+            StringAssert.Contains(nameof(WhenBareAssertFailsThenMessageNamesConditionMemberAndLine), message);
+
+            // The call site line number, captured by [CallerLineNumber].
+            StringAssert.Contains(expectedLine.ToString(), message);
+
+            // The source file, captured by [CallerFilePath] and reduced to its file name.
+            StringAssert.Contains("ValidityTests.cs", message);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenBareAssertFailsThenMessageCarriesNoAbsoluteSourcePath()
+        {
+            var exception = Assert.Throws<CompilerInternalException>(() => Validity.Assert(false));
+
+            // [CallerFilePath] is the absolute path on the machine that compiled the caller. That
+            // path must not reach a user-facing crash dialog, so only the file name is reported.
+            var thisFilePath = CurrentFilePath();
+            var directory = Path.GetDirectoryName(thisFilePath);
+
+            Assert.IsNotEmpty(directory);
+            Assert.IsFalse(exception.Message.Contains(directory),
+                "The assertion message must not leak the build machine's source directory.");
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenBareAssertHoldsThenNothingIsThrown()
+        {
+            Assert.DoesNotThrow(() => Validity.Assert(true));
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenAssertWithMessageFailsThenThatMessageIsUsed()
+        {
+            const string message = "DYN-10740 explicit assertion message.";
+
+            var exception = Assert.Throws<CompilerInternalException>(() => Validity.Assert(false, message));
+
+            Assert.AreEqual(message, exception.Message);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenAssertWithEmptyMessageFailsThenExceptionMessageIsStillNotEmpty()
+        {
+            var exception = Assert.Throws<CompilerInternalException>(() => Validity.Assert(false, string.Empty));
+
+            Assert.IsNotEmpty(exception.Message);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenAssertWithMessageHoldsThenNothingIsThrown()
+        {
+            Assert.DoesNotThrow(() => Validity.Assert(true, "unused"));
+        }
+
+        /// <summary>
+        /// Returns the absolute path of this source file as the compiler saw it.
+        /// </summary>
+        private static string CurrentFilePath([CallerFilePath] string filePath = null)
+        {
+            return filePath;
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

Fixes [DYN-10740](https://autodesk.atlassian.net/browse/DYN-10740) — an engine failure dialog with a **completely empty message**, reported after Autodesk Assistant rearranged the nodes of a graph in Revit. The graph ran successfully ("Run completed.") and *then* the dialog appeared. The original reporter's evidence was a screenshot showing only a stack trace, and it was not reproducible by hand.

**Root cause.** `ChangeSetApplier.Apply` runs its phases in a fixed order — Deleted, then Modified, then ForceExecute (`LiveRunner.cs:222-224`). The Modified phase deactivates every graph node listed in `RemovedBinaryNodesFromModification` (`:240`); the ForceExecute phase then requires an **active** graph node for each AST in `ForceExecuteASTList` (`:264-266`, via `AssociativeGraph.cs:773`). Any AST in both lists is therefore guaranteed to fail the assert.

Two paths put **the same cached AST object references** into both lists, for one subtree in one sync:

| Path | Line | Adds to |
| --- | --- | --- |
| DYN-5128 force-recompile block | `LiveRunner.cs:935-947` | `RemovedBinaryNodesFromModification` |
| `UpdateCachedASTList` | `LiveRunner.cs:840-844` | `ForceExecuteASTList` |

Both read the same cached subtree, and both trigger on the same condition — an unchanged AST. The clones the recompile injects don't rescue it: they compile at `:1854`, *after* `Apply` runs at `:1850`.

The older removal path guards exactly this invariant with `else if (!st.ForceExecution)` (`:802`). The block added by #17095 (DYN-5128) has no such check. The implicit assumption was that force-execution only happens on *input* nodes — true for a slider, which is correctly excluded by `!IsInput`, but false for a **non-input node with input ports**: a Revit category query (`ElementsQueryBase` force-executes on any document change and has a `Category` in-port) or, in core, `File From Path` / `Directory From Path` via their `FileSystemWatcher`. That is why this needed a Revit graph with no slider to surface, and why it resisted manual reproduction.

**Regression scope:** introduced by #17095 (`2900406fff5`, 2026-06-09). Present on `master` (4.3.0) and `RC4.2.0_master` (4.2.0); **absent on `RC4.1.0_master`** (the block does not exist there). This will need a cherry-pick to `RC4.2.0_master`.

**Commit 1 — diagnosability (why this cost so much to find).** `Validity.Assert(bool)` threw `CompilerInternalException("")`, and `GenericTaskDialog` renders `Message`, a blank line, then `StackTrace` — hence a dialog whose message area was blank, naming neither the invariant nor its location. Compiler-supplied caller info (`CallerArgumentExpression`/`CallerMemberName`/`CallerFilePath`/`CallerLineNumber`) now yields `Assertion failed: '<condition>' in <Member> at <File>:<line>`. Resolved at compile time, so it survives the JIT inlining that collapsed three wrapper frames out of the reported stack; only the file name is emitted, so no build path leaks. **This change named the assert on its first run.** Separately, an engine failure was never written to Dynamo's log at all (`DynamoModelEvents.cs` reported telemetry and showed the dialog only), so the reporter's log file was empty — it is now logged with the exception type and full stack before the dialog is dispatched.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

**API note for reviewers.** `ProtoCore.Utils.Validity` is public, and `Assert(bool)` gains four optional caller-info parameters. This is **source**-compatible (no call site changes; ~340 sites unchanged) but its metadata signature becomes `Assert(bool, string, string, string, int)`, so a *pre-compiled* assembly calling the old 1-arg signature against a newer ProtoCore would get `MissingMethodException`. Stale in-repo dependents had to be rebuilt for this reason. Adding a separate overload does not work — C# overload resolution prefers the zero-omitted-optional candidate and would keep binding to the old method. Checked in our ecosystem: DynamoRevit's only `Validity` usage is the unrelated `DynamoServices.Validity` (`ElementIDLifecycleManager.cs:71`), and DynamoMCP / Dynamo-AutodeskAssistant / DynamoPlayer have zero references. Flagging it explicitly so the trade-off is a deliberate call rather than a surprise.

One latent trap worth knowing: a future `Assert(cond, "fmt {0}", someString)` would now bind to the caller-info overload in normal form and silently drop the format. All four existing 3+ arg call sites pass `int`, so they still bind to the `params` overload. Renaming the `internal` format overload to `AssertFormat` would remove the hazard permanently; left out as out of scope here.

### Release Notes

Fixed a crash where Dynamo showed an engine failure dialog with no error message after a graph edit that combined a structural change with a node needing forced re-execution, most visibly when Autodesk Assistant rearranged nodes in Revit. Assertion failures in the DesignScript engine now report which check failed and where, and engine failures are written to the Dynamo log.

### Reviewers

@RobertGlobant20 (author of #17095 / DYN-5128, the change this fixes)

Notes for reviewers and testers:

- **Test evidence.** `WhenUnchangedForceExecutedNonInputSubtreeAccompaniesStructuralChangeThenEngineDoesNotFailInternally` fails on `master` with `Assertion failed: 'firstDirtyNode != null' in ApplyChangeSetForceExecute at LiveRunner.cs:266` and passes with the fix. It ships alongside five tests covering neighbouring paths on the same delta-sync mechanism (all of which passed both before and after — kept as regression guards for a mechanism that clearly tolerates very little disturbance). `ProtoTest` is green: **5092 passed / 0 failed** with `--filter "TestCategory!=Failure"`; the 191 excluded are the repo's pre-existing `[Category("Failure")]` tests.
- **Why suppress the force-execute entry rather than skip the recompile.** Adding `&& !modifiedSubTree.ForceExecution` at `:935` (mirroring `:802`) also stops the crash, but it disables the DYN-5128 recompile for force-executing subtrees and so reintroduces the PC-ordering problem #17095 fixed. Suppressing the redundant `ForceExecuteASTList` entry keeps both behaviours: the injected clones re-execute the subtree, which the test asserts by checking the value actually recomputes.
- `ApplyChangeSetForceExecute` now returns instead of failing when no active graph node remains, so any *other* route into this state degrades to a redundant execution rather than a crash dialog.

### FYIs

@mjkkirschner @QilongTang
