### PR TITLE
DYN-10818: Bump DynamoMCP to 0.5.9

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -2219,7 +2219,7 @@
     different DynamoVisualProgramming.* API. Bump in lockstep with the DynamoMCP release for this line.
   -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.5.8]" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="DynamoVisualProgramming.DynamoMCP" Version="[0.5.9]" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
   <!--
     The NuGet wraps the assembled package under bin\, so $(PkgDynamoVisualProgramming_DynamoMCP)\bin IS


### PR DESCRIPTION
### Purpose

Lockstep bump of the hard-pinned `DynamoVisualProgramming.DynamoMCP` built-in package reference from `[0.5.8]` to `[0.5.9]`, to consume the DynamoMCP 0.5.9 release. Same one-line shape as #17314 (0.5.7 → 0.5.8) and #17307 (0.5.6 → 0.5.7).

Tracking task: [DYN-10818](https://autodesk.atlassian.net/browse/DYN-10818).

The 0.5.9 release carries two fixes, both DynamoMCP-side:

* [DYN-10778](https://autodesk.atlassian.net/browse/DYN-10778) — makes the IDSDK startup self-test **passive**, fixing a regression shipped in 0.5.9's predecessor. The 0.5.8 self-test handed IDSDK a deliberately invalid probe token, and IDSDK treats a failed MCP validation as the session being bad — dropping cached Autodesk credentials and signing the user out of Dynamo. The check now asks whether the mapped `AdskIdentitySDK.dll` exports `idsdk_mcp_validate_token` instead of asking IDSDK to validate anything, so it cannot touch the session. The live probe is retained behind `DYNAMO_MCP_IDSDK_DEEP_SELFTEST`, off by default.
* [DYN-10818](https://autodesk.atlassian.net/browse/DYN-10818) — `save_workspace` passed `directory` straight to `Path.Combine`, so a bare alias (`Desktop`), a `~`/`%USERPROFILE%` path, or any relative value resolved against the *host process's* working directory (Revit's), creating a folder there. Dynamo records the handed-in path verbatim in `PreferenceSettings.RecentFiles` and drops entries failing `File.Exists` on next launch, so a graph saved via an assistant prompt vanished from **Recent Files** after restart. Paths are now expanded and canonicalised, `Desktop`/`Documents` resolve through `Environment.GetFolderPath` (honouring OneDrive redirection), and a still-relative directory is rejected with an actionable message.

Because DYN-10778 fixes a sign-out regression present in the currently-pinned 0.5.8, this bump is worth landing promptly.

Verification performed against the published package:

* `dotnet restore src/DynamoCoreWpf/DynamoCoreWpf.csproj` succeeds and `src/DynamoCoreWpf/obj/project.assets.json` resolves `DynamoVisualProgramming.DynamoMCP/0.5.9` under the exact-version pin, with no version-resolution errors.
* The 0.5.8 and 0.5.9 packages carry an **identical payload file set** (33 files; no assemblies added or removed).
* All bundled third-party assembly versions are **unchanged**: BigGustave 1.0.6, Humanizer 3.0.1, Json.More 2.2.0, JsonPointer.Net 6.0.1, JsonSchema.Net 8.0.5, ModelContextProtocol[.Core] 1.3.0, SharpGLTF.* 1.0.0, Microsoft.Extensions.* (10.0.826.23019 / AI.Abstractions 10.500.226.25501), DynamoPlayer.* 7.0.7. The ABOUT.txt third-party attribution added in DYN-10707 therefore needs no update.
* Only `MCPServer.dll` and `MCPExtension.dll` advance, 0.5.8.0 → 0.5.9.0 (verified by comparing `VersionInfo.FileVersion` across every DLL in both packages).

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards) — the existing csproj comment block documenting the hard pin and its lockstep-bump rule remains accurate; no code added.
- [x] The level of testing this PR includes is appropriate — dependency version bump with no new code paths, so no new tests. Verified via restore resolution and a content/assembly-version diff of the 0.5.8 vs 0.5.9 packages (above).
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document — no public API changes in this PR.

### Release Notes

Autodesk Assistant no longer signs the user out of Dynamo at startup, and a graph saved through an assistant prompt (e.g. "save the graph on Desktop") now lands in the requested folder and stays in **Recent Files** across restarts.

### Reviewers

@jasonstratton (reviewed #17307 and #17314)

Notes: the only functional change in this diff is the pinned version string on line 2222; everything else above is verification evidence.

### FYIs

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
