### PR TITLE
DYN-10778: Detect a missing ADP Desktop SDK in the MCP token validation gate

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3072,6 +3072,15 @@ namespace Dynamo.Wpf.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Package/Extension {0} not offered because the Autodesk ADP Desktop SDK is not installed ({1} could not be found), so MCP tokens cannot be validated; every request would be rejected with HTTP 401..
+        /// </summary>
+        public static string ExtensionNotOfferedAdpWrapperMissing {
+            get {
+                return ResourceManager.GetString("ExtensionNotOfferedAdpWrapperMissing", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Package/Extension {0} not {1} because Autodesk Identity (IDSDK) in this process cannot validate MCP tokens ({2} does not export {3}); every request would be rejected with HTTP 401..
         /// </summary>
         public static string ExtensionNotOfferedMcpTokenValidationUnavailable {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2328,6 +2328,10 @@ Do you want to install the latest Dynamo update?</value>
   <data name="ExtensionAlreadyPresent" xml:space="preserve">
     <value>No new tab is added, as the extension is already present in the extensions side bar.</value>
   </data>
+  <data name="ExtensionNotOfferedAdpWrapperMissing" xml:space="preserve">
+    <value>Package/Extension {0} not offered because the Autodesk ADP Desktop SDK is not installed ({1} could not be found), so MCP tokens cannot be validated; every request would be rejected with HTTP 401.</value>
+    <comment>{0} = extension name, {1} = native library file name. {1} is a technical identifier and must not be translated.</comment>
+  </data>
   <data name="ExtensionNotOfferedMcpTokenValidationUnavailable" xml:space="preserve">
     <value>Package/Extension {0} not offered because Autodesk Identity (IDSDK) in this process cannot validate MCP tokens ({1} does not export {2}); every request would be rejected with HTTP 401.</value>
     <comment>{0} = extension name, {1} = native library file name, {2} = native export name. {1} and {2} are technical identifiers and must not be translated.</comment>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2630,6 +2630,10 @@ Want to publish a different package?</value>
   <data name="ExtensionAlreadyPresent" xml:space="preserve">
     <value>No new tab is added, as the extension is already present in the extensions side bar.</value>
   </data>
+  <data name="ExtensionNotOfferedAdpWrapperMissing" xml:space="preserve">
+    <value>Package/Extension {0} not offered because the Autodesk ADP Desktop SDK is not installed ({1} could not be found), so MCP tokens cannot be validated; every request would be rejected with HTTP 401.</value>
+    <comment>{0} = extension name, {1} = native library file name. {1} is a technical identifier and must not be translated.</comment>
+  </data>
   <data name="ExtensionNotOfferedMcpTokenValidationUnavailable" xml:space="preserve">
     <value>Package/Extension {0} not offered because Autodesk Identity (IDSDK) in this process cannot validate MCP tokens ({1} does not export {2}); every request would be rejected with HTTP 401.</value>
     <comment>{0} = extension name, {1} = native library file name, {2} = native export name. {1} and {2} are technical identifiers and must not be translated.</comment>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 Dynamo.Wpf.Extensions.ViewLoadedParams.IsIDSDKInitialized.get -> bool
+static Dynamo.Wpf.Properties.Resources.ExtensionNotOfferedAdpWrapperMissing.get -> string
 static Dynamo.Wpf.Properties.Resources.ExtensionNotOfferedMcpTokenValidationUnavailable.get -> string
 Dynamo.Controls.NetworkStatusIconConverter
 Dynamo.Controls.NetworkStatusIconConverter.Convert(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object

--- a/src/DynamoCoreWpf/Utilities/IdsdkMcpTokenValidation.cs
+++ b/src/DynamoCoreWpf/Utilities/IdsdkMcpTokenValidation.cs
@@ -216,9 +216,11 @@ namespace Dynamo.Wpf.Utilities
         /// wrong in DYN-10773 — a probe must not be the thing that changes the answer.
         /// </para>
         /// <para>
-        /// Mirrors the search DynamoMCP's own <c>ResolveWrapperLibrary</c> performs: the default
-        /// OS search order first, then the canonical ADP Desktop SDK install path. Only a miss on
-        /// every one of them is treated as definitive, because this verdict withholds a feature.
+        /// Covers the same locations DynamoMCP's own <c>ResolveWrapperLibrary</c> can reach: the
+        /// default OS search path and the canonical ADP Desktop SDK install directory. The order
+        /// they are visited in carries no meaning here — this only asks whether the file exists
+        /// anywhere reachable, not which copy would win. Only a miss on every one of them is
+        /// treated as definitive, because this verdict withholds a feature.
         /// </para>
         /// </summary>
         private static bool IsAdpWrapperResolvable()
@@ -229,19 +231,16 @@ namespace Dynamo.Wpf.Utilities
                 return true;
             }
 
+            // No guard around the probe itself: Path.Join does not throw (unlike Path.Combine,
+            // which rejects a null segment) and File.Exists is documented to return false rather
+            // than throw for a malformed, too-long or unreadable path. A bad PATH entry therefore
+            // just fails to match instead of derailing the sweep.
             foreach (var directory in WrapperSearchDirectories())
             {
-                try
+                if (!string.IsNullOrWhiteSpace(directory) &&
+                    File.Exists(Path.Join(directory, AdpWrapperModuleName)))
                 {
-                    if (!string.IsNullOrWhiteSpace(directory) &&
-                        File.Exists(Path.Combine(directory, AdpWrapperModuleName)))
-                    {
-                        return true;
-                    }
-                }
-                catch (ArgumentException)
-                {
-                    // A malformed PATH entry is not evidence of anything; skip it.
+                    return true;
                 }
             }
 
@@ -271,7 +270,7 @@ namespace Dynamo.Wpf.Utilities
             var commonFiles = Environment.GetFolderPath(Environment.SpecialFolder.CommonProgramFiles);
             if (!string.IsNullOrEmpty(commonFiles))
             {
-                yield return Path.Combine(commonFiles, "Autodesk", "AdpDesktopSDK", "bin");
+                yield return Path.Join(commonFiles, "Autodesk", "AdpDesktopSDK", "bin");
             }
 
             var path = Environment.GetEnvironmentVariable("PATH");

--- a/src/DynamoCoreWpf/Utilities/IdsdkMcpTokenValidation.cs
+++ b/src/DynamoCoreWpf/Utilities/IdsdkMcpTokenValidation.cs
@@ -251,38 +251,30 @@ namespace Dynamo.Wpf.Utilities
         /// <summary>
         /// Directories a base-name DLL load would search, in roughly the order Windows uses,
         /// plus the ADP Desktop SDK's canonical install location.
+        /// <para>
+        /// The individual environment lookups are deliberately left unguarded. This iterator runs
+        /// inside <see cref="Probe"/>'s <c>try</c>, so anything that throws here surfaces as
+        /// <see cref="McpTokenValidationAvailability.Unknown"/> and fails open. Catching locally
+        /// would be worse than useless: the sweep would carry on with a silently truncated search
+        /// path and could then report the wrapper "absent", withholding a feature on the strength
+        /// of a search that never actually ran.
+        /// </para>
         /// </summary>
         private static IEnumerable<string> WrapperSearchDirectories()
         {
             yield return AppContext.BaseDirectory;
             yield return AppDomain.CurrentDomain.BaseDirectory;
-
-            string systemDirectory = null;
-            try { systemDirectory = Environment.SystemDirectory; } catch (Exception) { }
-            if (systemDirectory != null)
-            {
-                yield return systemDirectory;
-            }
+            yield return Environment.SystemDirectory;
 
             // C:\Program Files\Common Files\Autodesk\AdpDesktopSDK\bin — not on the default DLL
             // search order, which is why DynamoMCP installs a resolver to reach it explicitly.
-            string adpPath = null;
-            try
+            var commonFiles = Environment.GetFolderPath(Environment.SpecialFolder.CommonProgramFiles);
+            if (!string.IsNullOrEmpty(commonFiles))
             {
-                var commonFiles = Environment.GetFolderPath(Environment.SpecialFolder.CommonProgramFiles);
-                if (!string.IsNullOrEmpty(commonFiles))
-                {
-                    adpPath = Path.Combine(commonFiles, "Autodesk", "AdpDesktopSDK", "bin");
-                }
-            }
-            catch (Exception) { }
-            if (adpPath != null)
-            {
-                yield return adpPath;
+                yield return Path.Combine(commonFiles, "Autodesk", "AdpDesktopSDK", "bin");
             }
 
-            string path = null;
-            try { path = Environment.GetEnvironmentVariable("PATH"); } catch (Exception) { }
+            var path = Environment.GetEnvironmentVariable("PATH");
             if (!string.IsNullOrEmpty(path))
             {
                 foreach (var entry in path.Split(Path.PathSeparator))

--- a/src/DynamoCoreWpf/Utilities/IdsdkMcpTokenValidation.cs
+++ b/src/DynamoCoreWpf/Utilities/IdsdkMcpTokenValidation.cs
@@ -118,11 +118,24 @@ namespace Dynamo.Wpf.Utilities
         internal static McpTokenValidationAvailability GetAvailability() => Evaluate().Availability;
 
         /// <summary>
-        /// Why validation is unavailable, for the caller's log message.
-        /// <see cref="McpTokenValidationUnavailableReason.None"/> when validation is available
-        /// or availability could not be determined.
+        /// Availability and, when unavailable, why — read together in a single evaluation.
+        /// <para>
+        /// Callers that need both must use this rather than pairing <see cref="GetAvailability"/>
+        /// with a separate reason lookup. Two calls are two evaluations, and the two outcomes that
+        /// are deliberately not cached — <see cref="McpTokenValidationUnavailableReason.AdpWrapperMissing"/>
+        /// and <see cref="McpTokenValidationAvailability.Unknown"/> — re-probe every time. Those are
+        /// precisely the states a caller needs the reason for, so a split read can pair an
+        /// <c>Unavailable</c> verdict with a reason from a later probe that no longer agrees: the
+        /// wrong cause gets logged, or worse, an extension is withheld on a verdict a concurrent
+        /// re-check would have called <c>Unknown</c> and failed open on.
+        /// </para>
+        /// <para>
+        /// <see cref="McpTokenValidationUnavailableReason.None"/> when validation is available or
+        /// availability could not be determined.
+        /// </para>
         /// </summary>
-        internal static McpTokenValidationUnavailableReason GetUnavailableReason() => Evaluate().Reason;
+        internal static (McpTokenValidationAvailability Availability, McpTokenValidationUnavailableReason Reason) GetStatus()
+            => Evaluate();
 
         private static (McpTokenValidationAvailability Availability, McpTokenValidationUnavailableReason Reason) Evaluate()
         {

--- a/src/DynamoCoreWpf/Utilities/IdsdkMcpTokenValidation.cs
+++ b/src/DynamoCoreWpf/Utilities/IdsdkMcpTokenValidation.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace Dynamo.Wpf.Utilities
@@ -16,8 +18,9 @@ namespace Dynamo.Wpf.Utilities
         Available,
 
         /// <summary>
-        /// AdskIdentitySDK.dll is mapped into this process but does not export the MCP
-        /// validation entry point. Every MCP tool call will be rejected with HTTP 401.
+        /// Bearer-token validation cannot run in this process. Every MCP tool call will be
+        /// rejected with HTTP 401. See <see cref="McpTokenValidationUnavailableReason"/> for
+        /// which of the two causes applies.
         /// </summary>
         Unavailable,
 
@@ -26,6 +29,30 @@ namespace Dynamo.Wpf.Utilities
         /// determined. Callers must treat this as "don't know", never as a failure.
         /// </summary>
         Unknown
+    }
+
+    /// <summary>
+    /// Why MCP bearer-token validation is unavailable. The two causes are independent and
+    /// produce different guidance, so they are reported separately rather than collapsed
+    /// into a single message that would be wrong for one of them.
+    /// </summary>
+    internal enum McpTokenValidationUnavailableReason
+    {
+        /// <summary>Validation is available, or availability could not be determined.</summary>
+        None,
+
+        /// <summary>
+        /// AdskIdentitySDK.dll is mapped but does not export the MCP validation entry point.
+        /// The DYN-10773 cause: an IDSDK build predating the MCP validation API.
+        /// </summary>
+        IdsdkExportMissing,
+
+        /// <summary>
+        /// AdpSDKIdentityWrapper.dll cannot be found at all, so the ADP Desktop SDK is not
+        /// installed. DynamoMCP P/Invokes that wrapper directly; without it Tier 3 validation
+        /// never runs, whatever state IDSDK itself is in.
+        /// </summary>
+        AdpWrapperMissing
     }
 
     /// <summary>
@@ -48,11 +75,23 @@ namespace Dynamo.Wpf.Utilities
     /// A higher version number does not imply a superset of the API surface, so only the
     /// presence of the export is a sound signal (DYN-10773).
     /// </para>
+    /// <para>
+    /// The export check alone has a blind spot, which is what DYN-10778 adds the wrapper check
+    /// for: if the ADP Desktop SDK is not installed, <c>AdpSDKIdentityWrapper.dll</c> never
+    /// resolves and validation is dead — but IDSDK itself is perfectly healthy and exports the
+    /// entry point, so the export probe reports <see cref="McpTokenValidationAvailability.Available"/>.
+    /// </para>
     /// </summary>
     internal static class IdsdkMcpTokenValidation
     {
         /// <summary>Base name of the native Autodesk Identity library.</summary>
         internal const string IdsdkModuleName = "AdskIdentitySDK.dll";
+
+        /// <summary>
+        /// The ADP Desktop SDK wrapper DynamoMCP P/Invokes to reach IDSDK. Ships with the ADP
+        /// Desktop SDK, not with Dynamo.
+        /// </summary>
+        internal const string AdpWrapperModuleName = "AdpSDKIdentityWrapper.dll";
 
         /// <summary>
         /// The IDSDK export DynamoMCP's Tier 3 validation ultimately depends on. Introduced in
@@ -62,37 +101,56 @@ namespace Dynamo.Wpf.Utilities
 
         private static readonly object syncRoot = new object();
 
-        // Only a definitive result is cached. Unknown means AdskIdentitySDK.dll was not mapped
-        // yet, which can change later in the session, so it must stay re-probeable.
-        private static McpTokenValidationAvailability? cachedAvailability;
+        // Only a permanently-definitive result is cached. Unknown means AdskIdentitySDK.dll was
+        // not mapped yet, and AdpWrapperMissing means a file was not on disk yet — both can
+        // change later in the session, so they must stay re-probeable.
+        private static (McpTokenValidationAvailability Availability, McpTokenValidationUnavailableReason Reason)? cachedResult;
 
         private static McpTokenValidationAvailability? testOverride;
+        private static McpTokenValidationUnavailableReason testOverrideReason;
 
         /// <summary>
         /// Returns whether IDSDK in this process can service an MCP token validation call.
-        /// Cheap and safe to call repeatedly; a definitive answer is computed once and cached.
+        /// Cheap and safe to call repeatedly; a permanently-definitive answer is computed once
+        /// and cached.
         /// </summary>
-        internal static McpTokenValidationAvailability GetAvailability()
+        internal static McpTokenValidationAvailability GetAvailability() => Evaluate().Availability;
+
+        /// <summary>
+        /// Why validation is unavailable, for the caller's log message.
+        /// <see cref="McpTokenValidationUnavailableReason.None"/> when validation is available
+        /// or availability could not be determined.
+        /// </summary>
+        internal static McpTokenValidationUnavailableReason GetUnavailableReason() => Evaluate().Reason;
+
+        private static (McpTokenValidationAvailability Availability, McpTokenValidationUnavailableReason Reason) Evaluate()
         {
             lock (syncRoot)
             {
                 if (testOverride.HasValue)
                 {
-                    return testOverride.Value;
+                    return (testOverride.Value,
+                        testOverride.Value == McpTokenValidationAvailability.Unavailable
+                            ? testOverrideReason
+                            : McpTokenValidationUnavailableReason.None);
                 }
 
-                if (cachedAvailability.HasValue)
+                if (cachedResult.HasValue)
                 {
-                    return cachedAvailability.Value;
+                    return cachedResult.Value;
                 }
 
-                var availability = Probe();
-                if (availability != McpTokenValidationAvailability.Unknown)
+                var result = Probe();
+
+                // A missing DLL can be installed, and an unmapped IDSDK can be mapped, without
+                // restarting Dynamo. Only "mapped but no export" is settled for the session.
+                if (result.Reason == McpTokenValidationUnavailableReason.IdsdkExportMissing ||
+                    result.Availability == McpTokenValidationAvailability.Available)
                 {
-                    cachedAvailability = availability;
+                    cachedResult = result;
                 }
 
-                return availability;
+                return result;
             }
         }
 
@@ -102,35 +160,135 @@ namespace Dynamo.Wpf.Utilities
         /// so a test cannot be contaminated by an earlier one.
         /// </summary>
         /// <param name="availability">Value to report, or <c>null</c> to resume real probing.</param>
-        internal static void SetAvailabilityForTesting(McpTokenValidationAvailability? availability)
+        /// <param name="reason">Reason to report alongside
+        /// <see cref="McpTokenValidationAvailability.Unavailable"/>; ignored otherwise.</param>
+        internal static void SetAvailabilityForTesting(
+            McpTokenValidationAvailability? availability,
+            McpTokenValidationUnavailableReason reason = McpTokenValidationUnavailableReason.IdsdkExportMissing)
         {
             lock (syncRoot)
             {
                 testOverride = availability;
-                cachedAvailability = null;
+                testOverrideReason = reason;
+                cachedResult = null;
             }
         }
 
-        private static McpTokenValidationAvailability Probe()
+        private static (McpTokenValidationAvailability Availability, McpTokenValidationUnavailableReason Reason) Probe()
         {
             try
             {
+                // Checked first, and independently of IDSDK's own state: DynamoMCP P/Invokes the
+                // wrapper, so if the wrapper cannot be found nothing downstream matters. This is
+                // the failure mode the export check alone cannot see — IDSDK is healthy and
+                // exports the entry point, but there is no wrapper to reach it through.
+                if (!IsAdpWrapperResolvable())
+                {
+                    return (McpTokenValidationAvailability.Unavailable,
+                        McpTokenValidationUnavailableReason.AdpWrapperMissing);
+                }
+
                 var module = GetModuleHandle(IdsdkModuleName);
                 if (module == IntPtr.Zero)
                 {
                     // Nothing has mapped IDSDK yet (no auth provider, or a host that never
                     // initializes it). We cannot tell, so we must not block anything.
-                    return McpTokenValidationAvailability.Unknown;
+                    return (McpTokenValidationAvailability.Unknown,
+                        McpTokenValidationUnavailableReason.None);
                 }
 
                 return GetProcAddress(module, McpValidateTokenExport) != IntPtr.Zero
-                    ? McpTokenValidationAvailability.Available
-                    : McpTokenValidationAvailability.Unavailable;
+                    ? (McpTokenValidationAvailability.Available, McpTokenValidationUnavailableReason.None)
+                    : (McpTokenValidationAvailability.Unavailable, McpTokenValidationUnavailableReason.IdsdkExportMissing);
             }
             catch (Exception)
             {
                 // A probe that cannot run is not evidence that validation is broken.
-                return McpTokenValidationAvailability.Unknown;
+                return (McpTokenValidationAvailability.Unknown, McpTokenValidationUnavailableReason.None);
+            }
+        }
+
+        /// <summary>
+        /// Whether <c>AdpSDKIdentityWrapper.dll</c> could be loaded if something asked for it.
+        /// <para>
+        /// Deliberately looks the DLL up rather than loading it. Loading would map a new module
+        /// into the process purely to run a diagnostic, and load order is exactly what went
+        /// wrong in DYN-10773 — a probe must not be the thing that changes the answer.
+        /// </para>
+        /// <para>
+        /// Mirrors the search DynamoMCP's own <c>ResolveWrapperLibrary</c> performs: the default
+        /// OS search order first, then the canonical ADP Desktop SDK install path. Only a miss on
+        /// every one of them is treated as definitive, because this verdict withholds a feature.
+        /// </para>
+        /// </summary>
+        private static bool IsAdpWrapperResolvable()
+        {
+            // Already mapped — e.g. Autodesk Assistant is up and the ADP SDK pulled it in.
+            if (GetModuleHandle(AdpWrapperModuleName) != IntPtr.Zero)
+            {
+                return true;
+            }
+
+            foreach (var directory in WrapperSearchDirectories())
+            {
+                try
+                {
+                    if (!string.IsNullOrWhiteSpace(directory) &&
+                        File.Exists(Path.Combine(directory, AdpWrapperModuleName)))
+                    {
+                        return true;
+                    }
+                }
+                catch (ArgumentException)
+                {
+                    // A malformed PATH entry is not evidence of anything; skip it.
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Directories a base-name DLL load would search, in roughly the order Windows uses,
+        /// plus the ADP Desktop SDK's canonical install location.
+        /// </summary>
+        private static IEnumerable<string> WrapperSearchDirectories()
+        {
+            yield return AppContext.BaseDirectory;
+            yield return AppDomain.CurrentDomain.BaseDirectory;
+
+            string systemDirectory = null;
+            try { systemDirectory = Environment.SystemDirectory; } catch (Exception) { }
+            if (systemDirectory != null)
+            {
+                yield return systemDirectory;
+            }
+
+            // C:\Program Files\Common Files\Autodesk\AdpDesktopSDK\bin — not on the default DLL
+            // search order, which is why DynamoMCP installs a resolver to reach it explicitly.
+            string adpPath = null;
+            try
+            {
+                var commonFiles = Environment.GetFolderPath(Environment.SpecialFolder.CommonProgramFiles);
+                if (!string.IsNullOrEmpty(commonFiles))
+                {
+                    adpPath = Path.Combine(commonFiles, "Autodesk", "AdpDesktopSDK", "bin");
+                }
+            }
+            catch (Exception) { }
+            if (adpPath != null)
+            {
+                yield return adpPath;
+            }
+
+            string path = null;
+            try { path = Environment.GetEnvironmentVariable("PATH"); } catch (Exception) { }
+            if (!string.IsNullOrEmpty(path))
+            {
+                foreach (var entry in path.Split(Path.PathSeparator))
+                {
+                    yield return entry.Trim();
+                }
             }
         }
 

--- a/src/DynamoCoreWpf/Utilities/IdsdkMcpTokenValidation.cs
+++ b/src/DynamoCoreWpf/Utilities/IdsdkMcpTokenValidation.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace Dynamo.Wpf.Utilities
@@ -235,16 +236,12 @@ namespace Dynamo.Wpf.Utilities
             // which rejects a null segment) and File.Exists is documented to return false rather
             // than throw for a malformed, too-long or unreadable path. A bad PATH entry therefore
             // just fails to match instead of derailing the sweep.
-            foreach (var directory in WrapperSearchDirectories())
-            {
-                if (!string.IsNullOrWhiteSpace(directory) &&
-                    File.Exists(Path.Join(directory, AdpWrapperModuleName)))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            //
+            // Where/Any both stream, so this still stops at the first hit rather than materialising
+            // the whole search path.
+            return WrapperSearchDirectories()
+                .Where(directory => !string.IsNullOrWhiteSpace(directory))
+                .Any(directory => File.Exists(Path.Join(directory, AdpWrapperModuleName)));
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -3494,6 +3494,13 @@ namespace Dynamo.Controls
         /// <see cref="McpTokenValidationAvailability.Unknown"/> — IDSDK not mapped into the process,
         /// so nothing can be concluded — deliberately fails open.
         /// </para>
+        /// <para>
+        /// Two distinct causes reach the blocking branch, and they are logged differently
+        /// (DYN-10778): an IDSDK that does not export the MCP validation entry point, and an ADP
+        /// Desktop SDK that is not installed at all, so <c>AdpSDKIdentityWrapper.dll</c> — the
+        /// library DynamoMCP actually P/Invokes — never resolves. The second is invisible to the
+        /// export probe, because IDSDK itself is healthy in that case.
+        /// </para>
         /// </summary>
         /// <param name="extensionId">Unique id of the extension being considered.</param>
         /// <param name="extensionName">Display name, used only for the log line.</param>
@@ -3504,12 +3511,21 @@ namespace Dynamo.Controls
                  string.Equals(extensionId, McpViewExtensionId, StringComparison.OrdinalIgnoreCase)) &&
                 IdsdkMcpTokenValidation.GetAvailability() == McpTokenValidationAvailability.Unavailable)
             {
-                Log(string.Format(
-                    CultureInfo.CurrentCulture,
-                    Res.ExtensionNotOfferedMcpTokenValidationUnavailable,
-                    extensionName,
-                    IdsdkMcpTokenValidation.IdsdkModuleName,
-                    IdsdkMcpTokenValidation.McpValidateTokenExport));
+                // The two causes need different guidance: one is an out-of-date Identity Manager,
+                // the other a missing ADP Desktop SDK install. Reporting the export message for a
+                // wrapper that is not on disk at all would send the reader after the wrong thing.
+                Log(IdsdkMcpTokenValidation.GetUnavailableReason() == McpTokenValidationUnavailableReason.AdpWrapperMissing
+                    ? string.Format(
+                        CultureInfo.CurrentCulture,
+                        Res.ExtensionNotOfferedAdpWrapperMissing,
+                        extensionName,
+                        IdsdkMcpTokenValidation.AdpWrapperModuleName)
+                    : string.Format(
+                        CultureInfo.CurrentCulture,
+                        Res.ExtensionNotOfferedMcpTokenValidationUnavailable,
+                        extensionName,
+                        IdsdkMcpTokenValidation.IdsdkModuleName,
+                        IdsdkMcpTokenValidation.McpValidateTokenExport));
 
                 return true;
             }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -3507,14 +3507,24 @@ namespace Dynamo.Controls
         /// <returns>True when the extension's panel must not be opened.</returns>
         internal bool DisableExtensionWhenMcpTokenValidationUnavailable(string extensionId, string extensionName)
         {
-            if ((string.Equals(extensionId, AutodeskAssistantExtensionId, StringComparison.OrdinalIgnoreCase) ||
-                 string.Equals(extensionId, McpViewExtensionId, StringComparison.OrdinalIgnoreCase)) &&
-                IdsdkMcpTokenValidation.GetAvailability() == McpTokenValidationAvailability.Unavailable)
+            if (!string.Equals(extensionId, AutodeskAssistantExtensionId, StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(extensionId, McpViewExtensionId, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            // Read the verdict and its cause in one evaluation. Asking for them separately would
+            // run two probes, and the states that matter here are deliberately not cached, so the
+            // second could disagree with the first — logging a cause that no longer applies, or
+            // withholding an extension on a verdict a re-check would have failed open on.
+            var (availability, reason) = IdsdkMcpTokenValidation.GetStatus();
+
+            if (availability == McpTokenValidationAvailability.Unavailable)
             {
                 // The two causes need different guidance: one is an out-of-date Identity Manager,
                 // the other a missing ADP Desktop SDK install. Reporting the export message for a
                 // wrapper that is not on disk at all would send the reader after the wrong thing.
-                Log(IdsdkMcpTokenValidation.GetUnavailableReason() == McpTokenValidationUnavailableReason.AdpWrapperMissing
+                Log(reason == McpTokenValidationUnavailableReason.AdpWrapperMissing
                     ? string.Format(
                         CultureInfo.CurrentCulture,
                         Res.ExtensionNotOfferedAdpWrapperMissing,

--- a/test/DynamoCoreWpfTests/DynamoViewMcpTokenValidationTests.cs
+++ b/test/DynamoCoreWpfTests/DynamoViewMcpTokenValidationTests.cs
@@ -157,14 +157,14 @@ namespace DynamoCoreWpfTests
                 McpTokenValidationUnavailableReason.AdpWrapperMissing);
 
             Assert.AreEqual(McpTokenValidationUnavailableReason.AdpWrapperMissing,
-                IdsdkMcpTokenValidation.GetUnavailableReason());
+                IdsdkMcpTokenValidation.GetStatus().Reason);
 
             IdsdkMcpTokenValidation.SetAvailabilityForTesting(
                 McpTokenValidationAvailability.Unavailable,
                 McpTokenValidationUnavailableReason.IdsdkExportMissing);
 
             Assert.AreEqual(McpTokenValidationUnavailableReason.IdsdkExportMissing,
-                IdsdkMcpTokenValidation.GetUnavailableReason());
+                IdsdkMcpTokenValidation.GetStatus().Reason);
         }
 
         [Test]
@@ -177,14 +177,51 @@ namespace DynamoCoreWpfTests
                 McpTokenValidationUnavailableReason.AdpWrapperMissing);
 
             Assert.AreEqual(McpTokenValidationUnavailableReason.None,
-                IdsdkMcpTokenValidation.GetUnavailableReason());
+                IdsdkMcpTokenValidation.GetStatus().Reason);
 
             IdsdkMcpTokenValidation.SetAvailabilityForTesting(
                 McpTokenValidationAvailability.Unknown,
                 McpTokenValidationUnavailableReason.AdpWrapperMissing);
 
             Assert.AreEqual(McpTokenValidationUnavailableReason.None,
-                IdsdkMcpTokenValidation.GetUnavailableReason());
+                IdsdkMcpTokenValidation.GetStatus().Reason);
+        }
+
+        [Test]
+        public void GetStatusReturnsAVerdictAndItsCauseFromASingleEvaluation()
+        {
+            // Reading availability and reason through separate calls would be two evaluations, and
+            // AdpWrapperMissing / Unknown are deliberately not cached — so the second could re-probe
+            // and disagree with the first, logging a cause that no longer applies or withholding an
+            // extension on a verdict a re-check would have failed open on. GetStatus must therefore
+            // always hand back a self-consistent pair: a reason implies Unavailable, and every other
+            // availability implies None.
+            foreach (var availability in new[]
+                     {
+                         McpTokenValidationAvailability.Available,
+                         McpTokenValidationAvailability.Unavailable,
+                         McpTokenValidationAvailability.Unknown,
+                     })
+            {
+                IdsdkMcpTokenValidation.SetAvailabilityForTesting(
+                    availability,
+                    McpTokenValidationUnavailableReason.AdpWrapperMissing);
+
+                var status = IdsdkMcpTokenValidation.GetStatus();
+
+                Assert.AreEqual(availability, status.Availability);
+
+                if (availability == McpTokenValidationAvailability.Unavailable)
+                {
+                    Assert.AreNotEqual(McpTokenValidationUnavailableReason.None, status.Reason,
+                        "An Unavailable verdict must carry the cause that produced it.");
+                }
+                else
+                {
+                    Assert.AreEqual(McpTokenValidationUnavailableReason.None, status.Reason,
+                        "A reason must never accompany anything other than Unavailable.");
+                }
+            }
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/DynamoViewMcpTokenValidationTests.cs
+++ b/test/DynamoCoreWpfTests/DynamoViewMcpTokenValidationTests.cs
@@ -129,6 +129,79 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void WhenAdpWrapperIsMissingThenAutodeskAssistantExtensionIsDisabled()
+        {
+            // DYN-10778 AC 6. The export probe cannot see this case: IDSDK itself is healthy and
+            // exports idsdk_mcp_validate_token, but the ADP Desktop SDK is not installed, so
+            // AdpSDKIdentityWrapper.dll — the library DynamoMCP actually P/Invokes — never
+            // resolves and every MCP call is rejected with HTTP 401 regardless.
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(
+                McpTokenValidationAvailability.Unavailable,
+                McpTokenValidationUnavailableReason.AdpWrapperMissing);
+
+            var shouldDisable = View.DisableExtensionWhenMcpTokenValidationUnavailable(
+                DynamoView.AutodeskAssistantExtensionId,
+                "Autodesk Assistant");
+
+            Assert.IsTrue(shouldDisable);
+        }
+
+        [Test]
+        public void WhenAdpWrapperIsMissingThenTheReasonIsReportedSeparately()
+        {
+            // The two causes need different guidance — an out-of-date Identity Manager versus a
+            // missing ADP Desktop SDK install. Collapsing them would send whoever reads the log
+            // after the wrong thing.
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(
+                McpTokenValidationAvailability.Unavailable,
+                McpTokenValidationUnavailableReason.AdpWrapperMissing);
+
+            Assert.AreEqual(McpTokenValidationUnavailableReason.AdpWrapperMissing,
+                IdsdkMcpTokenValidation.GetUnavailableReason());
+
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(
+                McpTokenValidationAvailability.Unavailable,
+                McpTokenValidationUnavailableReason.IdsdkExportMissing);
+
+            Assert.AreEqual(McpTokenValidationUnavailableReason.IdsdkExportMissing,
+                IdsdkMcpTokenValidation.GetUnavailableReason());
+        }
+
+        [Test]
+        public void WhenValidationIsAvailableOrUnknownThenNoUnavailableReasonIsReported()
+        {
+            // A reason only means something alongside Unavailable. Leaking a stale one would let
+            // a caller log "ADP SDK missing" for a process where validation works.
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(
+                McpTokenValidationAvailability.Available,
+                McpTokenValidationUnavailableReason.AdpWrapperMissing);
+
+            Assert.AreEqual(McpTokenValidationUnavailableReason.None,
+                IdsdkMcpTokenValidation.GetUnavailableReason());
+
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(
+                McpTokenValidationAvailability.Unknown,
+                McpTokenValidationUnavailableReason.AdpWrapperMissing);
+
+            Assert.AreEqual(McpTokenValidationUnavailableReason.None,
+                IdsdkMcpTokenValidation.GetUnavailableReason());
+        }
+
+        [Test]
+        public void WhenAdpWrapperIsMissingThenUnrelatedExtensionIsNotDisabled()
+        {
+            IdsdkMcpTokenValidation.SetAvailabilityForTesting(
+                McpTokenValidationAvailability.Unavailable,
+                McpTokenValidationUnavailableReason.AdpWrapperMissing);
+
+            var shouldDisable = View.DisableExtensionWhenMcpTokenValidationUnavailable(
+                UnrelatedExtensionId,
+                "Some Other Extension");
+
+            Assert.IsFalse(shouldDisable);
+        }
+
+        [Test]
         public void WhenTestOverrideIsChangedThenTheCachedResultDoesNotShadowIt()
         {
             // Guards the seam itself. GetAvailability() caches a definitive answer, so a stale cache


### PR DESCRIPTION
### Purpose

Part of [DYN-10778](https://autodesk.atlassian.net/browse/DYN-10778), AC 6.

The [DYN-10775 gate](https://github.com/DynamoDS/Dynamo/pull/17291) asks one question: is `AdskIdentitySDK.dll` mapped, and does it export `idsdk_mcp_validate_token`? That catches the [DYN-10773](https://autodesk.atlassian.net/browse/DYN-10773) cause, but it has a blind spot.

DynamoMCP does not P/Invoke IDSDK directly — it P/Invokes **`AdpSDKIdentityWrapper.dll`**, which ships with the ADP Desktop SDK, and the wrapper reaches IDSDK from there. If the ADP Desktop SDK is not installed, that wrapper never resolves and Tier 3 validation is dead — **yet IDSDK itself is perfectly healthy and exports the entry point**, so the probe reports `Available` and the gate opens a panel where every MCP tool call is rejected with HTTP 401.

This PR adds a wrapper-resolvability check to the probe, mirroring the search DynamoMCP's own `ResolveWrapperLibrary` performs: the default OS search order, then the canonical ADP Desktop SDK install path under Common Files.

Three details worth a reviewer's attention:

- **It looks the DLL up rather than loading it.** Loading would map a module into the process purely to run a diagnostic, and load order is exactly what went wrong in DYN-10773 — a probe must not be the thing that changes the answer.
- **The two causes are reported separately** (`IdsdkExportMissing` vs `AdpWrapperMissing`) so the log names the right one. "Does not export X" for a DLL that is not on disk at all would send the reader after the wrong thing. New resource string `ExtensionNotOfferedAdpWrapperMissing`.
- **`AdpWrapperMissing` is deliberately not cached.** A missing DLL can be installed without restarting Dynamo, so only "mapped but no export" and "available" are settled for the session.

**Behaviour change reviewers should weigh:** the gate now blocks in a case where it previously failed open (`Unknown`). On a machine with no ADP Desktop SDK, the Autodesk Assistant and MCP panels will stop opening. That is the intended outcome — they cannot work there — but it is a real expansion of the blocking surface, which is why the check only reports missing after *every* search location misses.

#### Deferred: the other half of AC 6

AC 6 also asks that the gate consume **DynamoMCP's startup self-test result**. That is deliberately not in this PR.

`MCPServer.dll` is loaded into an isolated, collectible `AssemblyLoadContext` and driven by reflection, so its statics are separate storage that DynamoCore cannot read at any type level — the same mechanism the team hit in [DYN-10747](https://autodesk.atlassian.net/browse/DYN-10747). Consuming it would need a primitive-only handoff (a string in an `AppDomain` data slot) plus a DynamoMCP version-pin bump.

That deferred half would only add coverage for one further case: IDSDK exports the API but still fails to service a call. This PR covers the failure mode AC 6 explicitly names, in one repo, with no version coupling. The remaining case is worth paying for once it is actually observed — the DynamoMCP self-test is what would tell us.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

The Autodesk Assistant and MCP view extension panels are now also withheld when the Autodesk ADP Desktop SDK is not installed. Previously only an out-of-date Autodesk Identity component was detected, so on a machine without the ADP SDK the panels opened into a state where every request failed with HTTP 401.

### Reviewers

@jasonstratton (author of DYN-10778 and DYN-10775)

Testing: built with Visual Studio MSBuild (`dotnet build` fails on this repo with MSB4803 on the `AL` task, unrelated to these changes); `DynamoViewMcpTokenValidationTests` passes 11/11 — 7 pre-existing DYN-10775 cases plus 4 new ones covering the `AdpWrapperMissing` verdict, the reason being reported separately, no reason leaking on `Available`/`Unknown`, and unrelated extensions staying unaffected.

Localization: only `Resources.resx` and `Resources.en-US.resx` are hand-edited; the other locale files are populated by the master-localization process.

Note on AC 7 of DYN-10778 — whether an unhealthy result should escalate from "panel won't open" to withholding the extensions outright — it has been split out to [DYN-10816](https://autodesk.atlassian.net/browse/DYN-10816) and is **not** addressed here. It is a product decision with its own technical prerequisite: the signal does not exist until after `MCPViewExtension.Loaded()` has run, and Autodesk Assistant has no guaranteed load order relative to it. DYN-10816 carries the argument against escalating.

### FYIs

N/A
