### PR TITLE
DYN-10845: Fix Dynamo window restoring off-screen when saved monitor is unavailable

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1234,10 +1234,12 @@ namespace Dynamo.Controls
         /// <summary>
         /// Returns the factor that converts the device pixels reported by
         /// <see cref="System.Windows.Forms.Screen"/> into the device-independent
-        /// units used by WPF window bounds. It is derived from the primary monitor,
-        /// so it is an approximation on mixed-DPI layouts; that is acceptable here
-        /// because the visibility check only needs to know roughly where the
-        /// connected monitors are.
+        /// units used by WPF window bounds, derived from the primary monitor.
+        /// Dynamo is System-DPI-aware, so Windows virtualizes every monitor's
+        /// coordinates to this single system scale; the factor is therefore correct
+        /// for all displays, not just the primary one. If Dynamo ever adopts
+        /// Per-Monitor V2 awareness (where each display can have its own scale),
+        /// this must be replaced with a per-monitor GetDpiForMonitor lookup.
         /// </summary>
         private static double GetDeviceToDipScale()
         {

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -182,36 +182,32 @@ namespace Dynamo.Controls
             // Apply appropriate expand/collapse library button state depending on initial width
             UpdateLibraryCollapseIcon();
 
-            // Check that preference bounds are actually within one
-            // of the available monitors.
-            if (CheckVirtualScreenSize())
+            // Restore the saved window bounds, but only when they still land on a
+            // currently-connected display. When the monitor Dynamo was last shown
+            // on is no longer available (undocking, disconnected displays, remote
+            // sessions, changed multi-monitor layouts), the saved position can
+            // place the window entirely off-screen with no reliable way to recover
+            // it. In that case, recenter on the primary monitor's working area.
+            var savedBounds = new System.Drawing.Rectangle(
+                (int)dynamoViewModel.Model.PreferenceSettings.WindowX,
+                (int)dynamoViewModel.Model.PreferenceSettings.WindowY,
+                (int)dynamoViewModel.Model.PreferenceSettings.WindowW,
+                (int)dynamoViewModel.Model.PreferenceSettings.WindowH);
+
+            if (IsWindowVisibleOnAnyScreen(savedBounds))
             {
-                System.Windows.Forms.Screen[] screens = System.Windows.Forms.Screen.AllScreens;
-                int leftLimit = 0;
-                int topLimit = 0;
-                foreach (var screen in screens)
-                {
-                    leftLimit += screen.Bounds.Width;
-                    topLimit += screen.Bounds.Height;
-                }
-
-                Left = dynamoViewModel.Model.PreferenceSettings.WindowX;
-                Top = dynamoViewModel.Model.PreferenceSettings.WindowY;
-                Width = dynamoViewModel.Model.PreferenceSettings.WindowW;
-                Height = dynamoViewModel.Model.PreferenceSettings.WindowH;
-
-                //When the previous location was in a secondary screen then the next time Dynamo is launched will try to use the same location, then we need to added this validations to show Dynamo in the right place
-                if (Left > leftLimit)
-                    Left = 0;
-                if (Top > topLimit)
-                    Top = 0;
+                Left = savedBounds.Left;
+                Top = savedBounds.Top;
+                Width = savedBounds.Width;
+                Height = savedBounds.Height;
             }
             else
             {
-                Left = 0;
-                Top = 0;
-                Width = 1024;
-                Height = 768;
+                var workingArea = System.Windows.Forms.Screen.PrimaryScreen.WorkingArea;
+                Width = Math.Min(1024, workingArea.Width);
+                Height = Math.Min(768, workingArea.Height);
+                Left = workingArea.Left + (workingArea.Width - Width) / 2;
+                Top = workingArea.Top + (workingArea.Height - Height) / 2;
             }
 
             _workspaceResizeTimer.Tick += _resizeTimer_Tick;
@@ -1187,31 +1183,36 @@ namespace Dynamo.Controls
 
         #endregion
 
-        private bool CheckVirtualScreenSize()
+        // Minimum overlap (in pixels) that the saved window must share with a
+        // connected display's working area to be considered recoverable by the
+        // user. Anything less is treated as effectively off-screen.
+        private const int MinVisibleWindowExtent = 100;
+
+        /// <summary>
+        /// Determines whether the given window bounds overlap the working area of
+        /// any currently-connected display by a usable amount. Used on startup to
+        /// decide whether the last-saved window position can be safely restored, or
+        /// whether the window must be recentered because the monitor it was saved
+        /// on is no longer available.
+        /// </summary>
+        private static bool IsWindowVisibleOnAnyScreen(System.Drawing.Rectangle bounds)
         {
-            var w = SystemParameters.VirtualScreenWidth;
-            var h = SystemParameters.VirtualScreenHeight;
-            var ox = SystemParameters.VirtualScreenLeft;
-            var oy = SystemParameters.VirtualScreenTop;
-
-            // TODO: Remove 10 pixel check if others can't reproduce
-            // On Ian's Windows 8 setup, when Dynamo is maximized, the origin
-            // saves at -8,-8. There doesn't seem to be any documentation on this
-            // so we'll put in a 10 pixel check to still allow the window to maximize.
-            if (dynamoViewModel.Model.PreferenceSettings.WindowX < ox - 10 ||
-                dynamoViewModel.Model.PreferenceSettings.WindowY < oy - 10)
+            if (bounds.Width <= 0 || bounds.Height <= 0)
             {
                 return false;
             }
 
-            // Check that the window is smaller than the available area.
-            if (dynamoViewModel.Model.PreferenceSettings.WindowW > w ||
-                dynamoViewModel.Model.PreferenceSettings.WindowH > h)
+            foreach (var screen in System.Windows.Forms.Screen.AllScreens)
             {
-                return false;
+                var overlap = System.Drawing.Rectangle.Intersect(screen.WorkingArea, bounds);
+                if (overlap.Width >= MinVisibleWindowExtent &&
+                    overlap.Height >= MinVisibleWindowExtent)
+                {
+                    return true;
+                }
             }
 
-            return true;
+            return false;
         }
 
         private void DynamoView_LocationChanged(object sender, EventArgs e)

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -188,11 +188,11 @@ namespace Dynamo.Controls
             // sessions, changed multi-monitor layouts), the saved position can
             // place the window entirely off-screen with no reliable way to recover
             // it. In that case, recenter on the primary monitor's working area.
-            var savedBounds = new System.Drawing.Rectangle(
-                (int)dynamoViewModel.Model.PreferenceSettings.WindowX,
-                (int)dynamoViewModel.Model.PreferenceSettings.WindowY,
-                (int)dynamoViewModel.Model.PreferenceSettings.WindowW,
-                (int)dynamoViewModel.Model.PreferenceSettings.WindowH);
+            var savedBounds = new Rect(
+                dynamoViewModel.Model.PreferenceSettings.WindowX,
+                dynamoViewModel.Model.PreferenceSettings.WindowY,
+                Math.Max(0, dynamoViewModel.Model.PreferenceSettings.WindowW),
+                Math.Max(0, dynamoViewModel.Model.PreferenceSettings.WindowH));
 
             if (IsWindowVisibleOnAnyScreen(savedBounds))
             {
@@ -203,11 +203,13 @@ namespace Dynamo.Controls
             }
             else
             {
-                var workingArea = System.Windows.Forms.Screen.PrimaryScreen.WorkingArea;
-                Width = Math.Min(1024, workingArea.Width);
-                Height = Math.Min(768, workingArea.Height);
-                Left = workingArea.Left + (workingArea.Width - Width) / 2;
-                Top = workingArea.Top + (workingArea.Height - Height) / 2;
+                // SystemParameters.WorkArea is already in device-independent units,
+                // so it can be assigned to the window bounds without conversion.
+                var workArea = SystemParameters.WorkArea;
+                Width = Math.Min(1024, workArea.Width);
+                Height = Math.Min(768, workArea.Height);
+                Left = workArea.Left + (workArea.Width - Width) / 2;
+                Top = workArea.Top + (workArea.Height - Height) / 2;
             }
 
             _workspaceResizeTimer.Tick += _resizeTimer_Tick;
@@ -1183,10 +1185,10 @@ namespace Dynamo.Controls
 
         #endregion
 
-        // Minimum overlap (in pixels) that the saved window must share with a
-        // connected display's working area to be considered recoverable by the
-        // user. Anything less is treated as effectively off-screen.
-        private const int MinVisibleWindowExtent = 100;
+        // Minimum overlap (in device-independent units) that the saved window must
+        // share with a connected display's working area to be considered
+        // recoverable by the user. Anything less is treated as off-screen.
+        private const double MinVisibleWindowExtent = 100;
 
         /// <summary>
         /// Determines whether the given window bounds overlap the working area of
@@ -1195,17 +1197,31 @@ namespace Dynamo.Controls
         /// whether the window must be recentered because the monitor it was saved
         /// on is no longer available.
         /// </summary>
-        private static bool IsWindowVisibleOnAnyScreen(System.Drawing.Rectangle bounds)
+        /// <param name="bounds">Window bounds in device-independent units.</param>
+        private static bool IsWindowVisibleOnAnyScreen(Rect bounds)
         {
             if (bounds.Width <= 0 || bounds.Height <= 0)
             {
                 return false;
             }
 
+            // Screen reports device pixels, while the window bounds and the saved
+            // preferences are device-independent units, so the monitor rectangles
+            // have to be scaled before they can be intersected.
+            var scale = GetDeviceToDipScale();
+
             foreach (var screen in System.Windows.Forms.Screen.AllScreens)
             {
-                var overlap = System.Drawing.Rectangle.Intersect(screen.WorkingArea, bounds);
-                if (overlap.Width >= MinVisibleWindowExtent &&
+                var workingArea = screen.WorkingArea;
+                var overlap = new Rect(
+                    workingArea.Left * scale,
+                    workingArea.Top * scale,
+                    workingArea.Width * scale,
+                    workingArea.Height * scale);
+                overlap.Intersect(bounds);
+
+                if (!overlap.IsEmpty &&
+                    overlap.Width >= MinVisibleWindowExtent &&
                     overlap.Height >= MinVisibleWindowExtent)
                 {
                     return true;
@@ -1213,6 +1229,25 @@ namespace Dynamo.Controls
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Returns the factor that converts the device pixels reported by
+        /// <see cref="System.Windows.Forms.Screen"/> into the device-independent
+        /// units used by WPF window bounds. It is derived from the primary monitor,
+        /// so it is an approximation on mixed-DPI layouts; that is acceptable here
+        /// because the visibility check only needs to know roughly where the
+        /// connected monitors are.
+        /// </summary>
+        private static double GetDeviceToDipScale()
+        {
+            var primaryScreen = System.Windows.Forms.Screen.PrimaryScreen;
+            if (primaryScreen == null || primaryScreen.Bounds.Width <= 0)
+            {
+                return 1.0;
+            }
+
+            return SystemParameters.PrimaryScreenWidth / primaryScreen.Bounds.Width;
         }
 
         private void DynamoView_LocationChanged(object sender, EventArgs e)


### PR DESCRIPTION
### Purpose

Fixes [DYN-10845](https://autodesk.atlassian.net/browse/DYN-10845).

Dynamo restores its previous window position on launch. When the monitor it was last shown on is no longer available — undocking/docking a laptop, disconnecting a display, switching between office and home setups, remote sessions, or otherwise rearranging a multi-monitor layout — the saved position can place the window entirely off-screen: running, but inaccessible, with no reliable way to recover it (Win+Arrow does not consistently work on Dynamo's modeless window).

Reported via the community here: https://forum.dynamobim.com/t/dynamo-button-idea-for-ui/115174
Related issue: DynamoDS/DynamoRevit#3429

**Root cause**

The startup restore logic in `DynamoView` validated the saved bounds by summing every monitor's width and height (`leftLimit`/`topLimit`) and only reset `Left`/`Top` to 0 if the saved value exceeded that sum. The virtual desktop is not a simple tiling — monitors can sit at negative coordinates or with gaps between them — so that guard is geometrically meaningless. `CheckVirtualScreenSize()` only rejected positions past the top/left origin, so a window saved on a monitor that was later unplugged stayed off-screen. Nothing tested whether the saved rectangle actually intersects a currently connected display.

**Fix**

Replace the summing guard and `CheckVirtualScreenSize()` with a real visibility test (`IsWindowVisibleOnAnyScreen`) that intersects the saved bounds against each connected display's working area. The saved bounds are restored only when the window overlaps a live monitor by a usable amount (>= 100 units in both dimensions); otherwise the window is recentered on the primary monitor's work area. This handles negative coordinates and disconnected or rearranged monitors.

All of the geometry is done in device-independent units, which is the unit the `WindowX`/`WindowY`/`WindowW`/`WindowH` preferences are written in (they are populated from WPF `Left`/`Top` in `DynamoView_LocationChanged`). `SystemParameters.WorkArea` is already in DIPs and is used directly for the recentering fallback; the `System.Windows.Forms.Screen` rectangles are in device pixels, so they are scaled by the primary monitor's DIP-to-pixel ratio before being intersected. The scale is derived from the primary monitor, so it is an approximation on mixed-DPI layouts — acceptable here because the check only needs to know roughly where the connected monitors are, and it is bounded by the 100-unit overlap tolerance.

**Behavior change worth noting**

Previously the window was also reset when the saved size was larger than the virtual desktop. With this change an oversized saved window is restored as-is; because its top-left corner is guaranteed to be on a visible monitor, it remains recoverable and resizable. Called out here so it is not a surprise in review.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

No public API surface changes — both new members are private to `DynamoView`.

### Release Notes

Dynamo no longer opens off-screen when the monitor it was last used on is disconnected or rearranged; the window is recentered on the primary display when the saved position is no longer visible.

### Reviewers

Open to the Dynamo team — happy to add specific reviewers on request.

Manual verification: launch Dynamo on a secondary monitor, close it, disconnect that monitor, and relaunch — the window comes back centered on the primary display instead of off-screen. Repeat at 100% and 150% display scaling.

### FYIs

@JacobSmall (filed the related DynamoRevit issue)
