### PR TITLE
DYN-10756: undo/redo exposed for mcp

### DIFF
--- a/doc/distrib/xml/en-US/DSCoreNodes.xml
+++ b/doc/distrib/xml/en-US/DSCoreNodes.xml
@@ -353,7 +353,7 @@
         </member>
         <member name="M:DSCore.Data.DynamoJObjectToNative(Newtonsoft.Json.Linq.JObject)">
             <summary>
-            Parse implementation for converting JObject types to specific Dynamo objects (ie Geometry, Color, Images, etc) 
+            Parse implementation for converting JObject types to specific Dynamo objects (ie Geometry, Color, Images, etc)
             </summary>
             <param name="jObject"></param>
             <returns></returns>
@@ -378,7 +378,7 @@
         </member>
         <member name="M:DSCore.Data.CanObjectBeCached(System.Object)">
             <summary>
-            Helper function to determine if object can be cached or if it is null, "null" string, or empty list.  
+            Helper function to determine if object can be cached or if it is null, "null" string, or empty list.
             </summary>
             <param name="inputObject">Object to check</param>
             <returns></returns>
@@ -485,7 +485,7 @@
         <member name="M:DSCore.Data.FindCommonAncestorBetweenTwoNodes(DSCore.Data.DataNodeDynamoType,DSCore.Data.DataNodeDynamoType)">
             <summary>
             Recursive function to try and find a common ancestor between two dynamo types
-            Climbs up the hierarchical tree of the likelyAncestor until it 
+            Climbs up the hierarchical tree of the likelyAncestor until it
             </summary>
             <param name="node">Check if this node is derived from the likely ancestor</param>
             <param name="likelyAncestor">The likely ancestor that the node should be deriving from</param>

--- a/src/DynamoCore/Core/UndoRedoRecorder.cs
+++ b/src/DynamoCore/Core/UndoRedoRecorder.cs
@@ -295,6 +295,18 @@ namespace Dynamo.Core
         public bool CanRedo { get { return redoStack.Count > 0; } }
 
         /// <summary>
+        /// True while an action group is open — that is, between a <see cref="BeginActionGroup"/>
+        /// call and the disposal of the root disposable it returned.
+        /// </summary>
+        /// <remarks>
+        /// Undo and redo both refuse to run while a group is open (see EnsureValidRecorderStates),
+        /// so a caller that holds a group open across several separate operations needs to be able
+        /// to ask whether one is currently open. See
+        /// <see cref="Dynamo.Graph.Workspaces.WorkspaceModel.BeginUndoActionGroup"/>.
+        /// </remarks>
+        public bool IsActionGroupOpen { get { return currentActionGroup != null; } }
+
+        /// <summary>
         /// The number of action groups currently on the undo stack that actually affect
         /// what would be written to the saved file (i.e. were recorded via
         /// RecordCreationForUndo/RecordDeletionForUndo, or RecordModificationForUndo with
