### PR TITLE
DYN-5921: Clear code block edit flag on unload and focus loss

### DIFF
--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -55,6 +55,7 @@ Dynamo.Wpf.Views.GuidedTour.RealTimeInfoWindow.HyperlinkUri.get -> System.Uri
 Dynamo.Wpf.Views.GuidedTour.RealTimeInfoWindow.HyperlinkUri.set -> void
 override Dynamo.PackageManager.UI.PackageManagerTabControl.OnKeyDown(System.Windows.Input.KeyEventArgs e) -> void
 override Dynamo.UI.Controls.CodeBlockEditor.OnPreviewKeyDown(System.Windows.Input.KeyEventArgs e) -> void
+override Dynamo.UI.Controls.CodeBlockEditor.OnIsKeyboardFocusWithinChanged(System.Windows.DependencyPropertyChangedEventArgs e) -> void
 override Dynamo.PackageManager.UI.PackageManagerTabControl.OnSelectionChanged(System.Windows.Controls.SelectionChangedEventArgs e) -> void
 static Dynamo.PackageManager.UI.PackageManagerTabControl.GetSuppressHomeEndWhenSelected(System.Windows.DependencyObject element) -> bool
 static Dynamo.PackageManager.UI.PackageManagerTabControl.SetSuppressHomeEndWhenSelected(System.Windows.DependencyObject element, bool value) -> void

--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Windows;
 using Dynamo.Controls;
 using Dynamo.Core;
 using Dynamo.Graph.Nodes;
@@ -84,6 +85,17 @@ namespace Dynamo.UI.Controls
 
             WatermarkLabel.Text = Properties.Resources.WatermarkLabelText;
             stateMachine.OnStateChanged += OnEditorStateChanged;
+            nodeView.Unloaded += OnNodeViewUnloaded;
+        }
+
+        /// <summary>
+        /// Ensures graph shortcuts are restored if the editor is unloaded while still
+        /// in edit mode (e.g. node removal or workspace close). LostFocus may not commit
+        /// when <see cref="CodeCompletionEditor.IsDisposed"/> is already true.
+        /// </summary>
+        private void OnNodeViewUnloaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            nodeViewModel.DynamoViewModel.IsCodeBlockEditorActive = false;
         }
 
         protected override void OnEscape()
@@ -116,6 +128,23 @@ namespace Dynamo.UI.Controls
         protected override void OnTextAreaGotFocus(object sender, System.Windows.RoutedEventArgs e)
         {
             stateMachine.Transit(EditorStateMachine.State.Editing);
+            // Ensure the flag is set even if the state machine was already Editing
+            // (e.g. keyboard focus returned after a modal dialog closed).
+            nodeViewModel.DynamoViewModel.IsCodeBlockEditorActive = true;
+        }
+
+        /// <summary>
+        /// Restores graph shortcuts when keyboard focus leaves the editor without a
+        /// normal TextArea LostFocus commit (e.g. opening then canceling File → New).
+        /// </summary>
+        protected override void OnIsKeyboardFocusWithinChanged(DependencyPropertyChangedEventArgs e)
+        {
+            base.OnIsKeyboardFocusWithinChanged(e);
+
+            if (!IsKeyboardFocusWithin)
+            {
+                nodeViewModel.DynamoViewModel.IsCodeBlockEditorActive = false;
+            }
         }
 
         private void OnEditorStateChanged(EditorStateMachine.State state)

--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows;
 using Dynamo.Controls;
 using Dynamo.Core;
@@ -19,6 +19,11 @@ namespace Dynamo.UI.Controls
         }
 
         private State state;
+
+        /// <summary>
+        /// Current editor state.
+        /// </summary>
+        internal State CurrentState => state;
 
         /// <summary>
         /// Event handler for editor state changed.
@@ -89,13 +94,18 @@ namespace Dynamo.UI.Controls
         }
 
         /// <summary>
-        /// Ensures graph shortcuts are restored if the editor is unloaded while still
+        /// Ensures graph shortcuts are restored if this editor is unloaded while still
         /// in edit mode (e.g. node removal or workspace close). LostFocus may not commit
         /// when <see cref="CodeCompletionEditor.IsDisposed"/> is already true.
+        /// Only clears the shared flag when this editor was the active one, so unloading
+        /// another Code Block does not re-enable shortcuts mid-edit.
         /// </summary>
         private void OnNodeViewUnloaded(object sender, System.Windows.RoutedEventArgs e)
         {
-            nodeViewModel.DynamoViewModel.IsCodeBlockEditorActive = false;
+            if (stateMachine.CurrentState == EditorStateMachine.State.Editing)
+            {
+                nodeViewModel.DynamoViewModel.IsCodeBlockEditorActive = false;
+            }
         }
 
         protected override void OnEscape()
@@ -134,17 +144,15 @@ namespace Dynamo.UI.Controls
         }
 
         /// <summary>
-        /// Restores graph shortcuts when keyboard focus leaves the editor without a
-        /// normal TextArea LostFocus commit (e.g. opening then canceling File → New).
+        /// Keeps the shared edit flag in sync with keyboard focus. Clears it when focus
+        /// leaves (e.g. dialog or AA assistant chat) and sets it again when focus returns,
+        /// including cases where TextArea GotFocus does not fire reliably.
         /// </summary>
         protected override void OnIsKeyboardFocusWithinChanged(DependencyPropertyChangedEventArgs e)
         {
             base.OnIsKeyboardFocusWithinChanged(e);
 
-            if (!IsKeyboardFocusWithin)
-            {
-                nodeViewModel.DynamoViewModel.IsCodeBlockEditorActive = false;
-            }
+            nodeViewModel.DynamoViewModel.IsCodeBlockEditorActive = IsKeyboardFocusWithin;
         }
 
         private void OnEditorStateChanged(EditorStateMachine.State state)


### PR DESCRIPTION
This PR is a follow up on https://github.com/DynamoDS/Dynamo/pull/17306 and addresses [DYN-5921](https://autodesk.atlassian.net/browse/DYN-5921).

Disabling graph shortcuts while editing a Code Block worked, but the edit flag could stay on if the Code Block went away or lost keyboard focus without a normal save-and-leave. Shortcuts like pan, zoom, and fit view then stayed off until another edit cleared the flag.
This follow-up clears the edit flag on unload to be safe, and fixes a specific case where opening and closing a dialog left graph shortcuts disabled until the canvas was clicked.

Changes:
- Turn the flag off when the node view is unloaded, for example when the node is deleted or the workspace closes
- Turn the flag off when keyboard focus leaves the editor, e.g. : File, New, Cancel
- Turn the flag back on when the user clicks into the Code Block again
- Register the new override in PublicAPI.Unshipped.txt

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.


### Release Notes

Follow-up for the stuck shortcut flag. Clearing it when the node is unloaded, and fixed graph navigation shortcuts sometimes staying disabled after opening and closing a dialog while editing a Code Block.

### Reviewers

@zeusongit
@DynamoDS/eidos


### FYIs

@dnenov
@johnpierson
@jnealb 
@jasonstratton 