### PR TITLE
DYN-10864: Honor CancelRun so in-flight graph evaluation can be interrupted

### DIFF
--- a/src/DynamoCore/Engine/EngineController.cs
+++ b/src/DynamoCore/Engine/EngineController.cs
@@ -103,6 +103,25 @@ namespace Dynamo.Engine
             }
         }
 
+        /// <summary>
+        /// Asks the engine to stop the evaluation that is currently running.
+        /// Returns immediately: it raises a flag, it does not wait for the
+        /// evaluation to actually stop. Safe to call when nothing is running
+        /// and safe to call more than once.
+        internal void RequestCancellation()
+        {
+            if (IsDisposed) return;
+            LiveRunnerRuntimeCore?.RequestCancellation();
+        }
+
+        /// <summary>
+        /// Clears any pending cancellation so a later evaluation is unaffected.
+        /// </summary>
+        internal void ResetCancellation()
+        {
+            if (IsDisposed) return;
+            LiveRunnerRuntimeCore?.ResetCancellation();
+        }
 
         /// <summary>
         /// Returns library service instance.

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -826,12 +826,12 @@ namespace Dynamo.Graph.Workspaces
 
             if (wasCancelled)
             {
-                // These nodes had their dirty flags cleared when the task was scheduled,
-                // but the evaluation never reached them. Mark them dirty again so the
-                // next run recomputes them instead of quietly reusing older values.
-                foreach (var modifiedNode in updateTask.ModifiedNodes)
+                // Cancelling tears down and rebuilds the DesignScript VM, so nothing
+                // compiled survives. Mark the whole graph dirty the same way a VM reset
+                // does, otherwise the next run sends a partial graph to an empty VM.
+                foreach (var node in Nodes)
                 {
-                    modifiedNode.MarkNodeAsModified();
+                    node.MarkNodeAsModified();
                 }
             }
 

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -41,6 +41,11 @@ namespace Dynamo.Graph.Workspaces
 
         private bool graphRunInProgress;
 
+        // Set when a cancellation is requested for the run currently in progress,
+        // and cleared at the start and end of every run. Written and read from
+        // different threads, hence volatile.
+        private volatile bool runCancelledByUser;
+
         /// <summary>
         /// A flag which indicates whether Dynamo is currently running a graph.
         /// This flag is set to true when execution starts and is set to false
@@ -813,13 +818,30 @@ namespace Dynamo.Graph.Workspaces
             //set the node execution preview to false;
             OnSetNodeDeltaState(new DeltaComputeStateEventArgs(new List<Guid>(), graphExecuted));
 
+            // Take the cancellation state for this run and clear it straight away,
+            // so listeners all see the same value and nothing carries into the next run.
+            bool wasCancelled = runCancelledByUser;
+            runCancelledByUser = false;
+            EngineController?.ResetCancellation();
+
+            if (wasCancelled)
+            {
+                // These nodes had their dirty flags cleared when the task was scheduled,
+                // but the evaluation never reached them. Mark them dirty again so the
+                // next run recomputes them instead of quietly reusing older values.
+                foreach (var modifiedNode in updateTask.ModifiedNodes)
+                {
+                    modifiedNode.MarkNodeAsModified();
+                }
+            }
+
             // This method is guaranteed to be called in the context of 
             // ISchedulerThread (for Revit's case, it is the idle thread).
             // Dispatch the failure message display for execution on UI thread.
             // 
             EvaluationCompletedEventArgs e = task.Exception == null || IsTestMode
-                ? new EvaluationCompletedEventArgs(true, nodesWithInfos, null)
-                : new EvaluationCompletedEventArgs(true, nodesWithInfos, task.Exception);
+                ? new EvaluationCompletedEventArgs(true, nodesWithInfos, null, wasCancelled)
+                : new EvaluationCompletedEventArgs(true, nodesWithInfos, task.Exception, wasCancelled);
 
             EvaluationCount ++;
 
@@ -867,6 +889,11 @@ namespace Dynamo.Graph.Workspaces
                 return;
             }
 
