### PR TITLE
DYN-10637: Bump DynamoVisualProgramming.AutodeskAssistant to [0.3.8]

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2244,7 +2244,7 @@
     different DynamoVisualProgramming.* API. Bump in lockstep with the AA release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.AutodeskAssistant" Version="[0.3.7]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.AutodeskAssistant" Version="[0.3.8]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
     The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_AutodeskAssistant)\bin IS


### PR DESCRIPTION
### Purpose

Primary ticket for this PR: **DYN-10637** (public, host-callable `RegistrationUtils` entry points, so a host add-in that starts the DynamoMCP server itself can own the `dynamo-mcp` registration on its own schedule instead of it existing only while Dynamo is open).

Consumes the **0.3.8** release of the Autodesk Assistant built-in package (`DynamoVisualProgramming.AutodeskAssistant`), now published to nuget.org. Bumps the exact-version bracket pin in `DynamoCoreWpf.csproj` from `[0.3.7]` -> `[0.3.8]`.

`0.3.8` folds in the following:

| Ticket | Summary |
| --- | --- |
| DYN-10637 | Adds public, host-callable `RegisterDynamoMcpAsync` / `UnregisterDynamoMcp` entry points plus a one-way `ClaimRegistration()` latch. A Revit add-in can now own the `dynamo-mcp` registration itself; when the latch is claimed the extension skips its own registration, so the two never both register and then race to remove it. The class references no Dynamo type, so a host can call it without loading `DynamoCore`/`DynamoCoreWpf`. Also renames the internal "headless MCP host" concept to "host-owned Assistant" — Revit was never headless, since the package still contributes the greyed-out placeholder button and Extensions-menu item there. |
| DYN-10774 | The Assistant panel now tracks the extensions sidebar instead of keeping its create-time size, so resizing, maximizing or splitter-dragging re-lays it out live. Regressed by DYN-10767/DYN-10768, which parented the Assistant to a holder that took it off the `HwndHost` window WPF resizes on every layout pass. |
| DYN-10771 | The `en-US` satellite resource assembly inside the package's `bin\` is now GARASIGN-signed. The signing list previously covered only `AutodeskAssistantViewExtension.dll`, so the satellite shipped unsigned (observed in Revit 2028 Dev preview installs). Note `AutodeskAssistantViewExtension.resources.dll` is already on `check_file_version.ps1`'s independent-version allowlist, so no change is needed there. |

No Dynamo-side API or behavioral change beyond what these AA-side changes deliver — this PR is the version pin only.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

The API declaration is satisfied trivially: this PR changes no Dynamo API surface. The new public surface is in the independently versioned AutodeskAssistant package, which is consumed with `ExcludeAssets="all"` (files only, no compile refs), so it is not part of Dynamo's API.

### Release Notes

Updated the built-in Autodesk Assistant package to 0.3.8: the Assistant panel now resizes with the extensions sidebar, hosts that ship their own Autodesk Assistant can register the DynamoMCP server on their own schedule, and the package's satellite resource assembly is now code-signed.

### Reviewers

(FILL ME IN) Reviewer 1 — pending assignment; suggest whoever reviewed the previous AutodeskAssistant bumps (#17285, #17274).

This is a one-line version-pin bump; the substantive review happened on the Dynamo-AutodeskAssistant side (Dynamo/Dynamo-AutodeskAssistant#49, #50, #52).

### FYIs

N/A
