### PR TITLE
DYN-10821: Expose API to programmatically collapse and expand node groups

### DIFF
--- a/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
+++ b/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
@@ -413,9 +413,12 @@ namespace Dynamo.Graph.Annotations
             get { return isExpanded; }
             set
             {
+                if (isExpanded == value) return;
+
                 isExpanded = value;
                 UpdateBoundaryFromSelection();
                 UpdateErrorAndWarningIconVisibility();
+                RaisePropertyChanged(nameof(IsExpanded));
             }
         }
 
@@ -1024,7 +1027,7 @@ namespace Dynamo.Graph.Annotations
             this.InitialTop = helper.ReadDouble("InitialTop", DoubleValue);
             this.InitialHeight = helper.ReadDouble("InitialHeight", DoubleValue);
             this.IsSelected = helper.ReadBoolean(nameof(IsSelected), false);
-            this.IsExpanded = helper.ReadBoolean(nameof(IsExpanded), true);
+            this.isExpanded = helper.ReadBoolean(nameof(IsExpanded), true);
             this.IsOptionalInPortsCollapsed = helper.ReadBoolean(nameof(IsOptionalInPortsCollapsed), true);
             this.IsUnconnectedOutPortsCollapsed = helper.ReadBoolean(nameof(IsUnconnectedOutPortsCollapsed), true);
             this.HasToggledOptionalInPorts = helper.ReadBoolean(nameof(HasToggledOptionalInPorts), false);
@@ -1074,6 +1077,7 @@ namespace Dynamo.Graph.Annotations
             RaisePropertyChanged(nameof(AnnotationText));
             RaisePropertyChanged(nameof(Nodes));
             RaisePropertyChanged(nameof(IsExpanded));
+            UpdateErrorAndWarningIconVisibility();
             RaisePropertyChanged(nameof(IsOptionalInPortsCollapsed));
             RaisePropertyChanged(nameof(IsUnconnectedOutPortsCollapsed));
             this.ReportPosition();

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -38,6 +38,8 @@ Dynamo.ViewModels.PreferencesViewModel.AutoSyncDocumentBrowserIsChecked.get -> b
 Dynamo.ViewModels.PreferencesViewModel.AutoSyncDocumentBrowserIsChecked.set -> void
 Dynamo.ViewModels.PreferencesViewModel.ShowPythonAutoMigrationNotificationIsChecked.get -> bool
 Dynamo.ViewModels.PreferencesViewModel.ShowPythonAutoMigrationNotificationIsChecked.set -> void
+Dynamo.ViewModels.WorkspaceViewModel.GetGroupCollapsed(System.Guid groupId) -> bool
+Dynamo.ViewModels.WorkspaceViewModel.SetGroupCollapsed(System.Guid groupId, bool collapsed) -> void
 Dynamo.Wpf.UI.ToastManager
 Dynamo.Wpf.UI.ToastManager.CloseRealTimeInfoWindow() -> void
 Dynamo.Wpf.UI.ToastManager.CreateRealTimeInfoWindow(string content, bool stayOpen = false, string headerText = "", string hyperlinkText = "", System.Uri hyperlinkUri = null, System.Uri fileLinkUri = null) -> void

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -362,6 +362,8 @@ namespace Dynamo.ViewModels
             get => annotationModel.IsExpanded;
             set
             {
+                if (annotationModel.IsExpanded == value) return;
+
                 // This change is triggered by the user interaction in the View.
                 // Before we updating the value in the Model and ViewModel
                 // we record the current state in the UndoRedoStack.
@@ -374,8 +376,6 @@ namespace Dynamo.ViewModels
 
                 annotationModel.IsExpanded = value;
 
-                // Methods to collapse or expand the group based on the new value of IsExpanded.
-                ManageAnnotationMVExpansionAndCollapse();
                 HandlePrePortToggleLayout();
             }
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1289,16 +1289,8 @@ namespace Dynamo.ViewModels
         /// <exception cref="ArgumentException">Thrown when no annotation matches <paramref name="groupId"/>.</exception>
         public bool GetGroupCollapsed(Guid groupId)
         {
-            var annotation = Model.Annotations.FirstOrDefault(x => x.GUID == groupId);
-
-            if (annotation == null)
-            {
-                throw new ArgumentException($"No annotation group found with id: '{groupId}'.", nameof(groupId));
-            }
-
-            return !annotation.IsExpanded;
+            return !GetAnnotationViewModel(groupId).IsExpanded;
         }
