### PR TITLE
DYN-10775: Don't offer Autodesk Assistant when MCP token validation is unavailable

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -630,6 +630,7 @@
     <Compile Include="Utilities\CrashReportTool.cs" />
     <Compile Include="Utilities\CrashUtilities.cs" />
     <Compile Include="Utilities\GroupStyleItemSelector.cs" />
+    <Compile Include="Utilities\IdsdkMcpTokenValidation.cs" />
     <Compile Include="Utilities\LibraryDragAndDrop.cs" />
     <Compile Include="Utilities\MessageBoxUtilities.cs" />
     <Compile Include="Utilities\NetworkUtilities.cs" />

--- a/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
@@ -10,6 +10,7 @@ using Dynamo.Selection;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Visualization;
+using Dynamo.Wpf.Utilities;
 using Dynamo.Wpf.ViewModels.Watch3D;
 
 namespace Dynamo.Wpf.Extensions
@@ -96,6 +97,22 @@ namespace Dynamo.Wpf.Extensions
         public bool IsIDSDKInitialized => dynamoViewModel.IsIDSDKInitialized(showWarning: false);
 
         /// <summary>
+        /// Indicates whether Autodesk Identity (IDSDK) in this process is able to validate MCP
+        /// bearer tokens. When this is <c>false</c>, an MCP server running in this process will
+        /// reject every request with HTTP 401, so view extensions that depend on MCP (Autodesk
+        /// Assistant, the DynamoMCP view extension) should keep their own entry points disabled
+        /// rather than let the user reach a feature that cannot work.
+        /// <para>
+        /// This is a stronger signal than <see cref="IsIDSDKInitialized"/>: Dynamo's own IDSDK can
+        /// be initialized and still lack the MCP validation API entirely (DYN-10773). Reports
+        /// <c>true</c> when the capability cannot be determined, so it never disables a feature on
+        /// a guess.
+        /// </para>
+        /// </summary>
+        public bool IsMcpTokenValidationAvailable =>
+            IdsdkMcpTokenValidation.GetAvailability() != McpTokenValidationAvailability.Unavailable;
+
+        /// <summary>
         /// Adds a menu item to the extensions menu
         /// Items will be ordered alphabetically
         /// </summary>
@@ -134,7 +151,9 @@ namespace Dynamo.Wpf.Extensions
                     dynamoViewModel.Model.Logger.Log($"{viewExtension.Name} : {Wpf.Properties.Resources.ExtensionAlreadyPresent}");
                     break;
                 case DynamoView.ExtensionControlResult.Blocked:
-                    // Already logged by DisableExtensionWhenNoNetworkMode/DisableExtensionWhenIDSDKNotInitialized.
+                    // Already logged by DisableExtensionWhenNoNetworkMode /
+                    // DisableExtensionWhenMcpTokenValidationUnavailable /
+                    // DisableExtensionWhenIDSDKNotInitialized.
                     break;
             }
         }

--- a/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
@@ -10,7 +10,6 @@ using Dynamo.Selection;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Visualization;
-using Dynamo.Wpf.Utilities;
 using Dynamo.Wpf.ViewModels.Watch3D;
 
 namespace Dynamo.Wpf.Extensions
@@ -95,22 +94,6 @@ namespace Dynamo.Wpf.Extensions
         /// sign-in path.
         /// </summary>
         public bool IsIDSDKInitialized => dynamoViewModel.IsIDSDKInitialized(showWarning: false);
