### PR TITLE
DYN-10773: Bump Autodesk.IDSDK to 1.2.9

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Label="Common dependencies">
-    <PackageReference Include="Autodesk.IDSDK" Version="1.2.6" />
+    <PackageReference Include="Autodesk.IDSDK" Version="1.2.9" />
     <PackageReference Include="Greg" Version="3.0.2.8780" />
     <PackageReference Include="DynamoVisualProgramming.LibG_231_0_0" Version="4.0.0.5336" GeneratePathProperty="true" ExcludeAssets="all"/>
     <PackageReference Include="DynamoVisualProgramming.LibG_232_0_0" Version="4.0.0.5334" Condition=" '$(Configuration)' == 'Release' " GeneratePathProperty="true" ExcludeAssets="runtime"/>


### PR DESCRIPTION
### Purpose

Fixes [DYN-10773](https://autodesk.atlassian.net/browse/DYN-10773) — Autodesk Assistant is 100% broken in Dynamo Sandbox 4.2.0.5855.

**What's wrong**

Dynamo 4.2.0.5855 shipped `Autodesk.IDSDK` **1.2.6**, which carries native `AdskIdentitySDK.dll` **1.16.5.1**. That DLL **does not export `idsdk_mcp_validate_token`** — the IDSDK MCP validation APIs did not land until IDSDK **1.17.0**.

Consequence: DynamoMCP's Tier 3 bearer-token validation could never succeed. Every MCP tool call returned **HTTP 401**, so Autodesk Assistant was entirely non-functional in Dynamo Sandbox in the shipped build.

**The fix**

Bump `Autodesk.IDSDK` from **1.2.6** to **1.2.9** in `src/DynamoCore/DynamoCore.csproj`. 1.2.9 carries native **1.18.2.1**, which does export `idsdk_mcp_validate_token`.

**Why Dynamo for Revit was unaffected (and why this escaped testing)**

`AdpSDKIdentityWrapper.dll` reaches IDSDK through a base-name `LoadLibraryW("AdskIdentitySDK.dll")`, so it binds to whichever copy is already mapped into the process. Under Revit, that is Revit's own **1.16.4.7** — Dynamo's copy is never mapped at all. In Sandbox, Dynamo's copy is the only candidate, so the missing export is fatal.

**Why the version numbers are misleading (this was not a mistake by anyone)**

Revit's 1.16.4.7 is an *unofficial* build with the MCP work backported. 1.16.5.1 is a genuine *official* release that simply predates MCP. [DYN-10735](https://autodesk.atlassian.net/browse/DYN-10735) aligned Dynamo to the closest official version — but because the two builds sit on different lineages, the higher version number did not imply a superset of the API surface.

**Related**

- [DYN-10735](https://autodesk.atlassian.net/browse/DYN-10735) — the change that set 1.2.6.
- [DYN-10775](https://autodesk.atlassian.net/browse/DYN-10775) / #17291 — guards Autodesk Assistant when token validation is unavailable.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

Notes on the declarations:

- No public API surface changes — this is a single `PackageReference` version bump, so there is nothing to document in API Changes.
- Verified end-to-end against otherwise-unchanged shipped bits: **before** = 5 × HTTP 401 and 0 nodes produced; **after** = **0 × 401, 15 nodes, 28 connections**. Also manually verified sign-out → sign-in → Autodesk Assistant prompt succeeds.

### Release Notes

Fixed an issue where Autodesk Assistant failed with authorization errors and could not run in Dynamo Sandbox, caused by a bundled Autodesk identity component that was missing the token-validation API.

### Reviewers

@RobertGlobant20

Notes to reviewers/testers: the diff is a single line, but the behavior change is Sandbox-only — Dynamo for Revit is unaffected either way because it binds to Revit's already-loaded copy of `AdskIdentitySDK.dll`. To test, launch Dynamo Sandbox, sign in, and issue an Autodesk Assistant prompt that generates a graph; it should produce nodes rather than failing with 401s.

### FYIs

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