+            // Clear any cancellation left over from before, so it cannot abort
+            // the run we are about to start.
+            runCancelledByUser = false;
+            EngineController.ResetCancellation();
+
             var traceData = PreloadedTraceData;
             if ((traceData != null) && traceData.Any())
             {
@@ -910,6 +937,22 @@ namespace Dynamo.Graph.Workspaces
                 var e = new EvaluationCompletedEventArgs(false);
                 OnEvaluationCompleted(e);
             }
+        }
+
+        /// <summary>
+        /// Asks the engine to stop the graph evaluation that is currently running.
+        /// Does nothing when no evaluation is in progress, and does nothing extra
+        /// when called repeatedly during the same evaluation.
+        /// Returns immediately: the evaluation stops at the next point the engine
+        /// checks, which can be some time later if a single node is busy.
+        /// </summary>
+        internal void CancelRun()
+        {
+            if (!GraphRunInProgress) return;
+            if (EngineController == null) return;
+
+            runCancelledByUser = true;
+            EngineController.RequestCancellation();
         }
 
         /// <summary>

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -82,7 +82,7 @@ namespace Dynamo.Models
         private void RunCancelImpl(RunCancelCommand command)
         {
             var model = CurrentWorkspace as HomeWorkspaceModel;
-            if (model != null)
+            if (model == null)
                 return;
 
             if (command.CancelRun)

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -83,11 +83,25 @@ namespace Dynamo.Models
         {
             var model = CurrentWorkspace as HomeWorkspaceModel;
             if (model != null)
-                model.Run();
+                return;
+
+            if (command.CancelRun)
+            {
+                model.CancelRun();
+                return;
+            }
+
+            model.Run();
         }
 
         private void ForceRunCancelImpl(ForceRunCancelCommand command)
         {
+            if (command.CancelRun)
+            {
+                (CurrentWorkspace as HomeWorkspaceModel)?.CancelRun();
+                return;
+            }
+
             ForceRun();
         }
 

--- a/src/DynamoCore/Models/DynamoModelEventArgs.cs
+++ b/src/DynamoCore/Models/DynamoModelEventArgs.cs
@@ -143,6 +143,15 @@ namespace Dynamo.Models
         {
             get { return !error.HasValue(); }
         }
+
+        /// <summary>
+        /// Returns true when the evaluation was stopped before finishing because
+        /// a cancellation was requested. When this is true, the values cached on
+        /// the nodes are left over from an earlier run and are not the result of
+        /// this one.
+        /// </summary>
+        public bool WasCancelled { get; internal set; }
+
         /// <summary>
         /// IDs for messages generated during a run. These are node guids.
         /// </summary>
@@ -176,10 +185,11 @@ namespace Dynamo.Models
 
             error = errorMsg != null ? Option.Some(errorMsg) : Option.None<Exception>();
         }
-        internal EvaluationCompletedEventArgs(bool evaluationTookPlace, IEnumerable<Guid> messageKeys, Exception errorMsg = null)
+        internal EvaluationCompletedEventArgs(bool evaluationTookPlace, IEnumerable<Guid> messageKeys, Exception errorMsg = null, bool wasCancelled = false)
             :this(evaluationTookPlace,errorMsg)
         {
             MessageKeys = messageKeys;
+            WasCancelled = wasCancelled;
         }
     }
 

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -6,4 +6,5 @@ Dynamo.Models.DynamoModel.DefaultStartConfiguration.EnableUnTrustedLocationsNoti
 Dynamo.Models.DynamoModel.IStartConfiguration.EnableUnTrustedLocationsNotifications.get -> bool
 Dynamo.Models.DynamoModel.OpenFileCommand.OpenFileCommand(System.String filePath, System.Boolean forceManualExecutionMode, System.Boolean isTemplate, System.Boolean forceBlockRun) -> void
 Dynamo.Models.DynamoModel.InsertFileCommand.InsertFileCommand(System.String filePath, System.Boolean forceManualExecutionMode, System.Boolean forceBlockRun) -> void
+Dynamo.Models.EvaluationCompletedEventArgs.WasCancelled.get -> bool
 Dynamo.Graph.Workspaces.WorkspaceModel.MarkAsIndependentlyModified() -> void

