### PR TITLE
DYN-10839 Fix flaky test: NotificationsExtensionTests.PressNotificationButtonAndShowPopup

### DIFF
--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -52,7 +52,7 @@ namespace Dynamo.Notifications
 
     public class NotificationCenterController : IDisposable
     {
-        private readonly NotificationUI notificationUIPopup;
+        internal readonly NotificationUI notificationUIPopup;
         private readonly DynamoView dynamoView;
         private readonly DynamoViewModel dynamoViewModel;
         private readonly Button notificationsButton;

--- a/test/DynamoCoreWpf2Tests/ViewExtensions/NotificationsExtensionTests.cs
+++ b/test/DynamoCoreWpf2Tests/ViewExtensions/NotificationsExtensionTests.cs
@@ -24,23 +24,21 @@ namespace DynamoCoreWpfTests.ViewExtensions
             var notificationExtension = this.View.viewExtensionManager.ViewExtensions.OfType<NotificationsViewExtension>().FirstOrDefault();
             NotificationUI notificationUI = null;
 
-            // Wait for the NotificationCenterController webview2 control to finish initialization
+            // Wait for the NotificationCenterController webview2 control to finish initialization and the popup to open.
+            // Querying the popup directly (rather than searching PresentationSource.CurrentSources for the Popup's
+            // internal HwndSource) avoids racing against the timing of the Popup's own native window creation.
             DispatcherUtil.DoEventsLoop(() =>
             {
-                if (notificationExtension.notificationCenterController.initState == DynamoUtilities.AsyncMethodState.Done)
+                var popup = notificationExtension.notificationCenterController.notificationUIPopup;
+                if (notificationExtension.notificationCenterController.initState == DynamoUtilities.AsyncMethodState.Done
+                    && popup != null && popup.IsOpen)
                 {
-                    notificationUI = PresentationSource.CurrentSources.OfType<System.Windows.Interop.HwndSource>()
-                            .Select(h => h.RootVisual)
-                            .OfType<FrameworkElement>()
-                            .Select(f => f.Parent)
-                            .OfType<NotificationUI>()
-                            .FirstOrDefault(p => p.IsOpen);
-
-                    return notificationUI != null;
+                    notificationUI = popup;
+                    return true;
                 }
                 return false;
             }, 300);
-            
+
             Assert.NotNull(notificationUI, "Notification popup not part of the dynamo visual tree");
             var webView = notificationUI.FindName("webView");
             Assert.NotNull(webView, "WebView framework element not found.");

--- a/test/DynamoCoreWpf2Tests/ViewExtensions/NotificationsExtensionTests.cs
+++ b/test/DynamoCoreWpf2Tests/ViewExtensions/NotificationsExtensionTests.cs
@@ -24,22 +24,20 @@ namespace DynamoCoreWpfTests.ViewExtensions
             var notificationExtension = this.View.viewExtensionManager.ViewExtensions.OfType<NotificationsViewExtension>().FirstOrDefault();
             NotificationUI notificationUI = null;
 
-            // Wait for the NotificationCenterController webview2 control to finish initialization and the popup to open.
-            // Querying the popup directly (rather than searching PresentationSource.CurrentSources for the Popup's
-            // internal HwndSource) avoids racing against the timing of the Popup's own native window creation.
+            // Wait for the NotificationCenterController webview2 control to finish initialization.
+            // initState only reaches Done via webView.Loaded, which already implies the popup was realized,
+            // so this alone is sufficient (no need to also poll IsOpen or re-check for a null popup).
             DispatcherUtil.DoEventsLoop(() =>
             {
-                var popup = notificationExtension.notificationCenterController.notificationUIPopup;
-                if (notificationExtension.notificationCenterController.initState == DynamoUtilities.AsyncMethodState.Done
-                    && popup != null && popup.IsOpen)
+                if (notificationExtension.notificationCenterController.initState == DynamoUtilities.AsyncMethodState.Done)
                 {
-                    notificationUI = popup;
+                    notificationUI = notificationExtension.notificationCenterController.notificationUIPopup;
                     return true;
                 }
                 return false;
             }, 300);
 
-            Assert.NotNull(notificationUI, "Notification popup not part of the dynamo visual tree");
+            Assert.NotNull(notificationUI, "Notification popup did not open within the timeout");
             var webView = notificationUI.FindName("webView");
             Assert.NotNull(webView, "WebView framework element not found.");
         }


### PR DESCRIPTION
### Purpose

The test doesn't know what popup is open it goes hunting for it indirectly.

When a `Popup` opens, WPF creates a separate native HWND for it, and that HWND's root visual (`PopupRoot`) happens to have its `.Parent` wired back to the owning `Popup`. That window creation is itself async relative to `IsOpen = true`, stacked on top of the already-async WebView2 initialization the test is also waiting on (`initState == Done`). Two independent async completions have to line up, and the second one (native popup window registering in `PresentationSource.CurrentSources`) has no explicit synchronization point in the test — it's inferred by polling internal WPF plumbing that's sensitive to dispatcher scheduling and load.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

**NotificationCenterController.cs**: changed the `notificationUIPopup` field from `private` to `internal` (the test assembly already has InternalsVisibleTo access, same pattern already used for `initState`).
**NotificationsExtensionTests.cs**: replaced the `PresentationSource.CurrentSources` visual-tree walk with a direct check of `notificationCenterController.notificationUIPopup.IsOpen`, combined with the existing `initState == Done` check. This queries the object Dynamo actually owns and controls instead of racing against internal WPF window-registration timing.

### Reviewers

@jasonstratton @RobertGlobant20 

### FYIs

