### PR TITLE
DYN-10841 Fix flaky test: RecordedTests.TestReconnectionUndo

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -44,6 +44,12 @@ namespace Dynamo.UI.Controls
         private State currentState = State.Hidden;
         private readonly Queue<State> queuedRequest = new Queue<State>();
 
+        // The pending mouse-hover fade-in delay timer, if one is currently running.
+        // Tracked so it can be stopped when the control is unloaded, preventing its
+        // Tick handler from running against a control/model that has since been torn down.
+        private DispatcherTimer fadeInDelayTimer;
+        private Action fadeInOnMouseLeave;
+
         // Data source and display.
         private CompactBubbleViewModel cachedSmallContent;
         private WatchViewModel cachedLargeContent;
@@ -567,10 +573,23 @@ namespace Dynamo.UI.Controls
             nodeViewModel.OnMouseLeave += onMouseLeave;
             delayTimer.Tick += (obj, e) =>
             {
-                Dispatcher.Invoke(ProcessFadeIn);
                 nodeViewModel.OnMouseLeave -= onMouseLeave;
                 delayTimer.Stop();
+                fadeInDelayTimer = null;
+                fadeInOnMouseLeave = null;
+
+                // The control may have been unloaded (e.g. the node/workspace was
+                // torn down) while this timer was pending; in that case the scheduler
+                // backing this control is no longer valid, so skip the refresh.
+                if (!IsLoaded) return;
+
+                Dispatcher.Invoke(ProcessFadeIn);
             };
+
+            // Tracked so PreviewControl_Unloaded can stop this timer if the control
+            // is torn down before the delay elapses.
+            fadeInDelayTimer = delayTimer;
+            fadeInOnMouseLeave = onMouseLeave;
 
             await Task.Run(() => delayTimer.Start());
         }
@@ -706,6 +725,19 @@ namespace Dynamo.UI.Controls
         {
             SizeChanged -= UpdateMargin;
             Unloaded -= PreviewControl_Unloaded;
+
+            // Stop any pending fade-in delay timer so its Tick handler doesn't run
+            // later against this now torn-down control (see BeginFadeInTransition).
+            if (fadeInDelayTimer != null)
+            {
+                fadeInDelayTimer.Stop();
+                fadeInDelayTimer = null;
+            }
+            if (fadeInOnMouseLeave != null)
+            {
+                nodeViewModel.OnMouseLeave -= fadeInOnMouseLeave;
+                fadeInOnMouseLeave = null;
+            }
         }
 
         private void UpdateMargin(object sender, SizeChangedEventArgs e)


### PR DESCRIPTION
### Purpose

`ArgumentNullException("scheduler")` thrown from `AsyncTask`'s constructor, reached via `PreviewControl.RunOnSchedulerSync` → `RefreshCondensedDisplay` → `ProcessFadeIn` → `BeginFadeInTransition`, while a modal `Window.ShowDialog()` was pumping the dispatcher queue during recorded-command playback.

Root cause:
`PreviewControl.BeginFadeInTransition()` has two paths:

- In test mode (`DynamoModel.IsTestMode == true`), it calls `ProcessFadeIn()` synchronously — no delay, deterministic.
- Otherwise, it starts a real 500ms `DispatcherTimer`, and when it ticks, invokes `ProcessFadeIn()` on the dispatcher.

The timer was a bare local variable — nothing tracked it outside the method, and `PreviewControl_Unloaded` never stopped it. If the control is unloaded (node/workspace torn down, e.g. by an undo) before the `500ms` elapses, the timer keeps running regardless. When it eventually ticks, it calls `ProcessFadeIn()` against a `PreviewControl` whose backing model may already be gone — and `RunOnSchedulerSync` uses the scheduler field captured once at construction (`nodeViewModel.DynamoViewModel.Model.Scheduler`), which is null once that model has been shut down. That null hits the `ArgumentNullException` guard in `AsyncTask`'s constructor.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

1. Added `fadeInDelayTimer`/`fadeInOnMouseLeave` fields so the pending timer and its mouse-leave unsubscribe action are tracked on the instance, not just as method locals.
2. `PreviewControl_Unloaded` now stops the pending timer and unsubscribes the mouse-leave handler, so a timer can no longer outlive its control.
3. As a second line of defense, the timer's Tick handler now bails out (`if (!IsLoaded) return;`) before invoking `ProcessFadeIn` if the control was unloaded while the timer was pending, so even a timer that somehow wasn't stopped can't act on a torn-down control.

### Reviewers

@jasonstratton @RobertGlobant20 

@jnealb 

### FYIs
