### PR TITLE
DYN-10776: Bump DynamoMCP to 0.5.7

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2219,7 +2219,7 @@
     different DynamoVisualProgramming.* API. Bump in lockstep with the DynamoMCP release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.5.6]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.5.7]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
     The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_DynamoMCP)\bin IS


### PR DESCRIPTION
## Purpose

Bumps the pinned `DynamoVisualProgramming.DynamoMCP` built-in package from **0.5.6** to **0.5.7**, released today from [Dynamo/DynamoMCP](https://git.autodesk.com/Dynamo/DynamoMCP/releases/tag/v0.5.7).

The reference is hard-pinned with bracket notation (`[x.y.z]`) so a transitive bump can't pull a DynamoMCP built against a different `DynamoVisualProgramming.*` API — it has to be bumped in lockstep with each DynamoMCP release.

## What's in DynamoMCP 0.5.7

- [DYN-10776](https://autodesk.atlassian.net/browse/DYN-10776) `Fixed` An IDSDK `status_code` of `3104` (`IDSDK_E_MCP_FAILED_TO_VALIDATE`) — Identity Manager having no usable JWKS public key, typically just after key rotation or a long idle period — turned a recoverable blip into a hard 401. `IdsdkValidator.Validate` now retries `3104` up to twice with a 120 ms / 380 ms backoff. Deterministic token verdicts (`3101` expired, `3103` `aud` mismatch, `3105` malformed) are still answered on the first round-trip.
- [DYN-10776](https://autodesk.atlassian.net/browse/DYN-10776) `Added` The MCP startup log now records which `AdskIdentitySDK.dll` copies are mapped into the process, with path and file version, and rejection diagnostics name the `idsdk_status_code` instead of logging a bare number.
- [DYN-10795](https://autodesk.atlassian.net/browse/DYN-10795) `Fixed` A graph saved with `save_workspace` reopened with its nodes stacked at the origin and its groups, notes and node renames gone. Saving now goes through the view model with `SaveContext.Save` so the `"View"` block is written, and the write is confirmed before reporting success.
- [DYN-10792](https://autodesk.atlassian.net/browse/DYN-10792) `Fixed` Node ports carried `portIndex` but no `portName`, forcing clients to infer an index from a name and silently miswiring Code Block nodes. `get_workspace_info` / `get_selection` now emit `portName` and `create_nodes` returns its nodes' ports. Additive.

## Declarations

- [x] The change is small and self-contained (one line).
- [x] `GeneratePathProperty="true"` and `ExcludeAssets="all"` are unchanged; the `BuildDynamoMcpDynamoPackage` target below copies the resolved package's `bin\` into `Built-In Packages\packages\DynamoMCP\` automatically.
