### PR TITLE
DYN-10840: Fix flaky test: DynamoViewTests.OpeningWorkspaceWithTrustWarning

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1958,6 +1958,7 @@ namespace Dynamo.ViewModels
             {
                 var newVm = new HomeWorkspaceViewModel(item as HomeWorkspaceModel, this);
                 workspaces.Insert(0, newVm);
+                currentWorkspaceViewModel = newVm;
 
                 // The RunSettings control is a child of the DynamoView,
                 // but has its DataContext set to the RunSettingsViewModel
@@ -1989,11 +1990,10 @@ namespace Dynamo.ViewModels
         {
             var viewModel = workspaces.First(x => x.Model == item);
             if (currentWorkspaceViewModel == viewModel)
-                if(currentWorkspaceViewModel != null)
-                {
-                    currentWorkspaceViewModel.Dispose();
-                }
+            {
+                currentWorkspaceViewModel.Dispose();
                 currentWorkspaceViewModel = null;
+            }
             workspaces.Remove(viewModel);
         }
 


### PR DESCRIPTION
### Purpose

`Assert.IsTrue(ViewModel.FileTrustViewModel.ShowWarningPopup)` intermittently fails with **Expected: True / But was: False**, even though `ShouldForceBlockRun` correctly determines the file is untrusted.

**Root cause:**

In _DynamoViewModel.cs_, `Open()` gates the trust-warning update on the raw private field, not the self-correcting public property:
```
if (currentWorkspaceViewModel?.IsHomeSpace ?? false)
{
    UpdateFileTrustWarningUi(displayTrustWarning, directoryName);
}
```
Opening a **.dyn** home workspace goes through `DynamoModel.OpenWorkspace()`, which removes the old home workspace and adds the new one. That fires two view-model event handlers:

- `WorkspaceRemoved` — nulls `currentWorkspaceViewModel` when the removed workspace matches (correct in this case, since the old empty home workspace is the current one).
- `WorkspaceAdded` — creates the new `HomeWorkspaceViewModel` and inserts it into the **workspaces** collection, but never reassigns `currentWorkspaceViewModel`.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

1. `WorkspaceAdded` now sets `currentWorkspaceViewModel = newVm;` immediately when a new home workspace is inserted, so the field is always correct and doesn't depend on some other code path incidentally hitting the getter first.
2. `WorkspaceRemoved` — fixed the dangling-brace bug so the null-out only happens when the removed workspace was actually the current one.

### Reviewers

@jasonstratton @RobertGlobant20 

@jnealb 

### FYIs