-
 
         /// <summary>
         /// Collapses or expands an annotation group. The change is recordable and undoable.
@@ -1308,7 +1300,7 @@ namespace Dynamo.ViewModels
         /// <exception cref="ArgumentException">Thrown when no annotation matches <paramref name="groupId"/>.</exception>
         public void SetGroupCollapsed(Guid groupId, bool collapsed)
         {
-            var annotation = Model.Annotations.FirstOrDefault(x => x.GUID == groupId);
+            var annotation = GetAnnotationViewModel(groupId);
 
             if (annotation == null)
             {
@@ -1324,6 +1316,16 @@ namespace Dynamo.ViewModels
                     annotation.GUID,
                     nameof(AnnotationModel.IsExpanded),
                     expanded.ToString()));
+        }
+
+        private AnnotationModel GetAnnotationViewModel(Guid groupId)
+        {
+            var annotation = Annotations.FirstOrDefault(x => x.AnnotationModel.GUID == groupId);
+            if (annotation == null)
+            {
+                throw new ArgumentException($"No annotation group found with id: '{groupId}'.", nameof(groupId));
+            }
+            return annotation.AnnotationModel;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1282,6 +1282,51 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// Returns whether the annotation group is collapsed.
+        /// </summary>
+        /// <param name="groupId">GUID of the annotation group.</param>
+        /// <returns>True if the group is collapsed; false if expanded.</returns>
+        /// <exception cref="ArgumentException">Thrown when no annotation matches <paramref name="groupId"/>.</exception>
+        public bool GetGroupCollapsed(Guid groupId)
+        {
+            var annotation = Model.Annotations.FirstOrDefault(x => x.GUID == groupId);
+
+            if (annotation == null)
+            {
+                throw new ArgumentException($"No annotation group found with id: '{groupId}'.", nameof(groupId));
+            }
+
+            return !annotation.IsExpanded;
+        }
+
+
+        /// <summary>
+        /// Collapses or expands an annotation group. The change is recordable and undoable.
+        /// </summary>
+        /// <param name="groupId">GUID of the annotation group.</param>
+        /// <param name="collapsed">True to collapse; false to expand.</param>
+        /// <exception cref="ArgumentException">Thrown when no annotation matches <paramref name="groupId"/>.</exception>
+        public void SetGroupCollapsed(Guid groupId, bool collapsed)
+        {
+            var annotation = Model.Annotations.FirstOrDefault(x => x.GUID == groupId);
+
+            if (annotation == null)
+            {
+                throw new ArgumentException($"No annotation group found with id: '{groupId}'.", nameof(groupId));
+            }
+
+            var expanded = !collapsed;
+            if (annotation.IsExpanded == expanded) return;
+
+            DynamoViewModel.ExecuteCommand(
+                new DynamoModel.UpdateModelValueCommand(
+                    Guid.Empty,
+                    annotation.GUID,
+                    nameof(AnnotationModel.IsExpanded),
+                    expanded.ToString()));
+        }
+
+        /// <summary>
         /// Determine if a Dynamo element belongs to a collapsed group or sub group of a collapsed group
         /// </summary>
         /// <param name="model">Target node, note, annotation</param>

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1289,7 +1289,7 @@ namespace Dynamo.ViewModels
         /// <exception cref="ArgumentException">Thrown when no annotation matches <paramref name="groupId"/>.</exception>
         public bool GetGroupCollapsed(Guid groupId)
         {
-            return !GetAnnotationViewModel(groupId).IsExpanded;
+            return !GetAnnotationModel(groupId).IsExpanded;
         }
 
         /// <summary>
@@ -1300,7 +1300,7 @@ namespace Dynamo.ViewModels
         /// <exception cref="ArgumentException">Thrown when no annotation matches <paramref name="groupId"/>.</exception>
         public void SetGroupCollapsed(Guid groupId, bool collapsed)
         {
-            var annotation = GetAnnotationViewModel(groupId);
+            var annotation = GetAnnotationModel(groupId);
 
             if (annotation == null)
             {
@@ -1312,13 +1312,13 @@ namespace Dynamo.ViewModels
 
             DynamoViewModel.ExecuteCommand(
                 new DynamoModel.UpdateModelValueCommand(
-                    Guid.Empty,
+                    Model.Guid,
                     annotation.GUID,
                     nameof(AnnotationModel.IsExpanded),
                     expanded.ToString()));
         }
 
-        private AnnotationModel GetAnnotationViewModel(Guid groupId)
+        private AnnotationModel GetAnnotationModel(Guid groupId)
         {
             var annotation = Annotations.FirstOrDefault(x => x.AnnotationModel.GUID == groupId);
             if (annotation == null)

--- a/test/DynamoCoreTests/Graph/Annotations/AnnotationModelTests.cs
+++ b/test/DynamoCoreTests/Graph/Annotations/AnnotationModelTests.cs
@@ -309,5 +309,36 @@ namespace Dynamo.Tests
             Assert.AreEqual(resizedWidth, annotationModel.Width);
             Assert.AreEqual(resizedHeight, annotationModel.Height);
         }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenIsExpandedChangesThenPropertyChangedIsRaised()
+        {
+            var raised = false;
+            annotationModel.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(AnnotationModel.IsExpanded))
+                    raised = true;
+            };
+            annotationModel.IsExpanded = false;
+
+            Assert.IsTrue(raised);
+            Assert.IsFalse(annotationModel.IsExpanded);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenIsExpandedSetToSameValueThenPropertyChangedIsNotRaised()
+        {
+            var raised = false;
+            annotationModel.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(AnnotationModel.IsExpanded))
+                    raised = true;
+            };
+            annotationModel.IsExpanded = true;
+
+            Assert.IsFalse(raised);
+        }
     }
 }

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -1692,6 +1692,7 @@ namespace DynamoCoreWpfTests
             // Assert that the group is now collapsed and the graph has unsaved changes
             Assert.IsTrue(workspaceVm.GetGroupCollapsed(groupId));
             Assert.IsFalse(groupVm.IsExpanded);
