### PR TITLE
DYN-10661: Don't log a false Saving message when a template-folder save is blocked

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2866,7 +2866,6 @@ namespace Dynamo.ViewModels
         {
             try
             {
-                Model.Logger.Log(string.Format(Properties.Resources.SavingInProgress, path));
                 var hasSaved = false;
                 if (IsPathInTemplateDirectoryTree(path, Model.PathManager.TemplatesDirectory))
                 {
@@ -2876,6 +2875,7 @@ namespace Dynamo.ViewModels
                 }
                 else
                 {
+                    Model.Logger.Log(string.Format(Properties.Resources.SavingInProgress, path));
                     hasSaved = CurrentSpaceViewModel.Save(path, isBackup, Model.EngineController, saveContext);
                 }
 


### PR DESCRIPTION
### Purpose

[DYN-10661](https://autodesk.atlassian.net/browse/DYN-10661)
[DYN-10661 DynaNote](https://git.autodesk.com/strattj/DynaNotes/blob/master/DYN-10661/README.md) _(Autodesk internal)_

Follow-up to #17254. Neal verified that fix in 4.3.0.6020 and confirmed the UX (blocking a save into the templates folder) is correct, but found the console/log message misleading: it logs `Saving <path> ...` before checking whether the save is actually allowed to proceed.

Repro from Neal's log:
```
19:16:45Z : Saving C:\TEMP\BlockedTemplate\mytest.dyn ...
```
No file is written and no follow-up confirmation is logged — the save was blocked by the templates-directory warning dialog, but the log claims a save was in progress.

Key changes:
- `InternalSaveAs` in `src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs` moved the `SavingInProgress` log call into the branch that actually performs the save, after the `IsPathInTemplateDirectoryTree` check, instead of logging it unconditionally beforehand.

### Declarations

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixed a misleading "Saving ..." console message that appeared even when a save into the protected templates folder was blocked.

### Reviewers

(FILL ME IN) Reviewer 1

No new automated test was added: this is a one-line reordering with no new logic, and the blocking behavior itself is already covered by `TemplateSavePathCheckBlocksTemplateRootAndChildren` / `TemplateSavePathCheckDoesNotThrowWhenTemplateDirectoryIsUnknown` in `WorkspaceSaving.cs`. Asserting log-call ordering would require mocking `DynamoMessageBox.Show` and the logger inside `InternalSaveAs`, which isn't set up elsewhere in that suite.

### FYIs

(FILL ME IN, Optional)