### PR TITLE
DYN-10778: Bump DynamoMCP to 0.5.8

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2219,7 +2219,7 @@
     different DynamoVisualProgramming.* API. Bump in lockstep with the DynamoMCP release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.5.7]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.5.8]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
     The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_DynamoMCP)\bin IS


### PR DESCRIPTION
### Purpose

Lockstep bump of the hard-pinned `DynamoVisualProgramming.DynamoMCP` built-in package reference from `[0.5.7]` to `[0.5.8]`, to consume the DynamoMCP 0.5.8 release.

Tracking task: [DYN-10778](https://autodesk.atlassian.net/browse/DYN-10778). This is the DynamoMCP-side counterpart of the Dynamo-side ADP Desktop SDK detection landed in #17310 under the same ticket. Follows the same one-line shape as #17307 (0.5.6 → 0.5.7).

Verification performed against the published package:

* `dotnet restore src/DynamoCoreWpf/DynamoCoreWpf.csproj` resolves `DynamoVisualProgramming.DynamoMCP/0.5.8` under the exact-version pin, with no version-resolution errors.
* The 0.5.7 and 0.5.8 packages carry an **identical 36-file set** — no assemblies added or removed.
* All bundled third-party assembly versions are **unchanged**: BigGustave 1.0.6, Json.More 2.2.0, JsonPointer.Net 6.0.1, JsonSchema.Net 8.0.5, ModelContextProtocol[.Core] 1.3.0, SharpGLTF.* 1.0.0. The ABOUT.txt third-party attribution added in DYN-10707 therefore needs no update. Only `MCPServer.dll` and `MCPExtension.dll` advance to 0.5.8.0, alongside `pkg.json` and the nuspec version.
* `.github/scripts/check_file_version.ps1` lists the DynamoMCP assemblies by filename with no pinned versions, so its exclusion list is unaffected.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards) — the existing csproj comment block documenting the hard pin and its lockstep-bump rule remains accurate; no code added.
- [x] The level of testing this PR includes is appropriate — dependency version bump with no new code paths, so no new tests. Verified via restore resolution and a content diff of the 0.5.7 vs 0.5.8 packages (above).
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document — no public API changes in this PR.

### Release Notes

N/A — built-in package version bump with no Dynamo-side behavior change in this diff.

> Note to reviewers: if DynamoMCP 0.5.8 carries user-visible changes on its own side, this section should describe those instead of `N/A`. I don't have visibility into that repo's changelog from here.

### Reviewers

@jasonstratton (reviewed both #17307 and #17310)

Notes: the only functional change is the pinned version string. Everything else in this description is verification evidence, not modified code.

### FYIs

N/A