--- a/src/Engine/ProtoCore/RuntimeCore.cs
+++ b/src/Engine/ProtoCore/RuntimeCore.cs
@@ -193,6 +193,12 @@ namespace ProtoCore
         public ProtoCore.DSASM.Mirror.ExecutionMirror Mirror { get; set; }
 
         private bool cancellationPending = false;
+
+        /// <summary>
+        /// Returns true when a cancellation has been requested for the execution
+        /// that is currently in progress. The virtual machine reads this between
+        /// instructions and before dispatching a function call.
+        /// </summary>
         public bool CancellationPending
         {
             get
@@ -201,7 +207,26 @@ namespace ProtoCore
             }
         }
 
-#region DEBUGGER_PROPERTIES
+        /// <summary>
+        /// Asks the currently running execution to stop. Cancellation is cooperative:
+        /// the virtual machine only stops at the next instruction or function call
+        /// boundary, so a single long running external call must return first.
+        /// Calling this repeatedly has no additional effect.
+        /// </summary>
+        public void RequestCancellation()
+        {
+            cancellationPending = true;
+        }
+
+        /// <summary>
+        /// Clears a pending cancellation so it cannot affect a later execution.
+        /// </summary>
+        public void ResetCancellation()
+        {
+            cancellationPending = false;
+        }
+
+        #region DEBUGGER_PROPERTIES
 
         public int watchClassScope { get; set; }
 

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1496,6 +1496,7 @@ namespace ProtoScript.Runners
         private ChangeSetComputer changeSetComputer;
         private ChangeSetApplier changeSetApplier;
         private Dictionary<Guid, List<Guid>> executedAstGuids = new Dictionary<Guid, List<Guid>>();
+        private bool executionCancelled;
 
         public LiveRunner()
             : this(new Configuration())
@@ -1696,6 +1697,7 @@ namespace ProtoScript.Runners
             }
             catch (ProtoCore.Exceptions.ExecutionCancelledException)
             {
+                executionCancelled = true;
                 runtimeCore.Cleanup();
                 ReInitializeLiveRunner();
             }
@@ -1732,6 +1734,8 @@ namespace ProtoScript.Runners
         /// </summary>
         private void PostExecution()
         {
+            if (executionCancelled) return;
+
             ApplyUpdate();
             SuppressResolvedUnboundVariableWarnings();
         }
@@ -1760,9 +1764,11 @@ namespace ProtoScript.Runners
                 runnerCore.Options.ApplyUpdate = true;
                 Execute(true);
 
+                if (executionCancelled) return;
+
                 // Execute() will push a stack frame in SetupAndBounceStackFrame().
                 // In normal execution, that stack frame will pop in RETB. But in
-                // ApplyUpdate(), there is no RETB instruciton, so need to manually
+                // ApplyUpdate(), there is no RETB instruction, so need to manually
                 // cleanup stack frame.
                 StackValue restoreFramePointer = runtimeCore.RuntimeMemory.GetAtRelative(ProtoCore.DSASM.StackFrame.FrameIndexFramePointer);
                 runtimeCore.RuntimeMemory.FramePointer = (int)restoreFramePointer.IntegerValue;
@@ -1779,6 +1785,7 @@ namespace ProtoScript.Runners
         /// </summary>
         private void ResetForDeltaExecution()
         {
+            executionCancelled = false;
             runnerCore.ResetForDeltaExecution();
             runtimeCore.ResetForDeltaExecution();
         }

