### PR TITLE
DYN-10661: Log a blocked template-folder save, clarify unrelated JSON log message

### DIFF
--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -619,7 +619,7 @@ namespace Dynamo.UI.Controls
             {
                 if(ex is JsonReaderException)
                 {
-                    DynamoViewModel.Model.Logger.Log("File is not a valid json format.");
+                    DynamoViewModel.Model.Logger.Log($"Could not load Start Page preview data for '{filePath}': file is not valid JSON.");
                 }
                 else
                 {

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2870,6 +2870,7 @@ namespace Dynamo.ViewModels
                 if (IsPathInTemplateDirectoryTree(path, Model.PathManager.TemplatesDirectory))
                 {
                     // Give user notifications
+                    Model.Logger.Log(string.Format("{0}: {1}", path, WpfResources.WorkspaceSaveTemplateDirectoryBlockMsg));
                     DynamoMessageBox.Show(Owner, WpfResources.WorkspaceSaveTemplateDirectoryBlockMsg, WpfResources.WorkspaceSaveTemplateDirectoryBlockTitle,
                         MessageBoxButton.OK, MessageBoxImage.Warning);
                 }


### PR DESCRIPTION
### Purpose

[DYN-10661](https://autodesk.atlassian.net/browse/DYN-10661)
[DYN-10661 DynaNote](https://git.autodesk.com/strattj/DynaNotes/blob/master/DYN-10661/README.md) _(Autodesk internal)_

Follow-up to #17315. That PR removed the false `"Saving <path> ..."` message from the blocked-save branch of `InternalSaveAs`, but didn't add a replacement, so a blocked save logged nothing. That silence let an unrelated, pre-existing Start Page log message ("File is not a valid json format.") look like it was explaining the blocked save, when it isn't — it's logged by the Recent Files/Templates thumbnail loader, unrelated to saving.

This PR:
- Makes `InternalSaveAs` log the same text shown in the blocked-save warning dialog, so the console matches the UI.
- Clarifies the unrelated Start Page message to name the file and state it's about preview data, so it can't be mistaken for a save failure again.

### Declarations

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixed console logging for a blocked template-folder save to match the on-screen warning, and clarified an unrelated Start Page log message that could be mistaken for it.

### Reviewers

(FILL ME IN) Reviewer 1

### FYIs

(FILL ME IN, Optional)