+            Assert.That(groupVm.ViewModelBases.All(x => x.IsCollapsed));
             Assert.IsTrue(ViewModel.CurrentSpace.HasUnsavedChanges);
 
             // Undo the collapse
@@ -1700,6 +1701,40 @@ namespace DynamoCoreWpfTests
             // Assert that the group is no longer collapsed and the graph has unsaved changes
             Assert.IsFalse(workspaceVm.GetGroupCollapsed(groupId));
             Assert.IsTrue(groupVm.IsExpanded);
+            Assert.That(groupVm.ViewModelBases.All(x => !x.IsCollapsed));
+
+            ViewModel.RedoCommand.Execute(null);
+
+            Assert.IsTrue(workspaceVm.GetGroupCollapsed(groupId));
+            Assert.That(groupVm.ViewModelBases.All(x => x.IsCollapsed));
+        }
+
+        [Test]
+        [Category("DynamoUI")]
+        public void WhenGroupIdIsUnknownThenGetAndSetGroupCollapsedThrow()
+        {
+            var workspaceVm = ViewModel.CurrentSpaceViewModel;
+            var unknownId = Guid.NewGuid();
+
+            Assert.Throws<ArgumentException>(() => workspaceVm.GetGroupCollapsed(unknownId));
+            Assert.Throws<ArgumentException>(() => workspaceVm.SetGroupCollapsed(unknownId, true));
+        }
+
+        [Test]
+        [Category("DynamoUI")]
+        public void WhenSetGroupCollapsedOnNestedParentThenContentsAndNestedGroupAreCollapsed()
+        {
+            OpenModel(@"core\annotationViewModelTests\groupsTestFile.dyn");
+
+            var workspaceVm = ViewModel.CurrentSpaceViewModel;
+            var parent = workspaceVm.Annotations.First(x => x.AnnotationText == "GroupWithGroupedGroup");
+            var nested = workspaceVm.Annotations.First(x => x.AnnotationText == "GroupInsideOtherGroup");
+
+            workspaceVm.SetGroupCollapsed(parent.AnnotationModel.GUID, true);
+
+            Assert.IsTrue(workspaceVm.GetGroupCollapsed(parent.AnnotationModel.GUID));
+            Assert.That(parent.ViewModelBases.All(x => x.IsCollapsed));
+            Assert.IsTrue(nested.IsCollapsed);
         }
 
         #endregion

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -1665,6 +1665,43 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(2, connectors.Count(c => c.IsCollapsed));
         }
 