-
-        /// <summary>
-        /// Indicates whether Autodesk Identity (IDSDK) in this process is able to validate MCP
-        /// bearer tokens. When this is <c>false</c>, an MCP server running in this process will
-        /// reject every request with HTTP 401, so view extensions that depend on MCP (Autodesk
-        /// Assistant, the DynamoMCP view extension) should keep their own entry points disabled
-        /// rather than let the user reach a feature that cannot work.
-        /// <para>
-        /// This is a stronger signal than <see cref="IsIDSDKInitialized"/>: Dynamo's own IDSDK can
-        /// be initialized and still lack the MCP validation API entirely (DYN-10773). Reports
-        /// <c>true</c> when the capability cannot be determined, so it never disables a feature on
-        /// a guess.
-        /// </para>
-        /// </summary>
-        public bool IsMcpTokenValidationAvailable =>
-            IdsdkMcpTokenValidation.GetAvailability() != McpTokenValidationAvailability.Unavailable;
 
         /// <summary>
         /// Adds a menu item to the extensions menu

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3070,7 +3070,16 @@ namespace Dynamo.Wpf.Properties {
                 return ResourceManager.GetString("ExtensionAlreadyPresent", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Package/Extension {0} not {1} because Autodesk Identity (IDSDK) in this process cannot validate MCP tokens ({2} does not export {3}); every request would be rejected with HTTP 401..
+        /// </summary>
+        public static string ExtensionNotOfferedMcpTokenValidationUnavailable {
+            get {
+                return ResourceManager.GetString("ExtensionNotOfferedMcpTokenValidationUnavailable", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to All Files ({0})|{0}.
         /// </summary>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2329,8 +2329,8 @@ Do you want to install the latest Dynamo update?</value>
     <value>No new tab is added, as the extension is already present in the extensions side bar.</value>
   </data>
   <data name="ExtensionNotOfferedMcpTokenValidationUnavailable" xml:space="preserve">
-    <value>Package/Extension {0} not {1} because Autodesk Identity (IDSDK) in this process cannot validate MCP tokens ({2} does not export {3}); every request would be rejected with HTTP 401.</value>
-    <comment>{0} = extension name, {1} = the suppressed action (e.g. "added"), {2} = native library file name, {3} = native export name. {2} and {3} are technical identifiers and must not be translated.</comment>
+    <value>Package/Extension {0} not offered because Autodesk Identity (IDSDK) in this process cannot validate MCP tokens ({1} does not export {2}); every request would be rejected with HTTP 401.</value>
+    <comment>{0} = extension name, {1} = native library file name, {2} = native export name. {1} and {2} are technical identifiers and must not be translated.</comment>
   </data>
   <data name="MessageUninstallCustomNodeToContinue" xml:space="preserve">
     <value>{1} cannot be loaded.

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2328,6 +2328,10 @@ Do you want to install the latest Dynamo update?</value>
   <data name="ExtensionAlreadyPresent" xml:space="preserve">
     <value>No new tab is added, as the extension is already present in the extensions side bar.</value>
   </data>
+  <data name="ExtensionNotOfferedMcpTokenValidationUnavailable" xml:space="preserve">
+    <value>Package/Extension {0} not {1} because Autodesk Identity (IDSDK) in this process cannot validate MCP tokens ({2} does not export {3}); every request would be rejected with HTTP 401.</value>
+    <comment>{0} = extension name, {1} = the suppressed action (e.g. "added"), {2} = native library file name, {3} = native export name. {2} and {3} are technical identifiers and must not be translated.</comment>
+  </data>
   <data name="MessageUninstallCustomNodeToContinue" xml:space="preserve">
     <value>{1} cannot be loaded.
 Installing it will conflict with one or more node definitions that already exist in {0}, which is currently loaded. 

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2631,8 +2631,8 @@ Want to publish a different package?</value>
     <value>No new tab is added, as the extension is already present in the extensions side bar.</value>
   </data>
   <data name="ExtensionNotOfferedMcpTokenValidationUnavailable" xml:space="preserve">
-    <value>Package/Extension {0} not {1} because Autodesk Identity (IDSDK) in this process cannot validate MCP tokens ({2} does not export {3}); every request would be rejected with HTTP 401.</value>
-    <comment>{0} = extension name, {1} = the suppressed action (e.g. "added"), {2} = native library file name, {3} = native export name. {2} and {3} are technical identifiers and must not be translated.</comment>
+    <value>Package/Extension {0} not offered because Autodesk Identity (IDSDK) in this process cannot validate MCP tokens ({1} does not export {2}); every request would be rejected with HTTP 401.</value>
+    <comment>{0} = extension name, {1} = native library file name, {2} = native export name. {1} and {2} are technical identifiers and must not be translated.</comment>
   </data>
   <data name="MessageUninstallCustomNodeToContinue" xml:space="preserve">
     <value>{1} cannot be loaded.

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2630,6 +2630,10 @@ Want to publish a different package?</value>
   <data name="ExtensionAlreadyPresent" xml:space="preserve">
     <value>No new tab is added, as the extension is already present in the extensions side bar.</value>
   </data>
+  <data name="ExtensionNotOfferedMcpTokenValidationUnavailable" xml:space="preserve">
+    <value>Package/Extension {0} not {1} because Autodesk Identity (IDSDK) in this process cannot validate MCP tokens ({2} does not export {3}); every request would be rejected with HTTP 401.</value>
+    <comment>{0} = extension name, {1} = the suppressed action (e.g. "added"), {2} = native library file name, {3} = native export name. {2} and {3} are technical identifiers and must not be translated.</comment>
+  </data>
   <data name="MessageUninstallCustomNodeToContinue" xml:space="preserve">
     <value>{1} cannot be loaded.
 Installing it will conflict with one or more node definitions that already exist in {0}, which is currently loaded.

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 Dynamo.Wpf.Extensions.ViewLoadedParams.IsIDSDKInitialized.get -> bool
+Dynamo.Wpf.Extensions.ViewLoadedParams.IsMcpTokenValidationAvailable.get -> bool
+static Dynamo.Wpf.Properties.Resources.ExtensionNotOfferedMcpTokenValidationUnavailable.get -> string
 Dynamo.Controls.NetworkStatusIconConverter
 Dynamo.Controls.NetworkStatusIconConverter.Convert(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
 Dynamo.Controls.NetworkStatusIconConverter.ConvertBack(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 Dynamo.Wpf.Extensions.ViewLoadedParams.IsIDSDKInitialized.get -> bool
-Dynamo.Wpf.Extensions.ViewLoadedParams.IsMcpTokenValidationAvailable.get -> bool
 static Dynamo.Wpf.Properties.Resources.ExtensionNotOfferedMcpTokenValidationUnavailable.get -> string
 Dynamo.Controls.NetworkStatusIconConverter
 Dynamo.Controls.NetworkStatusIconConverter.Convert(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object

--- a/src/DynamoCoreWpf/Utilities/IdsdkMcpTokenValidation.cs
+++ b/src/DynamoCoreWpf/Utilities/IdsdkMcpTokenValidation.cs
@@ -137,7 +137,9 @@ namespace Dynamo.Wpf.Utilities
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern IntPtr GetModuleHandle(string lpModuleName);
 
+        // GetProcAddress has no Unicode variant — export names are always ANSI. The explicit
+        // LPStr keeps CA2101 satisfied without changing the marshaling CharSet.Ansi already picks.
         [DllImport("kernel32.dll", CharSet = CharSet.Ansi, BestFitMapping = false, SetLastError = true)]
-        private static extern IntPtr GetProcAddress(IntPtr hModule, string lpProcName);
+        private static extern IntPtr GetProcAddress(IntPtr hModule, [MarshalAs(UnmanagedType.LPStr)] string lpProcName);
     }
 }

--- a/src/DynamoCoreWpf/Utilities/IdsdkMcpTokenValidation.cs
+++ b/src/DynamoCoreWpf/Utilities/IdsdkMcpTokenValidation.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Dynamo.Wpf.Utilities
+{
+    /// <summary>
+    /// Whether Autodesk Identity (IDSDK) in this process is able to service an MCP
+    /// bearer-token validation call.
+    /// </summary>
+    internal enum McpTokenValidationAvailability
+    {
+        /// <summary>
+        /// AdskIdentitySDK.dll is mapped into this process and exports the MCP validation
+        /// entry point, so Tier 3 bearer-token validation can run.
+        /// </summary>
+        Available,
+
+        /// <summary>
+        /// AdskIdentitySDK.dll is mapped into this process but does not export the MCP
+        /// validation entry point. Every MCP tool call will be rejected with HTTP 401.
+        /// </summary>
+        Unavailable,
+
+        /// <summary>
+        /// AdskIdentitySDK.dll is not mapped into this process, so the capability cannot be
+        /// determined. Callers must treat this as "don't know", never as a failure.
+        /// </summary>
+        Unknown
+    }
+
+    /// <summary>
+    /// Detects whether Autodesk Identity (IDSDK) in this process can validate MCP bearer
+    /// tokens, so features that depend on it (Autodesk Assistant, the DynamoMCP view
+    /// extension) can be withheld instead of loading into a state where every tool call
+    /// returns HTTP 401.
+    /// <para>
+    /// DynamoMCP's Tier 3 gate P/Invokes <c>AdpSDKIdentityWrapper.dll</c>, which in turn
+    /// reaches IDSDK through a <em>base-name</em> <c>LoadLibraryW("AdskIdentitySDK.dll")</c>.
+    /// That binds to whichever <c>AdskIdentitySDK.dll</c> is already mapped into the process —
+    /// Dynamo's own copy in Sandbox, the host's copy under Revit. This probe therefore asks
+    /// the same question the same way: it inspects the <em>mapped</em> module and checks for
+    /// the export, rather than comparing file versions.
+    /// </para>
+    /// <para>
+    /// A version comparison would be wrong here. The MCP validation APIs were introduced in
+    /// official IDSDK 1.17.0, but Revit carries an unofficial 1.16.4.7 with the MCP work
+    /// backported, while official 1.16.5.1 — a <em>higher</em> version — lacks it entirely.
+    /// A higher version number does not imply a superset of the API surface, so only the
+    /// presence of the export is a sound signal (DYN-10773).
+    /// </para>
+    /// </summary>
+    internal static class IdsdkMcpTokenValidation
+    {
+        /// <summary>Base name of the native Autodesk Identity library.</summary>
+        internal const string IdsdkModuleName = "AdskIdentitySDK.dll";
+
+        /// <summary>
+        /// The IDSDK export DynamoMCP's Tier 3 validation ultimately depends on. Introduced in
+        /// IDSDK 1.17.0; absent from the 1.16.5.1 build Dynamo 4.2.0 originally shipped.
+        /// </summary>
+        internal const string McpValidateTokenExport = "idsdk_mcp_validate_token";
+
+        private static readonly object syncRoot = new object();
+
+        // Only a definitive result is cached. Unknown means AdskIdentitySDK.dll was not mapped
+        // yet, which can change later in the session, so it must stay re-probeable.
+        private static McpTokenValidationAvailability? cachedAvailability;
+
+        private static McpTokenValidationAvailability? testOverride;
+
+        /// <summary>
+        /// Returns whether IDSDK in this process can service an MCP token validation call.
+        /// Cheap and safe to call repeatedly; a definitive answer is computed once and cached.
+        /// </summary>
+        internal static McpTokenValidationAvailability GetAvailability()
+        {
+            lock (syncRoot)
+            {
+                if (testOverride.HasValue)
+                {
+                    return testOverride.Value;
+                }
+
+                if (cachedAvailability.HasValue)
+                {
+                    return cachedAvailability.Value;
+                }
+
+                var availability = Probe();
+                if (availability != McpTokenValidationAvailability.Unknown)
+                {
+                    cachedAvailability = availability;
+                }
+
+                return availability;
+            }
+        }
+
+        /// <summary>
+        /// Test seam. Forces <see cref="GetAvailability"/> to report the supplied value, or
+        /// restores real probing when passed <c>null</c>. Also clears the cached probe result
+        /// so a test cannot be contaminated by an earlier one.
+        /// </summary>
+        /// <param name="availability">Value to report, or <c>null</c> to resume real probing.</param>
+        internal static void SetAvailabilityForTesting(McpTokenValidationAvailability? availability)
+        {
+            lock (syncRoot)
+            {
+                testOverride = availability;
+                cachedAvailability = null;
+            }
+        }
+
+        private static McpTokenValidationAvailability Probe()
+        {
+            try
+            {
+                var module = GetModuleHandle(IdsdkModuleName);
+                if (module == IntPtr.Zero)
+                {
+                    // Nothing has mapped IDSDK yet (no auth provider, or a host that never
+                    // initializes it). We cannot tell, so we must not block anything.
+                    return McpTokenValidationAvailability.Unknown;
+                }
+
+                return GetProcAddress(module, McpValidateTokenExport) != IntPtr.Zero
+                    ? McpTokenValidationAvailability.Available
+                    : McpTokenValidationAvailability.Unavailable;
+            }
+            catch (Exception)
+            {
+                // A probe that cannot run is not evidence that validation is broken.
+                return McpTokenValidationAvailability.Unknown;
+            }
+        }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr GetModuleHandle(string lpModuleName);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Ansi, BestFitMapping = false, SetLastError = true)]
+        private static extern IntPtr GetProcAddress(IntPtr hModule, string lpProcName);
+    }
+}

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -548,9 +548,15 @@ namespace Dynamo.Controls
         /// <param name="content">Control being added</param>
         internal ExtensionControlResult AddOrFocusExtensionControl(IViewExtension viewExtension, UIElement content)
         {
+            // Order matters. DisableExtensionWhenIDSDKNotInitialized reads
+            // IDSDKManager.IsIDSDKInitialized, whose getter calls Initialize() as a side effect —
+            // and that is what maps AdskIdentitySDK.dll into the process. The MCP probe can only
+            // return a definitive answer once the module is mapped, so it must run after it;
+            // otherwise it reports Unknown and fails open. Same reasoning as the comment in
+            // DynamoLoadedViewExtensionHandler.
             if (DisableExtensionWhenNoNetworkMode(viewExtension.UniqueId, viewExtension.Name, "opened") ||
-                DisableExtensionWhenMcpTokenValidationUnavailable(viewExtension.UniqueId, viewExtension.Name, "opened") ||
-                DisableExtensionWhenIDSDKNotInitialized(viewExtension.UniqueId, viewExtension.Name, "opened"))
+                DisableExtensionWhenIDSDKNotInitialized(viewExtension.UniqueId, viewExtension.Name, "opened") ||
+                DisableExtensionWhenMcpTokenValidationUnavailable(viewExtension.UniqueId, viewExtension.Name))
                 return ExtensionControlResult.Blocked;
 
             var window = ExtensionWindows.ContainsKey(viewExtension.Name) ? ExtensionWindows[viewExtension.Name] : null;
@@ -1444,7 +1450,7 @@ namespace Dynamo.Controls
 
                     ext.Loaded(loadedParams);
 
-                    if (!idsdkNotInitialized && !DisableExtensionWhenMcpTokenValidationUnavailable(ext.UniqueId, ext.Name, "re-opened"))
+                    if (!idsdkNotInitialized && !DisableExtensionWhenMcpTokenValidationUnavailable(ext.UniqueId, ext.Name))
                     {
                         ReOpenSavedExtensionOnDynamoStartup(ext);
                     }
@@ -3491,9 +3497,8 @@ namespace Dynamo.Controls
         /// </summary>
         /// <param name="extensionId">Unique id of the extension being considered.</param>
         /// <param name="extensionName">Display name, used only for the log line.</param>
-        /// <param name="action">The action being suppressed, e.g. "opened" or "re-opened".</param>
         /// <returns>True when the extension's panel must not be opened.</returns>
-        internal bool DisableExtensionWhenMcpTokenValidationUnavailable(string extensionId, string extensionName, string action)
+        internal bool DisableExtensionWhenMcpTokenValidationUnavailable(string extensionId, string extensionName)
         {
             if ((string.Equals(extensionId, AutodeskAssistantExtensionId, StringComparison.OrdinalIgnoreCase) ||
                  string.Equals(extensionId, McpViewExtensionId, StringComparison.OrdinalIgnoreCase)) &&
@@ -3503,7 +3508,6 @@ namespace Dynamo.Controls
                     CultureInfo.CurrentCulture,
                     Res.ExtensionNotOfferedMcpTokenValidationUnavailable,
                     extensionName,
-                    action,
                     IdsdkMcpTokenValidation.IdsdkModuleName,
                     IdsdkMcpTokenValidation.McpValidateTokenExport));
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -38,6 +38,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Windows;
@@ -236,7 +237,8 @@ namespace Dynamo.Controls
             {
                 try
                 {
-                    if (DisableExtensionWhenNoNetworkMode(ext.UniqueId, ext.Name, "added"))
+                    if (DisableExtensionWhenNoNetworkMode(ext.UniqueId, ext.Name, "added") ||
+                        DisableExtensionWhenMcpTokenValidationUnavailable(ext.UniqueId, ext.Name, "added"))
                     {
                         continue;
                     }
@@ -548,6 +550,7 @@ namespace Dynamo.Controls
         internal ExtensionControlResult AddOrFocusExtensionControl(IViewExtension viewExtension, UIElement content)
         {
             if (DisableExtensionWhenNoNetworkMode(viewExtension.UniqueId, viewExtension.Name, "opened") ||
+                DisableExtensionWhenMcpTokenValidationUnavailable(viewExtension.UniqueId, viewExtension.Name, "opened") ||
                 DisableExtensionWhenIDSDKNotInitialized(viewExtension.UniqueId, viewExtension.Name, "opened"))
                 return ExtensionControlResult.Blocked;
 
@@ -1423,7 +1426,8 @@ namespace Dynamo.Controls
             {
                 try
                 {
-                    if (DisableExtensionWhenNoNetworkMode(ext.UniqueId, ext.Name, "loaded"))
+                    if (DisableExtensionWhenNoNetworkMode(ext.UniqueId, ext.Name, "loaded") ||
+                        DisableExtensionWhenMcpTokenValidationUnavailable(ext.UniqueId, ext.Name, "loaded"))
                     {
                         continue;
                     }
@@ -3458,6 +3462,46 @@ namespace Dynamo.Controls
                 !dynamoViewModel.IsIDSDKInitialized(showWarning: false))
             {
                 Log($"Package/Extension {extensionName} not {action} because Autodesk Identity (IDSDK) is not initialized");
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Withholds the Autodesk Assistant and MCP View extensions when Autodesk Identity (IDSDK)
+        /// in this process cannot validate MCP bearer tokens. Without this, both extensions load and
+        /// look healthy while every MCP tool call is rejected with HTTP 401, which is a worse failure
+        /// mode than the feature simply not being offered (DYN-10773 / DYN-10775).
+        /// <para>
+        /// Deliberately shaped like <see cref="DisableExtensionWhenNoNetworkMode"/> rather than
+        /// <see cref="DisableExtensionWhenIDSDKNotInitialized"/>: this condition cannot be recovered
+        /// from within the session, so there is nothing useful to leave behind in the UI.
+        /// </para>
+        /// <para>
+        /// Blocks only on a definitive <see cref="McpTokenValidationAvailability.Unavailable"/>.
+        /// <see cref="McpTokenValidationAvailability.Unknown"/> — IDSDK not mapped into the process,
+        /// so nothing can be concluded — deliberately fails open.
+        /// </para>
+        /// </summary>
+        /// <param name="extensionId">Unique id of the extension being considered.</param>
+        /// <param name="extensionName">Display name, used only for the log line.</param>
+        /// <param name="action">The action being suppressed, e.g. "added" or "loaded".</param>
+        /// <returns>True when the extension must not be offered.</returns>
+        internal bool DisableExtensionWhenMcpTokenValidationUnavailable(string extensionId, string extensionName, string action)
+        {
+            if ((string.Equals(extensionId, AutodeskAssistantExtensionId, StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(extensionId, McpViewExtensionId, StringComparison.OrdinalIgnoreCase)) &&
+                IdsdkMcpTokenValidation.GetAvailability() == McpTokenValidationAvailability.Unavailable)
+            {
+                Log(string.Format(
+                    CultureInfo.CurrentCulture,
+                    Res.ExtensionNotOfferedMcpTokenValidationUnavailable,
+                    extensionName,
+                    action,
+                    IdsdkMcpTokenValidation.IdsdkModuleName,
+                    IdsdkMcpTokenValidation.McpValidateTokenExport));
 
                 return true;
             }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -237,8 +237,7 @@ namespace Dynamo.Controls
             {
                 try
                 {
-                    if (DisableExtensionWhenNoNetworkMode(ext.UniqueId, ext.Name, "added") ||
-                        DisableExtensionWhenMcpTokenValidationUnavailable(ext.UniqueId, ext.Name, "added"))
+                    if (DisableExtensionWhenNoNetworkMode(ext.UniqueId, ext.Name, "added"))
                     {
                         continue;
                     }
@@ -1426,8 +1425,7 @@ namespace Dynamo.Controls
             {
                 try
                 {
-                    if (DisableExtensionWhenNoNetworkMode(ext.UniqueId, ext.Name, "loaded") ||
-                        DisableExtensionWhenMcpTokenValidationUnavailable(ext.UniqueId, ext.Name, "loaded"))
+                    if (DisableExtensionWhenNoNetworkMode(ext.UniqueId, ext.Name, "loaded"))
                     {
                         continue;
                     }
@@ -1437,10 +1435,11 @@ namespace Dynamo.Controls
                     // previously-open panel is skipped. Extensions that depend on IDSDK are expected to
                     // gate their own entry points via ViewLoadedParams.IsIDSDKInitialized.
                     var idsdkNotInitialized = DisableExtensionWhenIDSDKNotInitialized(ext.UniqueId, ext.Name, "re-opened");
+                    var mcpTokenValidationUnavailable = DisableExtensionWhenMcpTokenValidationUnavailable(ext.UniqueId, ext.Name, "re-opened");
 
                     ext.Loaded(loadedParams);
 
-                    if (!idsdkNotInitialized)
+                    if (!idsdkNotInitialized && !mcpTokenValidationUnavailable)
                     {
                         ReOpenSavedExtensionOnDynamoStartup(ext);
                     }
@@ -3470,14 +3469,14 @@ namespace Dynamo.Controls
         }
 
         /// <summary>
-        /// Withholds the Autodesk Assistant and MCP View extensions when Autodesk Identity (IDSDK)
-        /// in this process cannot validate MCP bearer tokens. Without this, both extensions load and
-        /// look healthy while every MCP tool call is rejected with HTTP 401, which is a worse failure
-        /// mode than the feature simply not being offered (DYN-10773 / DYN-10775).
+        /// Prevents the Autodesk Assistant and MCP View extensions from being (re-)opened when
+        /// Autodesk Identity (IDSDK) in this process cannot validate MCP bearer tokens, so the user
+        /// is not led into a panel where every MCP tool call is rejected with HTTP 401 (DYN-10773).
         /// <para>
-        /// Deliberately shaped like <see cref="DisableExtensionWhenNoNetworkMode"/> rather than
-        /// <see cref="DisableExtensionWhenIDSDKNotInitialized"/>: this condition cannot be recovered
-        /// from within the session, so there is nothing useful to leave behind in the UI.
+        /// Deliberately shaped like <see cref="DisableExtensionWhenIDSDKNotInitialized"/> rather than
+        /// <see cref="DisableExtensionWhenNoNetworkMode"/>: <c>Startup()</c> and <c>Loaded()</c> still
+        /// run, so an extension keeps whatever UI it registers and can present its own disabled state.
+        /// Only opening the panel — and the automatic re-open of a previously-open one — is blocked.
         /// </para>
         /// <para>
         /// Blocks only on a definitive <see cref="McpTokenValidationAvailability.Unavailable"/>.
@@ -3487,8 +3486,8 @@ namespace Dynamo.Controls
         /// </summary>
         /// <param name="extensionId">Unique id of the extension being considered.</param>
         /// <param name="extensionName">Display name, used only for the log line.</param>
-        /// <param name="action">The action being suppressed, e.g. "added" or "loaded".</param>
-        /// <returns>True when the extension must not be offered.</returns>
+        /// <param name="action">The action being suppressed, e.g. "opened" or "re-opened".</param>
+        /// <returns>True when the extension's panel must not be opened.</returns>
         internal bool DisableExtensionWhenMcpTokenValidationUnavailable(string extensionId, string extensionName, string action)
         {
             if ((string.Equals(extensionId, AutodeskAssistantExtensionId, StringComparison.OrdinalIgnoreCase) ||

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1434,12 +1434,17 @@ namespace Dynamo.Controls
                     // (menu items, toolbar buttons) stays visible; only the automatic re-open of a
                     // previously-open panel is skipped. Extensions that depend on IDSDK are expected to
                     // gate their own entry points via ViewLoadedParams.IsIDSDKInitialized.
+                    //
+                    // The IDSDK check runs first and, as a side effect, forces IDSDK initialization —
+                    // so it must run before Loaded(). The MCP token-validation check is re-evaluated
+                    // immediately before the re-open decision instead, since its Unknown state is
+                    // deliberately re-probed on each call: if Loaded() is what causes the ADP wrapper
+                    // to finish mapping, that must be reflected before deciding whether to re-open.
                     var idsdkNotInitialized = DisableExtensionWhenIDSDKNotInitialized(ext.UniqueId, ext.Name, "re-opened");
-                    var mcpTokenValidationUnavailable = DisableExtensionWhenMcpTokenValidationUnavailable(ext.UniqueId, ext.Name, "re-opened");
 
                     ext.Loaded(loadedParams);
 
-                    if (!idsdkNotInitialized && !mcpTokenValidationUnavailable)
+                    if (!idsdkNotInitialized && !DisableExtensionWhenMcpTokenValidationUnavailable(ext.UniqueId, ext.Name, "re-opened"))
                     {
                         ReOpenSavedExtensionOnDynamoStartup(ext);
                     }

--- a/test/DynamoCoreWpfTests/DynamoViewMcpTokenValidationTests.cs
+++ b/test/DynamoCoreWpfTests/DynamoViewMcpTokenValidationTests.cs
@@ -110,8 +110,11 @@ namespace DynamoCoreWpfTests
             // call is blocked — only the MCP token validation gate can.
             IdsdkMcpTokenValidation.SetAvailabilityForTesting(McpTokenValidationAvailability.Unavailable);
 
+            // Real content rather than null: if the gate ever stops blocking, AddOrFocusExtensionControl
+            // goes on to use it, and a NullReferenceException here would mask the actual regression
+            // (the gate letting the extension through) behind a confusing failure.
             var stubExtension = new StubViewExtension(DynamoView.AutodeskAssistantExtensionId);
-            var result = View.AddOrFocusExtensionControl(stubExtension, null);
+            var result = View.AddOrFocusExtensionControl(stubExtension, new System.Windows.Controls.ContentControl());
 
             Assert.AreEqual(DynamoView.ExtensionControlResult.Blocked, result);
             Assert.IsFalse(ViewModel.SideBarTabItems

--- a/test/DynamoCoreWpfTests/DynamoViewMcpTokenValidationTests.cs
+++ b/test/DynamoCoreWpfTests/DynamoViewMcpTokenValidationTests.cs
@@ -9,8 +9,9 @@ namespace DynamoCoreWpfTests
 {
     /// <summary>
     /// Covers the DYN-10775 gate: when Autodesk Identity (IDSDK) in this process cannot validate
-    /// MCP bearer tokens, Autodesk Assistant and the MCP view extension must not be offered,
-    /// because every MCP tool call would be rejected with HTTP 401 (DYN-10773).
+    /// MCP bearer tokens, the Autodesk Assistant and MCP view extension panels must not be opened
+    /// or auto-re-opened, because every MCP tool call would be rejected with HTTP 401 (DYN-10773).
+    /// The extensions still load and register their own UI; only opening a panel is blocked.
     /// <para>
     /// These tests drive <see cref="IdsdkMcpTokenValidation"/> through its test seam rather than
     /// relying on the machine's real IDSDK. That is deliberate: the sibling
@@ -37,7 +38,7 @@ namespace DynamoCoreWpfTests
             var shouldDisable = View.DisableExtensionWhenMcpTokenValidationUnavailable(
                 DynamoView.AutodeskAssistantExtensionId,
                 "Autodesk Assistant",
-                "added");
+                "re-opened");
 
             Assert.IsTrue(shouldDisable);
         }
@@ -50,7 +51,7 @@ namespace DynamoCoreWpfTests
             var shouldDisable = View.DisableExtensionWhenMcpTokenValidationUnavailable(
                 DynamoView.McpViewExtensionId,
                 "Dynamo MCP View Extension",
-                "added");
+                "re-opened");
 
             Assert.IsTrue(shouldDisable);
         }
@@ -63,7 +64,7 @@ namespace DynamoCoreWpfTests
             var shouldDisable = View.DisableExtensionWhenMcpTokenValidationUnavailable(
                 DynamoView.AutodeskAssistantExtensionId,
                 "Autodesk Assistant",
-                "added");
+                "re-opened");
 
             Assert.IsFalse(shouldDisable);
         }
@@ -79,7 +80,7 @@ namespace DynamoCoreWpfTests
             var shouldDisable = View.DisableExtensionWhenMcpTokenValidationUnavailable(
                 DynamoView.AutodeskAssistantExtensionId,
                 "Autodesk Assistant",
-                "added");
+                "re-opened");
 
             Assert.IsFalse(shouldDisable);
         }
@@ -92,7 +93,7 @@ namespace DynamoCoreWpfTests
             var shouldDisable = View.DisableExtensionWhenMcpTokenValidationUnavailable(
                 UnrelatedExtensionId,
                 "Some Other Extension",
-                "added");
+                "re-opened");
 
             Assert.IsFalse(shouldDisable);
         }
@@ -117,26 +118,6 @@ namespace DynamoCoreWpfTests
                 .OfType<System.Windows.Controls.TabItem>()
                 .Any(t => string.Equals(t.Uid, DynamoView.AutodeskAssistantExtensionId,
                     StringComparison.OrdinalIgnoreCase)));
-        }
-
-        [Test]
-        public void WhenMcpTokenValidationIsUnavailableThenViewLoadedParamsReportsItUnavailable()
-        {
-            IdsdkMcpTokenValidation.SetAvailabilityForTesting(McpTokenValidationAvailability.Unavailable);
-
-            var loadedParams = new ViewLoadedParams(View, ViewModel);
-
-            Assert.IsFalse(loadedParams.IsMcpTokenValidationAvailable);
-        }
-
-        [Test]
-        public void WhenMcpTokenValidationIsUnknownThenViewLoadedParamsReportsItAvailable()
-        {
-            IdsdkMcpTokenValidation.SetAvailabilityForTesting(McpTokenValidationAvailability.Unknown);
-
-            var loadedParams = new ViewLoadedParams(View, ViewModel);
-
-            Assert.IsTrue(loadedParams.IsMcpTokenValidationAvailable);
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/DynamoViewMcpTokenValidationTests.cs
+++ b/test/DynamoCoreWpfTests/DynamoViewMcpTokenValidationTests.cs
@@ -24,6 +24,16 @@ namespace DynamoCoreWpfTests
     {
         private const string UnrelatedExtensionId = "11111111-1111-1111-1111-111111111111";
 
+        // Reset before each test as well as after. The probe result is process-global static
+        // state, so anything else in this assembly that sets it and fails to clean up would
+        // otherwise silently decide these tests' outcomes. NUnit runs the base fixture's
+        // [SetUp] Start() first, then this.
+        [SetUp]
+        public void ResetMcpTokenValidationProbeBeforeTest()
+        {
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(null);
+        }
+
         [TearDown]
         public void ResetMcpTokenValidationProbe()
         {
@@ -37,8 +47,7 @@ namespace DynamoCoreWpfTests
 
             var shouldDisable = View.DisableExtensionWhenMcpTokenValidationUnavailable(
                 DynamoView.AutodeskAssistantExtensionId,
-                "Autodesk Assistant",
-                "re-opened");
+                "Autodesk Assistant");
 
             Assert.IsTrue(shouldDisable);
         }
@@ -50,8 +59,7 @@ namespace DynamoCoreWpfTests
 
             var shouldDisable = View.DisableExtensionWhenMcpTokenValidationUnavailable(
                 DynamoView.McpViewExtensionId,
-                "Dynamo MCP View Extension",
-                "re-opened");
+                "Dynamo MCP View Extension");
 
             Assert.IsTrue(shouldDisable);
         }
@@ -63,8 +71,7 @@ namespace DynamoCoreWpfTests
 
             var shouldDisable = View.DisableExtensionWhenMcpTokenValidationUnavailable(
                 DynamoView.AutodeskAssistantExtensionId,
-                "Autodesk Assistant",
-                "re-opened");
+                "Autodesk Assistant");
 
             Assert.IsFalse(shouldDisable);
         }
@@ -79,8 +86,7 @@ namespace DynamoCoreWpfTests
 
             var shouldDisable = View.DisableExtensionWhenMcpTokenValidationUnavailable(
                 DynamoView.AutodeskAssistantExtensionId,
-                "Autodesk Assistant",
-                "re-opened");
+                "Autodesk Assistant");
 
             Assert.IsFalse(shouldDisable);
         }
@@ -92,8 +98,7 @@ namespace DynamoCoreWpfTests
 
             var shouldDisable = View.DisableExtensionWhenMcpTokenValidationUnavailable(
                 UnrelatedExtensionId,
-                "Some Other Extension",
-                "re-opened");
+                "Some Other Extension");
 
             Assert.IsFalse(shouldDisable);
         }

