### PR TITLE
DYN-10831: PacMan - Navigate to Installed Packages after new version is published

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -66,6 +66,7 @@ namespace Dynamo.UI.Views
         internal Action<string, string> RequestShowDialog;
         internal Action RequestCancelUpload;
         internal Action<int, int, string> RequestUploadProgress;
+        internal Action RequestNavigateToInstalledPackages;
 
         private PackageUpdateRequest previousPackageDetails;
 
@@ -107,6 +108,7 @@ namespace Dynamo.UI.Views
             RequestShowDialog = ShowDialog;
             RequestCancelUpload = CancelUpload;
             RequestUploadProgress = UploadProgress;
+            RequestNavigateToInstalledPackages = NavigateToInstalledPackages;
 
             DataContextChanged += OnDataContextChanged;
         }
@@ -274,7 +276,8 @@ namespace Dynamo.UI.Views
                             RequestApplicationLoaded,
                             RequestShowDialog,
                             RequestCancelUpload,
-                            RequestUploadProgress));
+                            RequestUploadProgress,
+                            RequestNavigateToInstalledPackages));
 
                 }
                 catch (Exception ex)
@@ -1010,6 +1013,22 @@ namespace Dynamo.UI.Views
         {
             SendUploadProgress(currentFile, totalFiles, currentFileName);
         }
+
+        /// <summary>
+        /// A request from the front-end to switch to the Installed Packages tab after publishing a new version.
+        /// No-ops unless the session was started with Publish Version from that tab.
+        /// </summary>
+        internal void NavigateToInstalledPackages()
+        {
+            if (publishPackageViewModel?.IsNewVersion != true) return;
+
+            Dispatcher.Invoke(() =>
+            {
+                var packageManagerView = Window.GetWindow(this) as PackageManagerView;
+                packageManagerView?.Navigate(
+                    Dynamo.Wpf.Properties.Resources.PackageManagerInstalledPackagesTab);
+            });
+        }
         #endregion
 
         #region Utility
@@ -1249,6 +1268,7 @@ namespace Dynamo.UI.Views
         readonly Action<string, string> RequestShowDialog;
         readonly Action RequestCancelUpload;
         readonly Action<int, int, string> RequestUploadProgress;
+        readonly Action RequestNavigateToInstalledPackages;
 
         public ScriptWizardObject(
             Action<string> requestAddFileOrFolder,
@@ -1267,7 +1287,8 @@ namespace Dynamo.UI.Views
             Action requestApplicationLoaded,
             Action<string, string> requestShowDialog,
             Action requestCancelUpload,
-            Action<int, int, string> requestUploadProgress)
+            Action<int, int, string> requestUploadProgress,
+            Action requestNavigateToInstalledPackages)
         {
             RequestAddFileOrFolder = requestAddFileOrFolder;
             RequestRemoveFileOrFolder = requestRemoveFileOrFolder;
@@ -1286,6 +1307,7 @@ namespace Dynamo.UI.Views
             RequestShowDialog = requestShowDialog;
             RequestCancelUpload = requestCancelUpload;
             RequestUploadProgress = requestUploadProgress;
+            RequestNavigateToInstalledPackages = requestNavigateToInstalledPackages;
         }
 
         [DynamoJSInvokable]
@@ -1390,6 +1412,12 @@ namespace Dynamo.UI.Views
         public void UploadProgress(int currentFile, int totalFiles, string currentFileName)
         {
             RequestUploadProgress(currentFile, totalFiles, currentFileName);
+        }
+
+        [DynamoJSInvokable]
+        public void NavigateToInstalledPackages()
+        {
+            RequestNavigateToInstalledPackages();
         }
     }
 


### PR DESCRIPTION
### Purpose

Reference - [DYN-10831](https://autodesk.atlassian.net/browse/DYN-10831)

This is a small PR aimed at a minor bug in the publishing process. After publishing a new version of an existing package (started from Installed Packages via Publish Version…) and pressing Done on the finish step, the user was sent back to the Publish a Package tab with leftover / invalid field state.

This PR adds a `NavigateToInstalledPackages()` host method on `PackageManagerWizard` / `ScriptWizardObject`. When the wizard calls it, Dynamo switches to the Installed Packages tab only if `PublishPackageViewModel.IsNewVersion` is true (the Publish Version path). A brand-new package started on the Publish tab is unchanged: the call no-ops and the user stays on Publish after reset.

This pairs with the Package Publish Wizard [PR](https://git.autodesk.com/Dynamo/PackagePublishWizard/pull/79) that invokes the host method from the footer Done handler before reset.

Please refer to [this](https://autodesk.slack.com/archives/CPJ5UQW0Z/p1786027782618559) Slack thread.

<img width="960" height="540" alt="2026-09-01 09-47-08" src="https://github.com/user-attachments/assets/f881d5fc-2a2c-4a5a-a644-1aaff2256c7d" />


### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

The user lands on the Installed Packages tab after they publish a new version of an existing package.

### Reviewers

@DynamoDS/eidos
@jasonstratton

### FYIs

@dnenov
@johnpierson