+        [Test]
+        [Category("DynamoUI")]
+        public void WhenSetGroupCollapsedThenGroupIsCollapsedAndUndoRestoresIt()
+        {
+            // Arrange - create a new group with a node in it
+            var addNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
+            DynamoSelection.Instance.Selection.Add(addNode);
+            ViewModel.AddAnnotationCommand.Execute(null);
+
+            var workspaceVm = ViewModel.CurrentSpaceViewModel;
+            var groupVm = workspaceVm.Annotations.FirstOrDefault();
+
+            // Assert that the group was created and is not collapsed
+            Assert.IsNotNull(groupVm, "Expected a group after AddAnnotationCommand.");
+
+            var groupId = groupVm.AnnotationModel.GUID;
+            Assert.IsFalse(workspaceVm.GetGroupCollapsed(groupId));
+
+            ViewModel.CurrentSpace.HasUnsavedChanges = false;
+
+            // Collapse the group
+            workspaceVm.SetGroupCollapsed(groupId, true);
+
+            // Assert that the group is now collapsed and the graph has unsaved changes
+            Assert.IsTrue(workspaceVm.GetGroupCollapsed(groupId));
+            Assert.IsFalse(groupVm.IsExpanded);
+            Assert.IsTrue(ViewModel.CurrentSpace.HasUnsavedChanges);
+
+            // Undo the collapse
+            ViewModel.UndoCommand.Execute(null);
+
+            // Assert that the group is no longer collapsed and the graph has unsaved changes
+            Assert.IsFalse(workspaceVm.GetGroupCollapsed(groupId));
+            Assert.IsTrue(groupVm.IsExpanded);
+        }
+
         #endregion
     }
 }

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -719,7 +719,6 @@ namespace DynamoCoreWpfTests
             string newName = "A1B2C3";
             var workspaceVm = ViewModel.CurrentSpaceViewModel;
             var groupVm = workspaceVm.Annotations.First();
-            groupVm.IsExpanded = true;
 
             // Assert that initial conditions are met
             Assert.IsNotNull(groupVm, "Expected an initial group to be present");
@@ -727,8 +726,8 @@ namespace DynamoCoreWpfTests
             Assert.IsFalse(groupVm.AnnotationText.Equals(newName));
 
             // Rename and collapse the group
-            groupVm.AnnotationText = newName;
-            groupVm.IsExpanded = false;
+            ViewModel.ExecuteCommand(new DynamoModel.UpdateModelValueCommand(Guid.Empty, groupId, "TextBlockText", newName));
+            workspaceVm.SetGroupCollapsed(groupId, true);
 
             // Assert initial action
             Assert.IsFalse(groupVm.IsExpanded, "Group should be collapsed");

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -719,6 +719,7 @@ namespace DynamoCoreWpfTests
             string newName = "A1B2C3";
             var workspaceVm = ViewModel.CurrentSpaceViewModel;
             var groupVm = workspaceVm.Annotations.First();
+            var groupId = groupVm.AnnotationModel.GUID;
 
             // Assert that initial conditions are met
             Assert.IsNotNull(groupVm, "Expected an initial group to be present");

