### PR TITLE
Make RC4.2.0_master NuGet packages stable

### DIFF
--- a/tools/NuGet/BuildPackages.bat
+++ b/tools/NuGet/BuildPackages.bat
@@ -37,7 +37,7 @@ for /f %%f in ('cscript //Nologo ..\install\GetFileVersion.vbs %harvestPath%\Dyn
   set /a count=!count!+1
 )
 setlocal DisableDelayedExpansion
-set version=%Major%.%Minor%.%Build%-beta%Revision%
+set version=%Major%.%Minor%.%Build%.%Revision%
 
 for /f %%i in ('git rev-parse HEAD') do set COMMIT=%%i
 


### PR DESCRIPTION
### Purpose

Make NuGet packages stable for RC4.2.0_master by removing the `-beta` suffix from the version format in `BuildPackages.bat`.

This changes the NuGet version format from `Major.Minor.Build-betaRevision` (pre-release) to `Major.Minor.Build.Revision` (stable).

> Equivalent to [DynamoDS/Dynamo#11340](https://github.com/DynamoDS/Dynamo/pull/11340)

### Release Notes

Update BuildPackages.bat to produce stable NuGet package versions.