--- a/test/DynamoCoreTests/Models/RunCancelCommandTests.cs
+++ b/test/DynamoCoreTests/Models/RunCancelCommandTests.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Workspaces;
+using Dynamo.Models;
+using Dynamo.Scheduler;
+using NUnit.Framework;
+
+namespace Dynamo.Tests.ModelsTest
+{
+    [TestFixture]
+    class RunCancelCommandTests : DynamoModelTestBase
+    {
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("DesignScriptBuiltin.dll");
+            libraries.Add("DSCoreNodes.dll");
+            base.GetLibrariesToPreload(libraries);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenNoRunInProgressThenCancelIsNoOp()
+        {
+            var home = CurrentHomeWorkspace();
+            var evaluationCount = home.EvaluationCount;
+            var runtime = CurrentDynamoModel.EngineController.LiveRunnerRuntimeCore;
+
+            Assert.DoesNotThrow(() =>
+                CurrentDynamoModel.ExecuteCommand(new DynamoModel.RunCancelCommand(false, true)));
+
+            Assert.IsFalse(home.GraphRunInProgress);
+            Assert.AreEqual(evaluationCount, home.EvaluationCount);
+            Assert.IsFalse(runtime.CancellationPending);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenCancelRunIsTrueThenGraphIsNotStarted()
+        {
+            CreateCodeBlock("x = 1;");
+            var home = CurrentHomeWorkspace();
+            var evaluationCount = home.EvaluationCount;
+
+            CurrentDynamoModel.ExecuteCommand(new DynamoModel.RunCancelCommand(false, true));
+
+            Assert.AreEqual(evaluationCount, home.EvaluationCount);
+            Assert.IsFalse(home.GraphRunInProgress);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenForceRunCancelCommandCancelRunIsTrueThenGraphIsNotForceRun()
+        {
+            var home = CurrentHomeWorkspace();
+            var evaluationCount = home.EvaluationCount;
+
+            Assert.DoesNotThrow(() =>
+                CurrentDynamoModel.ExecuteCommand(new DynamoModel.ForceRunCancelCommand(false, true)));
+
+            Assert.AreEqual(evaluationCount, home.EvaluationCount);
+            Assert.IsFalse(home.GraphRunInProgress);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenCancelCalledTwiceWhileIdleThenSecondCallIsNoOp()
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                CurrentDynamoModel.ExecuteCommand(new DynamoModel.RunCancelCommand(false, true));
+                CurrentDynamoModel.ExecuteCommand(new DynamoModel.RunCancelCommand(false, true));
+            });
+
+            Assert.IsFalse(CurrentDynamoModel.EngineController.LiveRunnerRuntimeCore.CancellationPending);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenRunCompletesWithoutCancelThenWasCancelledIsFalse()
+        {
+            EvaluationCompletedEventArgs completed = null;
+            CurrentDynamoModel.EvaluationCompleted += (_, e) => completed = e;
+
+            CreateCodeBlock("x = 1;");
+            BeginRun();
+
+            Assert.IsNotNull(completed);
+            Assert.IsFalse(completed.WasCancelled);
+            Assert.IsTrue(completed.EvaluationSucceeded);
+        }
+
+        [Test]
+        public void WhenRunIsCancelledThenWasCancelledIsTrue()
+        {
+            var completed = CancelInFlightInfiniteLoop(out _);
+
+            Assert.IsTrue(completed.WasCancelled);
+            Assert.IsTrue(completed.EvaluationSucceeded);
+        }
+
+        [Test]
+        public void WhenRunIsCancelledThenModifiedNodesStayDirty()
+        {
+            CancelInFlightInfiniteLoop(out var codeBlock);
+
+            Assert.IsTrue(codeBlock.IsModified);
+        }
+
+        [Test]
+        public void WhenCancelledRunFinishesThenNextRunCanSucceed()
+        {
+            CancelInFlightInfiniteLoop(out var codeBlock);
+
+            CurrentDynamoModel.Scheduler.ProcessMode = TaskProcessMode.Synchronous;
+            CurrentDynamoModel.ExecuteCommand(
+                new DynamoModel.UpdateModelValueCommand(Guid.Empty, codeBlock.GUID, "Code", "x = 2;"));
+
+            EvaluationCompletedEventArgs completed = null;
+            CurrentDynamoModel.EvaluationCompleted += (_, e) => completed = e;
+            BeginRun();
+
+            Assert.IsNotNull(completed);
+            Assert.IsFalse(completed.WasCancelled);
+            AssertPreviewValue(codeBlock.GUID.ToString(), 2);
+        }
+
+        private HomeWorkspaceModel CurrentHomeWorkspace()
+        {
+            return (HomeWorkspaceModel)CurrentDynamoModel.CurrentWorkspace;
+        }
+
+        private CodeBlockNodeModel CreateCodeBlock(string code)
+        {
+            var cbn = new CodeBlockNodeModel(CurrentDynamoModel.LibraryServices);
+            CurrentDynamoModel.ExecuteCommand(new DynamoModel.CreateNodeCommand(cbn, 0, 0, true, false));
+            CurrentDynamoModel.ExecuteCommand(
+                new DynamoModel.UpdateModelValueCommand(Guid.Empty, cbn.GUID, "Code", code));
+            return cbn;
+        }
+
+        private EvaluationCompletedEventArgs CancelInFlightInfiniteLoop(out CodeBlockNodeModel codeBlock)
+        {
+            var home = CurrentHomeWorkspace();
+
+            // Manual mode: only run when this test says so. In Automatic mode, editing
+            // the code block would start a run on its own, on the test thread.
+            home.RunSettings.RunType = RunType.Manual;
+
+            // Background scheduler, set before the node exists so nothing can ever run
+            // the slow graph inline on this thread.
+            CurrentDynamoModel.Scheduler.ProcessMode = TaskProcessMode.Asynchronous;
+
+            // Slow but finite. The engine checks for cancellation between instructions,
+            // so this is interruptible. It must be able to end on its own: if cancelling
+            // fails, an endless loop would leave the scheduler thread spinning and the
+            // test run would freeze in teardown instead of failing. Tune the count so an
+            // uncancelled run takes roughly ten seconds on your machine.
+            const string slowLoop = @"b = [Imperative]
+{
+    i = 0;
+    while (i < 1000000)
+    {
+        i = i + 1;
+    }
+    return = i;
+};";
+
+            codeBlock = CreateCodeBlock(slowLoop);
+
+            EvaluationCompletedEventArgs completed = null;
+            using var finished = new ManualResetEventSlim(false);
+            CurrentDynamoModel.EvaluationCompleted += (_, e) =>
+            {
+                completed = e;
+                finished.Set();
+            };
+
+            BeginRun();
+            Assert.IsTrue(home.GraphRunInProgress, "Run did not start.");
+
+            var deadline = DateTime.UtcNow.AddSeconds(30);
+            while (!finished.Wait(50))
+            {
+                Assert.Less(DateTime.UtcNow, deadline, "Cancelled evaluation never completed.");
+                CurrentDynamoModel.ExecuteCommand(new DynamoModel.RunCancelCommand(false, true));
+            }
+
+            return completed;
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

This PR aims to address [DYN-10864](https://autodesk.atlassian.net/browse/DYN-10864?atlOrigin=eyJpIjoiY2Q2YTMwOTFkZTYxNDE1MDg1ZDAzNjM5ZjllOTI0ZmIiLCJwIjoiaiJ9): Make `RunCancelCommand(false, true)` interrupt an in-flight graph evaluation instead of starting another run. This unblocks [DYN-10759](https://autodesk.atlassian.net/browse/DYN-10759) (`cancel_run` on DynamoMCP).

Cancel must return immediately: it only raises a flag. The engine stops at the next instruction or function-call check. Sharing any lock that is held for the whole run would make cancel undeliverable.

Changes:
- `RunCancelImpl` / `ForceRunCancelImpl` honor `CancelRun` and call `HomeWorkspaceModel.CancelRun()` instead of `Run()`
- Restore `RuntimeCore.RequestCancellation()`; idle and double cancel are no-ops
- `EvaluationCompletedEventArgs.WasCancelled` so a cancelled run is not treated as a fresh success (`PublicAPI.Unshipped.txt` updated)
- After cancel, `LiveRunner` skips post-execution on the rebuilt VM (avoids `exe != null` assert) and the workspace re-dirties all nodes so the next Run recomputes
- Tests in `test/DynamoCoreTests/Models/RunCancelCommandTests.cs`

Cancel is cooperative: a single long blocking node (sleep, Python, Revit API) will not stop until that call returns.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Graph evaluation can now be cancelled while a run is in progress (Shift+F5). A following Run recomputes the graph instead of keeping leftover values.

### Reviewers

@DynamoDS/eidos
@jasonstratton 
@johnpierson 

### FYIs

@dnenov 