--- a/test/DynamoCoreWpfTests/AnnotationViewTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewTests.cs
@@ -222,5 +222,64 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(initialWorkspaceNodeCount + 1, ws.Nodes.Count(), "A new node should be created in the workspace.");
             Assert.AreEqual(initialGroupNodeCount, groupModel.Nodes.Count(), "Collapsed group should NOT receive the new node.");
         }
+
+        [Test]
+        [Category("DynamoUI")]
+        public void WhenAnnotationModelIsExpandedSetFalseThenGroupCollapsesOnCanvas()
+        {
+            // Arrange
+            Open(@"core\annotationViewModelTests\groupsTestFile.dyn");
+
+            var annotationModel = Model.CurrentWorkspace.Annotations.First();
+            var workspaceViewModel = ViewModel.CurrentSpaceViewModel;
+            var groupId = annotationModel.GUID;
+
+            // Assert initial state - the group is expanded
+            Assert.IsNotNull(annotationModel);
+            Assert.IsTrue(annotationModel.IsExpanded);
+            Assert.IsFalse(workspaceViewModel.GetGroupCollapsed(groupId));
+
+            // Collapse through the model
+            annotationModel.IsExpanded = false;
+            DispatcherUtil.DoEvents();
+
+            // Assert that the group is collapsed on the canvas
+            Assert.IsFalse(annotationModel.IsExpanded);
+            Assert.IsTrue(workspaceViewModel.GetGroupCollapsed(groupId));
+            Assert.IsFalse(workspaceViewModel.Annotations.First().IsExpanded);
+        }
+
+        [Test]
+        [Category("DynamoUI")]
+        public void WhenSetGroupCollapsedThenGroupCollapseStateMatches()
+        {
+            // Arrange
+            Open(@"core\annotationViewModelTests\groupsTestFile.dyn");
+
+            var annotationModel = Model.CurrentWorkspace.Annotations.First();
+            var workspaceViewModel = ViewModel.CurrentSpaceViewModel;
+            var groupId = annotationModel.GUID;
+
+            // Assert initial state - the group is expanded
+            Assert.IsNotNull(annotationModel);
+            Assert.IsTrue(annotationModel.IsExpanded);
+            Assert.IsFalse(workspaceViewModel.GetGroupCollapsed(groupId));
+
+            // Collapse through the workspace view model
+            workspaceViewModel.SetGroupCollapsed(groupId, collapsed: true);
+            DispatcherUtil.DoEvents();
+
+            // Assert that the group is collapsed on the canvas
+            Assert.IsTrue(workspaceViewModel.GetGroupCollapsed(groupId));
+            Assert.IsFalse(workspaceViewModel.Annotations.First().IsExpanded);
+
+            // Expand through the workspace view model
+            workspaceViewModel.SetGroupCollapsed(groupId, collapsed: false);
+            DispatcherUtil.DoEvents();
+
+            // Assert that the group is expanded on the canvas
+            Assert.IsFalse(workspaceViewModel.GetGroupCollapsed(groupId));
+            Assert.IsTrue(workspaceViewModel.Annotations.First().IsExpanded);
+        }
     }
 }

--- a/test/DynamoCoreWpfTests/AnnotationViewTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewTests.cs
@@ -230,23 +230,25 @@ namespace DynamoCoreWpfTests
             // Arrange
             Open(@"core\annotationViewModelTests\groupsTestFile.dyn");
 
-            var annotationModel = Model.CurrentWorkspace.Annotations.First();
             var workspaceViewModel = ViewModel.CurrentSpaceViewModel;
-            var groupId = annotationModel.GUID;
+            var groupVm = workspaceViewModel.Annotations.First();
+            var groupId = groupVm.AnnotationModel.GUID;
+
 
             // Assert initial state - the group is expanded
-            Assert.IsNotNull(annotationModel);
-            Assert.IsTrue(annotationModel.IsExpanded);
+            Assert.IsTrue(groupVm.IsExpanded);
             Assert.IsFalse(workspaceViewModel.GetGroupCollapsed(groupId));
+            Assert.That(groupVm.ViewModelBases.Any());
+            Assert.That(groupVm.ViewModelBases.All(x => !x.IsCollapsed));
 
             // Collapse through the model
