### PR TITLE
DYN-10801: Fix Custom Selection node losing items after delete + undo (#17305)

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/CustomSelection.cs
+++ b/src/Libraries/CoreNodeModels/Input/CustomSelection.cs
@@ -152,7 +152,11 @@ namespace CoreNodeModels.Input
         {
             base.SerializeCore(nodeElement, context);
 
-            if (context == SaveContext.Copy)
+            // Persist the custom items for both copy/paste and undo/redo. Both operations
+            // round-trip the node through XML (SaveContext.Copy and SaveContext.Undo
+            // respectively); without covering Undo, deleting the node and undoing it would
+            // restore the constructor defaults and lose the user's items (see issue #17305).
+            if (context == SaveContext.Copy || context == SaveContext.Undo)
             {
                 var doc = nodeElement.OwnerDocument;
 
@@ -170,7 +174,7 @@ namespace CoreNodeModels.Input
         {
             base.DeserializeCore(nodeElement, context);
 
-            if (context == SaveContext.Copy)
+            if (context == SaveContext.Copy || context == SaveContext.Undo)
             {
                 Items.Clear();
                 foreach (XmlNode child in nodeElement.ChildNodes)

--- a/src/Libraries/CoreNodeModels/Input/CustomSelection.cs
+++ b/src/Libraries/CoreNodeModels/Input/CustomSelection.cs
@@ -174,6 +174,9 @@ namespace CoreNodeModels.Input
         {
             base.DeserializeCore(nodeElement, context);
 
+            // Mirrors the guard in SerializeCore: the items are only written for
+            // copy/paste and undo/redo, so they can only be read back for those
+            // same contexts.
             if (context == SaveContext.Copy || context == SaveContext.Undo)
             {
                 Items.Clear();

--- a/test/DynamoCoreTests/Nodes/CustomDropdownTests.cs
+++ b/test/DynamoCoreTests/Nodes/CustomDropdownTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using CoreNodeModels;
 using CoreNodeModels.Input;
 using Dynamo.Graph.Nodes;
+using Dynamo.Models;
 using Dynamo.PackageManager;
 
 using NUnit.Framework;
@@ -92,6 +93,46 @@ namespace Dynamo.Tests.Nodes
             Assert.NotNull(watchNode);
             string watchValue = watchNode.CachedValue.StringData;
             Assert.AreEqual("3", watchValue);
+        }
+
+        /// <summary>
+        /// Deleting a customized Custom Selection node and undoing the delete should
+        /// restore the user's items and selection rather than the constructor defaults.
+        /// Regression test for https://github.com/DynamoDS/Dynamo/issues/17305
+        /// </summary>
+        [Test]
+        public void DeleteAndUndoKeepsCustomItemsAndSelection()
+        {
+            var node = new CustomSelection();
+
+            // Replace the default items with custom ones and pick a non-default selection.
+            node.Items.Clear();
+            node.Items.Add(new DynamoDropDownItem("Alpha", "10"));
+            node.Items.Add(new DynamoDropDownItem("Beta", "20"));
+            node.Items.Add(new DynamoDropDownItem("Gamma", "30"));
+            node.SelectedIndex = 2;
+
+            CurrentDynamoModel.ExecuteCommand(new DynamoModel.CreateNodeCommand(node, 0, 0, true, false));
+
+            var guid = node.GUID;
+
+            // Delete the node, then undo the delete.
+            CurrentDynamoModel.ExecuteCommand(new DynamoModel.DeleteModelCommand(guid));
+            Assert.IsNull(CurrentDynamoModel.CurrentWorkspace.Nodes.FirstOrDefault(n => n.GUID == guid));
+
+            CurrentDynamoModel.ExecuteCommand(new DynamoModel.UndoRedoCommand(DynamoModel.UndoRedoCommand.Operation.Undo));
+
+            var restored = CurrentDynamoModel.CurrentWorkspace.Nodes
+                .OfType<CustomSelection>()
+                .FirstOrDefault(n => n.GUID == guid);
+            Assert.NotNull(restored, "The Custom Selection node should be restored after undo.");
+
+            Assert.AreEqual(3, restored.Items.Count);
+            Assert.AreEqual("Alpha", restored.Items[0].Name);
+            Assert.AreEqual("10", restored.Items[0].Item);
+            Assert.AreEqual("Beta", restored.Items[1].Name);
+            Assert.AreEqual("Gamma", restored.Items[2].Name);
+            Assert.AreEqual(2, restored.SelectedIndex);
         }
     }
 }

--- a/test/DynamoCoreTests/Nodes/CustomDropdownTests.cs
+++ b/test/DynamoCoreTests/Nodes/CustomDropdownTests.cs
@@ -131,7 +131,9 @@ namespace Dynamo.Tests.Nodes
             Assert.AreEqual("Alpha", restored.Items[0].Name);
             Assert.AreEqual("10", restored.Items[0].Item);
             Assert.AreEqual("Beta", restored.Items[1].Name);
+            Assert.AreEqual("20", restored.Items[1].Item);
             Assert.AreEqual("Gamma", restored.Items[2].Name);
+            Assert.AreEqual("30", restored.Items[2].Item);
             Assert.AreEqual(2, restored.SelectedIndex);
         }
     }


### PR DESCRIPTION
### Purpose

Fixes #17305 (tracked internally as DYN-10801).

The **Custom Selection** node loses its custom items and selection when the node is deleted and then restored with Ctrl+Z. After undo, the node comes back with the constructor defaults (`One` / `Two` / `Three`) instead of the user's configured items.

**Root cause:** `CustomSelection.SerializeCore` / `DeserializeCore` only persist the custom items when `context == SaveContext.Copy`. Undo/redo round-trips the node through XML with `SaveContext.Undo` (`UndoRedoRecorder.Serialize(..., SaveContext.Undo)` on record, `NodeFactory.CreateNodeFromXml(..., SaveContext.Undo)` on restore), so the custom items are never written to the undo record nor read back — the node falls back to the defaults created in the constructor.

**Fix:** broaden both guards to `SaveContext.Copy || SaveContext.Undo`, so the same item round-tripping used for copy/paste is also applied for undo/redo. This mirrors the existing pattern in `DummyNode` (`context == SaveContext.Copy || context == SaveContext.Undo`).

This is the same underlying serialization gap as the previously reported #16922 (paste to a new graph), which only added the `Copy` branch and did not cover `Undo`.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

(No public API changes — this is an internal serialization fix.)

### Release Notes

Fixed the Custom Selection node losing its configured items and selection after deleting the node and undoing the delete.

### Reviewers

(FILL ME IN)

Added a regression test `CustomDropDownTests.DeleteAndUndoKeepsCustomItemsAndSelection` that customizes a Custom Selection node, deletes it, undoes the delete, and asserts the items and selected index are restored.

### FYIs

N/A
