### PR TITLE
DYN-10777: Fix RVA-to-offset span in IDSDK export check

### DIFF
--- a/.github/scripts/check_idsdk_exports.ps1
+++ b/.github/scripts/check_idsdk_exports.ps1
@@ -144,8 +144,10 @@ function Get-PEExportedName {
     $rvaToOffset = {
         param([uint32]$rva)
         foreach ($section in $sections) {
-            # VirtualSize can be 0 in object files; fall back to the raw size.
-            $span = if ($section.VirtualSize -gt 0) { $section.VirtualSize } else { $section.SizeOfRawData }
+            # VirtualSize can be smaller than SizeOfRawData due to file/section alignment padding
+            # (or 0 in object files), so a valid RVA can exceed VirtualSize but still fall inside
+            # the section's raw data. Use the larger of the two as the span.
+            $span = [Math]::Max($section.VirtualSize, $section.SizeOfRawData)
             if ($rva -ge $section.VirtualAddress -and $rva -lt ($section.VirtualAddress + $span)) {
                 return [int]($section.PointerToRawData + ($rva - $section.VirtualAddress))
             }


### PR DESCRIPTION
### Purpose

Follow-up to [DYN-10777](https://autodesk.atlassian.net/browse/DYN-10777) (#17295), addressing a Copilot review comment that landed after merge.

`Get-PEExportedName`'s `rvaToOffset` helper only fell back from `VirtualSize` to `SizeOfRawData` when `VirtualSize` was exactly `0`. `VirtualSize` can be smaller than `SizeOfRawData` due to section alignment padding, so a valid RVA could exceed `VirtualSize` while still falling inside the section's raw data — causing the CI guard to fail with `"RVA ... does not fall inside any section"` on an otherwise-valid DLL. Now uses `[Math]::Max($section.VirtualSize, $section.SizeOfRawData)` as the span.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

N/A — CI/build tooling only, no user-facing change.

### Reviewers

(FILL ME IN) Reviewer 1

### FYIs

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)