--- a/test/DynamoCoreWpfTests/DynamoViewMcpTokenValidationTests.cs
+++ b/test/DynamoCoreWpfTests/DynamoViewMcpTokenValidationTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Linq;
+using Dynamo.Controls;
+using Dynamo.Wpf.Extensions;
+using Dynamo.Wpf.Utilities;
+using NUnit.Framework;
+
+namespace DynamoCoreWpfTests
+{
+    /// <summary>
+    /// Covers the DYN-10775 gate: when Autodesk Identity (IDSDK) in this process cannot validate
+    /// MCP bearer tokens, Autodesk Assistant and the MCP view extension must not be offered,
+    /// because every MCP tool call would be rejected with HTTP 401 (DYN-10773).
+    /// <para>
+    /// These tests drive <see cref="IdsdkMcpTokenValidation"/> through its test seam rather than
+    /// relying on the machine's real IDSDK. That is deliberate: the sibling
+    /// <see cref="DynamoViewNoNetworkModeTests"/> fixture has no AuthProvider, so IDSDK is never
+    /// mapped into the process and a real probe would always report
+    /// <see cref="McpTokenValidationAvailability.Unknown"/> — which by design blocks nothing.
+    /// </para>
+    /// </summary>
+    public class DynamoViewMcpTokenValidationTests : DynamoTestUIBase
+    {
+        private const string UnrelatedExtensionId = "11111111-1111-1111-1111-111111111111";
+
+        [TearDown]
+        public void ResetMcpTokenValidationProbe()
+        {
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(null);
+        }
+
+        [Test]
+        public void WhenMcpTokenValidationIsUnavailableThenAutodeskAssistantExtensionIsDisabled()
+        {
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(McpTokenValidationAvailability.Unavailable);
+
+            var shouldDisable = View.DisableExtensionWhenMcpTokenValidationUnavailable(
+                DynamoView.AutodeskAssistantExtensionId,
+                "Autodesk Assistant",
+                "added");
+
+            Assert.IsTrue(shouldDisable);
+        }
+
+        [Test]
+        public void WhenMcpTokenValidationIsUnavailableThenMcpViewExtensionIsDisabled()
+        {
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(McpTokenValidationAvailability.Unavailable);
+
+            var shouldDisable = View.DisableExtensionWhenMcpTokenValidationUnavailable(
+                DynamoView.McpViewExtensionId,
+                "Dynamo MCP View Extension",
+                "added");
+
+            Assert.IsTrue(shouldDisable);
+        }
+
+        [Test]
+        public void WhenMcpTokenValidationIsAvailableThenAutodeskAssistantExtensionIsNotDisabled()
+        {
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(McpTokenValidationAvailability.Available);
+
+            var shouldDisable = View.DisableExtensionWhenMcpTokenValidationUnavailable(
+                DynamoView.AutodeskAssistantExtensionId,
+                "Autodesk Assistant",
+                "added");
+
+            Assert.IsFalse(shouldDisable);
+        }
+
+        [Test]
+        public void WhenMcpTokenValidationIsUnknownThenAutodeskAssistantExtensionIsNotDisabled()
+        {
+            // Unknown means AdskIdentitySDK.dll is not mapped into the process, so nothing can be
+            // concluded about the MCP validation API. The gate must fail open rather than withhold
+            // the Assistant on a guess.
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(McpTokenValidationAvailability.Unknown);
+
+            var shouldDisable = View.DisableExtensionWhenMcpTokenValidationUnavailable(
+                DynamoView.AutodeskAssistantExtensionId,
+                "Autodesk Assistant",
+                "added");
+
+            Assert.IsFalse(shouldDisable);
+        }
+
+        [Test]
+        public void WhenMcpTokenValidationIsUnavailableThenUnrelatedExtensionIsNotDisabled()
+        {
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(McpTokenValidationAvailability.Unavailable);
+
+            var shouldDisable = View.DisableExtensionWhenMcpTokenValidationUnavailable(
+                UnrelatedExtensionId,
+                "Some Other Extension",
+                "added");
+
+            Assert.IsFalse(shouldDisable);
+        }
+
+        [Test]
+        public void WhenMcpTokenValidationIsUnavailableThenAssistantTabCannotBeAddedViaSideBar()
+        {
+            // Covers the late-add path an extension reaches through
+            // ViewLoadedParams.AddToExtensionsSideBar(), which bypasses the extension-load guards.
+            //
+            // This fixture does not enable NoNetworkMode and its DynamoModel has no AuthProvider
+            // (so AuthenticationManager.IsIDSDKInitialized() is unconditionally true), which means
+            // neither of the other two guards in AddOrFocusExtensionControl can be the reason the
+            // call is blocked — only the MCP token validation gate can.
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(McpTokenValidationAvailability.Unavailable);
+
+            var stubExtension = new StubViewExtension(DynamoView.AutodeskAssistantExtensionId);
+            var result = View.AddOrFocusExtensionControl(stubExtension, null);
+
+            Assert.AreEqual(DynamoView.ExtensionControlResult.Blocked, result);
+            Assert.IsFalse(ViewModel.SideBarTabItems
+                .OfType<System.Windows.Controls.TabItem>()
+                .Any(t => string.Equals(t.Uid, DynamoView.AutodeskAssistantExtensionId,
+                    StringComparison.OrdinalIgnoreCase)));
+        }
+
+        [Test]
+        public void WhenMcpTokenValidationIsUnavailableThenViewLoadedParamsReportsItUnavailable()
+        {
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(McpTokenValidationAvailability.Unavailable);
+
+            var loadedParams = new ViewLoadedParams(View, ViewModel);
+
+            Assert.IsFalse(loadedParams.IsMcpTokenValidationAvailable);
+        }
+
+        [Test]
+        public void WhenMcpTokenValidationIsUnknownThenViewLoadedParamsReportsItAvailable()
+        {
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(McpTokenValidationAvailability.Unknown);
+
+            var loadedParams = new ViewLoadedParams(View, ViewModel);
+
+            Assert.IsTrue(loadedParams.IsMcpTokenValidationAvailable);
+        }
+
+        [Test]
+        public void WhenTestOverrideIsChangedThenTheCachedResultDoesNotShadowIt()
+        {
+            // Guards the seam itself. GetAvailability() caches a definitive answer, so a stale cache
+            // would make one test's setup silently determine the next test's outcome.
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(McpTokenValidationAvailability.Unavailable);
+            Assert.AreEqual(McpTokenValidationAvailability.Unavailable, IdsdkMcpTokenValidation.GetAvailability());
+
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(McpTokenValidationAvailability.Available);
+            Assert.AreEqual(McpTokenValidationAvailability.Available, IdsdkMcpTokenValidation.GetAvailability());
+        }
+
+        private class StubViewExtension : IViewExtension
+        {
+            public StubViewExtension(string uniqueId) { UniqueId = uniqueId; }
+            public string UniqueId { get; }
+            public string Name => "Stub";
+            public void Startup(ViewStartupParams p) { }
+            public void Loaded(ViewLoadedParams p) { }
+            public void Shutdown() { }
+            public void Dispose() { }
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

[DYN-10775](https://autodesk.atlassian.net/browse/DYN-10775) — follow-up to [DYN-10773](https://autodesk.atlassian.net/browse/DYN-10773).

When Tier 3 bearer-token validation cannot work, Autodesk Assistant still opens and looks healthy, but every MCP tool call returns HTTP 401. The user opens the panel, types a prompt, and gets an opaque failure. This was the user-facing shape of DYN-10773 (4.2.0 shipped with AA 100% broken in Sandbox).

**What this does.** When the gate trips, the Assistant and MCP view extension panels are not opened, and a previously-open panel is not auto-re-opened at startup. A log line states plainly which extension was withheld and why.

`Startup()` and `Loaded()` still run, so each extension keeps whatever UI it registers and can present its own disabled state. This deliberately matches the existing `DisableExtensionWhenIDSDKNotInitialized` gate rather than `DisableExtensionWhenNoNetworkMode`, which suppresses an extension outright. Withholding the feature completely, plus a deeper IDSDK health check, is deferred to 4.2.1.

**The signal: the export, not the version.**

The gate asks whether the `AdskIdentitySDK.dll` *actually mapped into this process* exports `idsdk_mcp_validate_token`. `AdpSDKIdentityWrapper.dll` reaches IDSDK via a base-name `LoadLibraryW("AdskIdentitySDK.dll")`, so it binds to whichever copy is already mapped — Dynamo's own in Sandbox, the host's under Revit. `GetModuleHandle` + `GetProcAddress` asks the identical question the identical way.

A version comparison would be actively wrong here: Revit carries an *unofficial* 1.16.4.7 with the MCP work backported, while *official* 1.16.5.1 — a higher version — lacks the API entirely. Different lineages, so a higher version number does not imply a superset of the API surface.

**Tri-state, fails open.** `Available` / `Unavailable` / `Unknown`. Only a definitive `Unavailable` blocks anything. `Unknown` (IDSDK never mapped into the process — no auth provider, or a host that doesn't initialize it) blocks nothing, so a panel is never withheld on a guess.

`AuthenticationManager.IsIDSDKInitialized()` was evaluated as the signal and is **not** sufficient — DYN-10773 is precisely the case where it returns true (Dynamo's IDSDK initialized fine, sign-in worked) while validation was structurally impossible. The two gates are orthogonal and both are retained.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

**No discretionary public API is added.** The gate and the capability probe are both internal. The single `PublicAPI.Unshipped.txt` entry is the auto-generated getter for the new localizable log string, which is unavoidable because `Dynamo.Wpf.Properties.Resources` is public:

- `static Dynamo.Wpf.Properties.Resources.ExtensionNotOfferedMcpTokenValidationUnavailable.get -> string`

An earlier revision also exposed `ViewLoadedParams.IsMcpTokenValidationAvailable` for the AA/DynamoMCP extensions to consume. It was removed: nothing but its own tests used it, and the intended consumer cannot compile against it until a Dynamo release ships — so it would have committed us to a shape before knowing what that consumer wants. It can be added when there is something to consume it.

### Release Notes

Autodesk Assistant and the Dynamo MCP view extension panels no longer open when Autodesk Identity in the running process cannot validate MCP tokens, instead of opening into a state where every request fails with an unexplained error.

### Reviewers

@RobertGlobant20

Testing: 7 tests in `test/DynamoCoreWpfTests/DynamoViewMcpTokenValidationTests.cs`, plus the 5 existing `DynamoViewNoNetworkModeTests` — 12/12 passing locally.

One note for review: `DynamoViewNoNetworkModeTests` deliberately neutralizes the IDSDK gate (see the comment at `:115-118` — that fixture has no `AuthProvider`, so `IsIDSDKInitialized()` is unconditionally true). A real IDSDK probe in tests would therefore always return `Unknown` and assert nothing. The new tests drive the probe through an explicit test seam instead, which also keeps them independent of whatever IDSDK the build agent happens to have installed.

The English log string is in `.resx`; localized strings follow separately and are not expected to make 4.2/4.2.1.

### FYIs

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)