### PR TITLE
DYN-10842 Fix flaky test: NoteViewTests.T02_ZIndex_Test_NoteGreaterThanNode

### DIFF
--- a/test/DynamoCoreWpf3Tests/NoteViewTests.cs
+++ b/test/DynamoCoreWpf3Tests/NoteViewTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Windows.Input;
+using Dynamo.Models;
 using Dynamo.Selection;
 using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
@@ -13,7 +14,19 @@ namespace DynamoCoreWpfTests
 
         public override void Open(string path)
         {
+            // These graphs run RunType="Automatic", so a single DoEvents() pump can
+            // return before the background evaluation (and its UI updates) finishes,
+            // racing under CI load. Waiting for EvaluationCompleted closes that race.
+            // See DYN-10842.
+            var evaluationCompleted = false;
+            EventHandler<EvaluationCompletedEventArgs> markDone = (s, e) => evaluationCompleted = true;
+            ViewModel.Model.EvaluationCompleted += markDone;
+
             base.Open(path);
+
+            DispatcherUtil.DoEventsLoop(() => evaluationCompleted, timeoutSeconds: 10);
+
+            ViewModel.Model.EvaluationCompleted -= markDone;
 
             DispatcherUtil.DoEvents();
         }

--- a/test/DynamoCoreWpf3Tests/NoteViewTests.cs
+++ b/test/DynamoCoreWpf3Tests/NoteViewTests.cs
@@ -18,16 +18,21 @@ namespace DynamoCoreWpfTests
             // return before the background evaluation (and its UI updates) finishes,
             // racing under CI load. Waiting for EvaluationCompleted closes that race.
             // See DYN-10842.
-            var evaluationCompleted = false;
-            EventHandler<EvaluationCompletedEventArgs> markDone = (s, e) => evaluationCompleted = true;
+            var evaluationCompleted = 0;
+            EventHandler<EvaluationCompletedEventArgs> markDone = (_, __) => System.Threading.Interlocked.Exchange(ref evaluationCompleted, 1);
             ViewModel.Model.EvaluationCompleted += markDone;
 
-            base.Open(path);
+            try
+            {
+                base.Open(path);
 
-            DispatcherUtil.DoEventsLoop(() => evaluationCompleted, timeoutSeconds: 10);
-
-            ViewModel.Model.EvaluationCompleted -= markDone;
-
+                DispatcherUtil.DoEventsLoop(() => System.Threading.Volatile.Read(ref evaluationCompleted) == 1, timeoutSeconds: 10);
+                Assert.That(System.Threading.Volatile.Read(ref evaluationCompleted) == 1, $"Timed out waiting for EvaluationCompleted after opening '{path}'.");
+            }
+            finally
+            {
+                ViewModel.Model.EvaluationCompleted -= markDone;
+            }
             DispatcherUtil.DoEvents();
         }
 

--- a/test/DynamoCoreWpf3Tests/NoteViewTests.cs
+++ b/test/DynamoCoreWpf3Tests/NoteViewTests.cs
@@ -17,7 +17,9 @@ namespace DynamoCoreWpfTests
             // These graphs run RunType="Automatic", so a single DoEvents() pump can
             // return before the background evaluation (and its UI updates) finishes,
             // racing under CI load. Waiting for EvaluationCompleted closes that race.
-            // See DYN-10842.
+            // Assumes every graph opened via this override is RunType="Automatic";
+            // a non-Automatic graph will never raise EvaluationCompleted and will
+            // burn the full 10s timeout before failing. See DYN-10842.
             var evaluationCompleted = 0;
             EventHandler<EvaluationCompletedEventArgs> markDone = (_, __) => System.Threading.Interlocked.Exchange(ref evaluationCompleted, 1);
             ViewModel.Model.EvaluationCompleted += markDone;

--- a/test/DynamoCoreWpf3Tests/NoteViewTests.cs
+++ b/test/DynamoCoreWpf3Tests/NoteViewTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Windows.Input;
+using Dynamo.Controls;
 using Dynamo.Models;
 using Dynamo.Selection;
 using DynamoCoreWpfTests.Utility;