-            annotationModel.IsExpanded = false;
+            groupVm.AnnotationModel.IsExpanded = false;
             DispatcherUtil.DoEvents();
 
             // Assert that the group is collapsed on the canvas
-            Assert.IsFalse(annotationModel.IsExpanded);
             Assert.IsTrue(workspaceViewModel.GetGroupCollapsed(groupId));
-            Assert.IsFalse(workspaceViewModel.Annotations.First().IsExpanded);
+            Assert.IsFalse(groupVm.IsExpanded);
+            Assert.That(groupVm.ViewModelBases.All(x => x.IsCollapsed));
         }
 
         [Test]
@@ -256,13 +258,12 @@ namespace DynamoCoreWpfTests
             // Arrange
             Open(@"core\annotationViewModelTests\groupsTestFile.dyn");
 
-            var annotationModel = Model.CurrentWorkspace.Annotations.First();
             var workspaceViewModel = ViewModel.CurrentSpaceViewModel;
-            var groupId = annotationModel.GUID;
+            var groupVm = workspaceViewModel.Annotations.First();
+            var groupId = groupVm.AnnotationModel.GUID;
 
             // Assert initial state - the group is expanded
-            Assert.IsNotNull(annotationModel);
-            Assert.IsTrue(annotationModel.IsExpanded);
+            Assert.IsTrue(groupVm.IsExpanded);
             Assert.IsFalse(workspaceViewModel.GetGroupCollapsed(groupId));
 
             // Collapse through the workspace view model
@@ -271,7 +272,8 @@ namespace DynamoCoreWpfTests
 
             // Assert that the group is collapsed on the canvas
             Assert.IsTrue(workspaceViewModel.GetGroupCollapsed(groupId));
-            Assert.IsFalse(workspaceViewModel.Annotations.First().IsExpanded);
+            Assert.IsFalse(groupVm.IsExpanded);
+            Assert.That(groupVm.ViewModelBases.All(x => x.IsCollapsed));
 
             // Expand through the workspace view model
             workspaceViewModel.SetGroupCollapsed(groupId, collapsed: false);
@@ -279,7 +281,8 @@ namespace DynamoCoreWpfTests
 
             // Assert that the group is expanded on the canvas
             Assert.IsFalse(workspaceViewModel.GetGroupCollapsed(groupId));
-            Assert.IsTrue(workspaceViewModel.Annotations.First().IsExpanded);
+            Assert.IsTrue(groupVm.IsExpanded);
+            Assert.That(groupVm.ViewModelBases.All(x => !x.IsCollapsed));
         }
     }
 }


### PR DESCRIPTION
### Purpose

This PR aims to address [DYN-10821](https://autodesk.atlassian.net/browse/DYN-10821?atlOrigin=eyJpIjoiMWNiNTcyY2M1NjQzNGIxZDlmNjAxOWRiYzcyZjNiNmIiLCJwIjoiaiJ9).

Automation and AI assistants could create and style groups, but could not tidy the canvas by collapsing completed sections.

The changes here add a public get/set for a group's collapsed state and makes `AnnotationModel.IsExpanded` notify so a programmatic change updates the live workspace (contents, connectors, proxy ports), not only the model flag.

Key changes:
- `WorkspaceViewModel.GetGroupCollapsed(Guid)` and `WorkspaceViewModel.SetGroupCollapsed(Guid, bool)` — additive public API, registered in `DynamoCoreWpf/PublicAPI.Unshipped.txt`
- `SetGroupCollapsed` goes through `UpdateModelValueCommand`, so the change is undoable and marks the graph dirty
- `AnnotationModel.IsExpanded` raises `PropertyChanged`; the view-model collapses/expands from that notification
- Tests for get/set, canvas contents, undo/redo, unknown id, and nested groups

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Added a public API to collapse and expand node groups by id, so graphs can be organised programmatically without clicking each group header.

### Reviewers

@DynamoDS/eidos
@jasonstratton
@johnpierson

### FYIs

@dnenov 