@@ -524,6 +536,13 @@ namespace Dynamo.Core
         {
             private readonly UndoRedoRecorder recorder;
             private readonly bool isRoot;
+
+            // EndActionGroup throws when no group is open, so a second Dispose() would throw rather
+            // than no-op. A `using` block never disposes twice, but a caller holding the group open
+            // across separate calls (WorkspaceModel.BeginUndoActionGroup) can reach a second dispose
+            // on an error or teardown path, and a disposable that throws on redispose is a trap.
+            private bool disposed;
+
             public ActionGroupDisposable(UndoRedoRecorder recorder, bool isRoot)
             {
                 this.recorder = recorder;
@@ -532,6 +551,13 @@ namespace Dynamo.Core
 
             public void Dispose()
             {
+                if (disposed)
+                {
+                    return;
+                }
+
+                disposed = true;
+
                 if (isRoot)
                 {
                     recorder.EndActionGroup();

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -55,6 +55,71 @@ namespace Dynamo.Graph.Workspaces
             }
         }
 
+        /// <summary>
+        /// True while an undo action group opened by <see cref="BeginUndoActionGroup"/> is still open.
+        /// Undo and redo are unavailable while a group is open.
+        /// </summary>
+        public bool IsUndoActionGroupOpen
+        {
+            get
+            {
+                return (null != undoRecorder && undoRecorder.IsActionGroupOpen);
+            }
+        }
+
+        /// <summary>
+        /// Opens an undo action group that stays open until the returned object is disposed, so that
+        /// every change recorded in the meantime is reverted by a SINGLE undo.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Individual workspace operations already open their own action groups internally, and
+        /// nested groups are flattened into the outermost one. Holding a group open across several
+        /// operations therefore collapses all of them into one undo step, which is what an automation
+        /// client (for example an assistant applying a batch of edits in response to a single user
+        /// request) needs so the user can reverse the whole batch with one undo rather than one undo
+        /// per internal operation. The number of internal undo steps an operation occupies is an
+        /// implementation detail and varies per operation, so it is not something a client can
+        /// compensate for by counting.
+        /// </para>
+        /// <para>
+        /// The caller MUST dispose the returned object. While a group is open the recorder refuses
+        /// undo and redo, and nothing recorded in the group reaches the undo stack, so a group that
+        /// is never closed leaves undo unavailable and keeps absorbing later changes. Callers that
+        /// cannot use a <c>using</c> block — because the group spans several separate calls — must
+        /// hold the object and dispose it on every exit path, including error paths.
+        /// </para>
+        /// <para>
+        /// A group in which nothing was recorded is discarded rather than pushed onto the undo
+        /// stack, so opening and closing one around a read-only operation leaves the stack untouched.
+        /// </para>
+        /// </remarks>
+        /// <returns>
+        /// An object that closes the group when disposed. Disposing it more than once is safe.
+        /// </returns>
+        public IDisposable BeginUndoActionGroup()
+        {
+            if (null == undoRecorder)
+            {
+                return NoOpUndoActionGroup.Instance;
+            }
+
+            return undoRecorder.BeginActionGroup();
+        }
+
+        /// <summary>
+        /// Returned by <see cref="BeginUndoActionGroup"/> when there is no recorder to open a group
+        /// on, so that callers can always dispose the result unconditionally.
+        /// </summary>
+        private sealed class NoOpUndoActionGroup : IDisposable
+        {
+            internal static readonly NoOpUndoActionGroup Instance = new NoOpUndoActionGroup();
+
+            private NoOpUndoActionGroup() { }
+
+            public void Dispose() { }
+        }
+
         internal void Undo()
         {
             if (null != undoRecorder)


### PR DESCRIPTION
DYN-10756: Expose undo action groups as public API

UndoRedoRecorder already flattens nested action groups into the outermost open one, so holding a root group open across several operations collapses them into a single undo step. The machinery was complete but unreachable from outside core: the recorder type and WorkspaceModel.UndoRecorder are both internal. This adds public WorkspaceModel.BeginUndoActionGroup(), which opens a root group and returns the object that closes it, plus IsUndoActionGroupOpen and the recorder's IsActionGroupOpen behind it. The motivating case is an automation client -- an assistant applying a batch of edits in response to one user request -- that needs the user to reverse the whole batch with one undo rather than one undo per internal operation, since the number of undo steps an operation occupies is an implementation detail a client cannot compensate for by counting.

ActionGroupDisposable.Dispose() is now idempotent. EndActionGroup() throws when no group is open, so a second dispose used to throw; a using block never disposes twice, but a caller holding a group open across separate calls can reach a second dispose on an error or teardown path, and a disposable that throws on redispose is a trap. Callers of the new API take on a real obligation in exchange: the group cannot live in a using block, so it must be disposed on every exit path. While one is open the recorder refuses undo and redo and nothing recorded reaches the undo stack, so a group that is never closed leaves undo unavailable and keeps absorbing later changes. Groups in which nothing was recorded are still discarded rather than pushed, so opening one around a read-only operation leaves the stack untouched.

<!--
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. PRs will be reviewed from oldest to newest
3. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
4. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
5. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
6. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.
-->

### Purpose

(FILL ME IN) This section describes why this PR is here. Usually it would include a reference to the tracking task that it is part or all of the solution for.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

This PR works in conjunction with the infrastructure set up in: https://git.autodesk.com/Dynamo/DynamoMCP/pull/308. It should implement the undo/redo group function that bundles the changes that a single prompt makes into an undo group so a user should only have to press undo once to undo the changes made by a single prompt. 

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