--- a/test/DynamoCoreWpf3Tests/NoteViewTests.cs
+++ b/test/DynamoCoreWpf3Tests/NoteViewTests.cs
@@ -45,6 +45,34 @@ namespace DynamoCoreWpfTests
             DispatcherUtil.DoEvents();
         }
 
+        /// <summary>
+        /// Resolves the NodeView for the given guid, waiting for its ZIndex to reach a
+        /// stable, non-zero value before returning it. ZIndex is assigned exactly once,
+        /// in the NodeViewModel constructor (never to 0), so a 0 read here means the
+        /// container/view-model pairing observed is not yet the final one -- e.g. it is
+        /// still settling after Open(). Waiting here avoids asserting against that
+        /// transient state without weakening the assertions that consume the result.
+        /// See DYN-10842.
+        /// </summary>
+        private NodeView WaitForStableNodeView(string guid, int timeoutSeconds = 5)
+        {
+            NodeView result = null;
+            DispatcherUtil.DoEventsLoop(() =>
+            {
+                var matches = View.NodeViewsInFirstWorkspace()
+                    .Where(x => x.ViewModel.NodeLogic.GUID.ToString() == guid)
+                    .ToList();
+
+                if (matches.Count != 1) return false;
+
+                result = matches[0];
+                return result.ViewModel.ZIndex != 0;
+            }, timeoutSeconds);
+
+            Assert.IsNotNull(result, $"Timed out waiting for a stable NodeView with guid: {guid}");
+            return result;
+        }
+
         [Test]
         public void T01_ZIndex_Test_MouseDown()
         {
@@ -81,7 +109,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(3 + ViewModel.HomeSpace.Notes.Count() + ViewModel.HomeSpace.Nodes.Count(), Dynamo.ViewModels.NoteViewModel.StaticZIndex);
 
             // Index of First Node (initally) == 4
-            var nodeView = NodeViewWithGuid("bbc16882-75c2-4a50-a4e4-5e50e191af8f");
+            var nodeView = WaitForStableNodeView("bbc16882-75c2-4a50-a4e4-5e50e191af8f");
             Assert.AreEqual(4, nodeView.ViewModel.ZIndex);
             Assert.AreEqual(3 + ViewModel.HomeSpace.Nodes.Count(), Dynamo.ViewModels.NodeViewModel.StaticZIndex);
 
@@ -98,7 +126,7 @@ namespace DynamoCoreWpfTests
 
             Open(@"UI\UINotes.dyn");
             var noteView = NoteViewWithGuid("4677e999-d5f5-4bb2-9706-a97bf3a86711");
-            var nodeView = NodeViewWithGuid("bbc16882-75c2-4a50-a4e4-5e50e191af8f");
+            var nodeView = WaitForStableNodeView("bbc16882-75c2-4a50-a4e4-5e50e191af8f");
 
             // Click on First Node
             nodeView.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left)


### PR DESCRIPTION
### Purpose

The mechanism `RunType="Automatic"` on **UINotes.dyn** means `Open()` triggers graph evaluation on the background `DynamoScheduler` thread. When it finishes, HomeWorkspaceViewModel.hwm_EvaluationCompleted fires from that background thread and re-enters the UI thread via `DynamoViewModel.UIDispatcher.BeginInvoke(...)` — an indeterminate-latency hop back onto the dispatcher queue, separate from whatever OpenCommand.Execute() did synchronously.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

 Test graphs in this suite are `RunType="Automatic"`, so opening them kicks off evaluation on the background scheduler thread. A single `DoEvents()` pump only drains work already queued on the dispatcher; it does not wait for that background evaluation (and the UI updates it marshals back via `Dispatcher.BeginInvoke` once complete) to finish.
On a fast/idle machine that work reliably finishes within the single pump, but under CI load (thread-pool contention, GC pauses) it can still be in flight when assertions run immediately afterwards, producing intermittent failures. Waiting for `EvaluationCompleted` closes that race.

### Reviewers

@jasonstratton @RobertGlobant20 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
